### PR TITLE
PERCONA_EXT is now a configuration option, not hardcoded

### DIFF
--- a/configure
+++ b/configure
@@ -762,6 +762,7 @@ CPPFLAGS
 LDFLAGS
 CFLAGS
 CC
+enable_percona_ext
 enable_injection_points
 enable_tap_tests
 enable_dtrace
@@ -844,6 +845,7 @@ enable_coverage
 enable_dtrace
 enable_tap_tests
 enable_injection_points
+enable_percona_ext
 with_blocksize
 with_segsize
 with_segsize_blocks
@@ -1538,6 +1540,7 @@ Optional Features:
   --enable-tap-tests      enable TAP tests (requires Perl and IPC::Run)
   --enable-injection-points
                           enable injection points (for testing)
+  --disable-percona-ext   enable Percona specific features
   --enable-depend         turn on automatic dependency tracking
   --enable-cassert        enable assertion checks (for debugging)
   --disable-largefile     omit support for large files
@@ -3710,6 +3713,38 @@ $as_echo "#define USE_INJECTION_POINTS 1" >>confdefs.h
 
 else
   enable_injection_points=no
+
+fi
+
+
+
+
+#
+# Percona ext
+#
+
+
+# Check whether --enable-percona-ext was given.
+if test "${enable_percona_ext+set}" = set; then :
+  enableval=$enable_percona_ext;
+  case $enableval in
+    yes)
+
+$as_echo "#define PERCONA_EXT 1" >>confdefs.h
+
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --enable-percona-ext option" "$LINENO" 5
+      ;;
+  esac
+
+else
+  enable_percona_ext=yes
+
+$as_echo "#define PERCONA_EXT 1" >>confdefs.h
 
 fi
 
@@ -14899,7 +14934,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -14945,7 +14980,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -14969,7 +15004,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -15014,7 +15049,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -15038,7 +15073,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];

--- a/configure.ac
+++ b/configure.ac
@@ -257,6 +257,13 @@ PGAC_ARG_BOOL(enable, injection-points, no, [enable injection points (for testin
 AC_SUBST(enable_injection_points)
 
 #
+# Percona ext
+#
+PGAC_ARG_BOOL(enable, percona-ext, yes, [enable Percona specific features],
+              [AC_DEFINE([PERCONA_EXT], 1, [Define to 1 to build with Percona specific features. (--enable-percona-ext)])])
+AC_SUBST(enable_percona_ext)
+
+#
 # Block size
 #
 AC_MSG_CHECKING([for block size])

--- a/meson.build
+++ b/meson.build
@@ -427,6 +427,7 @@ meson_bin = find_program(meson_binpath, native: true)
 
 cdata.set('USE_ASSERT_CHECKING', get_option('cassert') ? 1 : false)
 cdata.set('USE_INJECTION_POINTS', get_option('injection_points') ? 1 : false)
+cdata.set('PERCONA_EXT', get_option('percona_ext') ? 1 : false)
 
 blocksize = get_option('blocksize').to_int() * 1024
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -215,3 +215,8 @@ option('ZSTD', type: 'string', value: 'zstd',
 
 option('ZIC', type: 'string', value: 'zic',
   description: 'Path to zic binary, when cross-compiling')
+
+# Percona options
+
+option('percona_ext', type: 'boolean', value: true,
+  description: 'Enable Percona specific features')

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -607,6 +607,10 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
+/* Define to 1 to build with Percona specific features. (--enable-percona-ext)
+   */
+#undef PERCONA_EXT
+
 /* Define to the name of a signed 128-bit integer type. */
 #undef PG_INT128_TYPE
 

--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -383,8 +383,3 @@
  * Enable tracing of syncscan operations (see also the trace_syncscan GUC var).
  */
 /* #define TRACE_SYNCSCAN */
-
-/*
- * Enable Percona specific features, should always be defined in this fork
- */
-#define PERCONA_EXT 1


### PR DESCRIPTION
This way the build scripts are aware of its value, and we can use it to add tests specifically to tde_heap, or other percona features.