### PR TITLE
Modify version string display.

### DIFF
--- a/configure
+++ b/configure
@@ -2854,6 +2854,13 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
+PG_PERCONAVERSION=1
+
+cat >>confdefs.h <<_ACEOF
+#define PG_PERCONAVERSION "$PG_PERCONAVERSION"
+_ACEOF
+
+
 
 
 
@@ -2868,12 +2875,12 @@ if test "${with_extra_version+set}" = set; then :
       as_fn_error $? "argument required for --with-extra-version option" "$LINENO" 5
       ;;
     *)
-      PG_VERSION="$PACKAGE_VERSION$withval"
+      PG_VERSION="$PACKAGE_VERSION.$PG_PERCONAVERSION (Percona Server for PostgreSQL)$withval"
       ;;
   esac
 
 else
-  PG_VERSION="$PACKAGE_VERSION"
+  PG_VERSION="$PACKAGE_VERSION.$PG_PERCONAVERSION (Percona Server for PostgreSQL)"
 fi
 
 
@@ -19223,7 +19230,7 @@ fi
 
 
 cat >>confdefs.h <<_ACEOF
-#define PG_VERSION_STR "Percona Server for PostgreSQL $PG_VERSION on $host, compiled by $cc_string, `expr $ac_cv_sizeof_void_p \* 8`-bit"
+#define PG_VERSION_STR "PostgreSQL $PG_VERSION on $host, compiled by $cc_string, `expr $ac_cv_sizeof_void_p \* 8`-bit"
 _ACEOF
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -37,9 +37,12 @@ AC_DEFINE_UNQUOTED(PG_MAJORVERSION, "$PG_MAJORVERSION", [PostgreSQL major versio
 AC_DEFINE_UNQUOTED(PG_MAJORVERSION_NUM, $PG_MAJORVERSION, [PostgreSQL major version number])
 AC_DEFINE_UNQUOTED(PG_MINORVERSION_NUM, $PG_MINORVERSION, [PostgreSQL minor version number])
 
+[PG_PERCONAVERSION=1]
+AC_DEFINE_UNQUOTED(PG_PERCONAVERSION, "$PG_PERCONAVERSION", [PostgreSQL Percona version as a string])
+
 PGAC_ARG_REQ(with, extra-version, [STRING], [append STRING to version],
-             [PG_VERSION="$PACKAGE_VERSION$withval"],
-             [PG_VERSION="$PACKAGE_VERSION"])
+             [PG_VERSION="$PACKAGE_VERSION.$PG_PERCONAVERSION (Percona Server for PostgreSQL)$withval"],
+             [PG_VERSION="$PACKAGE_VERSION.$PG_PERCONAVERSION (Percona Server for PostgreSQL)"])
 AC_DEFINE_UNQUOTED(PG_VERSION, "$PG_VERSION", [PostgreSQL version as a string])
 
 AC_CANONICAL_HOST
@@ -2444,7 +2447,7 @@ else
 fi
 
 AC_DEFINE_UNQUOTED(PG_VERSION_STR,
-                   ["Percona Server for PostgreSQL $PG_VERSION on $host, compiled by $cc_string, `expr $ac_cv_sizeof_void_p \* 8`-bit"],
+                   ["PostgreSQL $PG_VERSION on $host, compiled by $cc_string, `expr $ac_cv_sizeof_void_p \* 8`-bit"],
                    [A string containing the version number, platform, and C compiler])
 
 # Supply a numeric version string for use by 3rd party add-ons

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -35,7 +35,6 @@ SUBDIRS = \
 		pg_prewarm	\
 		pg_stat_statements \
 		pg_surgery	\
-		pg_tde		\
 		pg_trgm		\
 		pgrowlocks	\
 		pgstattuple	\

--- a/contrib/oid2name/oid2name.c
+++ b/contrib/oid2name/oid2name.c
@@ -110,7 +110,7 @@ get_opts(int argc, char **argv, struct options *my_opts)
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("oid2name (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("oid2name (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/contrib/vacuumlo/vacuumlo.c
+++ b/contrib/vacuumlo/vacuumlo.c
@@ -480,7 +480,7 @@ main(int argc, char **argv)
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("vacuumlo (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("vacuumlo (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/meson.build
+++ b/meson.build
@@ -134,6 +134,7 @@ endif
 pg_version_major = pg_version_arr[0].to_int()
 pg_version_minor = pg_version_arr[1].to_int()
 pg_version_num = (pg_version_major * 10000) + pg_version_minor
+pg_percona_ver = '1'
 
 pg_url = 'https://www.postgresql.org/'
 
@@ -144,6 +145,7 @@ cdata.set_quoted('PACKAGE_VERSION', pg_version)
 cdata.set_quoted('PACKAGE_STRING', 'PostgreSQL @0@'.format(pg_version))
 cdata.set_quoted('PACKAGE_TARNAME', 'postgresql')
 
+pg_version += '.' + pg_percona_ver + ' (Percona Server for PostgreSQL)'
 pg_version += get_option('extra_version')
 cdata.set_quoted('PG_VERSION', pg_version)
 cdata.set_quoted('PG_MAJORVERSION', pg_version_major.to_string())
@@ -2769,7 +2771,7 @@ cdata.set_quoted('DLSUFFIX', dlsuffix)
 
 # built later than the rest of the version metadata, we need SIZEOF_VOID_P
 cdata.set_quoted('PG_VERSION_STR',
-  'Percona Server for PostgreSQL @0@ on @1@-@2@, compiled by @3@-@4@, @5@-bit'.format(
+  'PostgreSQL @0@ on @1@-@2@, compiled by @3@-@4@, @5@-bit'.format(
     pg_version, host_machine.cpu_family(), host_system,
     cc.get_id(), cc.version(), cdata.get('SIZEOF_VOID_P') * 8,
   )

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -3162,7 +3162,7 @@ main(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("initdb (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("initdb (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_archivecleanup/pg_archivecleanup.c
+++ b/src/bin/pg_archivecleanup/pg_archivecleanup.c
@@ -307,7 +307,7 @@ main(int argc, char **argv)
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_archivecleanup (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_archivecleanup (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -2415,7 +2415,7 @@ main(int argc, char **argv)
 		else if (strcmp(argv[1], "-V") == 0
 				 || strcmp(argv[1], "--version") == 0)
 		{
-			puts("pg_basebackup (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_basebackup (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_basebackup/pg_createsubscriber.c
+++ b/src/bin/pg_basebackup/pg_createsubscriber.c
@@ -344,7 +344,7 @@ get_exec_path(const char *argv0, const char *progname)
 	char	   *exec_path;
 	int			ret;
 
-	versionstr = psprintf("%s (Percona Server for PostgreSQL) %s\n", progname, PG_VERSION);
+	versionstr = psprintf("%s (PostgreSQL) %s\n", progname, PG_VERSION);
 	exec_path = pg_malloc(MAXPGPATH);
 	ret = find_other_exec(argv0, progname, versionstr, exec_path);
 
@@ -1916,7 +1916,7 @@ main(int argc, char **argv)
 		else if (strcmp(argv[1], "-V") == 0
 				 || strcmp(argv[1], "--version") == 0)
 		{
-			puts("pg_createsubscriber (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_createsubscriber (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_basebackup/pg_receivewal.c
+++ b/src/bin/pg_basebackup/pg_receivewal.c
@@ -672,7 +672,7 @@ main(int argc, char **argv)
 		else if (strcmp(argv[1], "-V") == 0 ||
 				 strcmp(argv[1], "--version") == 0)
 		{
-			puts("pg_receivewal (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_receivewal (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_basebackup/pg_recvlogical.c
+++ b/src/bin/pg_basebackup/pg_recvlogical.c
@@ -741,7 +741,7 @@ main(int argc, char **argv)
 		else if (strcmp(argv[1], "-V") == 0 ||
 				 strcmp(argv[1], "--version") == 0)
 		{
-			puts("pg_recvlogical (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_recvlogical (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_checksums/pg_checksums.c
+++ b/src/bin/pg_checksums/pg_checksums.c
@@ -464,7 +464,7 @@ main(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_checksums (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_checksums (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_controldata/pg_controldata.c
+++ b/src/bin/pg_controldata/pg_controldata.c
@@ -120,7 +120,7 @@ main(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_controldata (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_controldata (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -896,7 +896,7 @@ do_init(void)
 	char	   *cmd;
 
 	if (exec_path == NULL)
-		exec_path = find_other_exec_or_die(argv0, "initdb", "initdb (Percona Server for PostgreSQL) " PG_VERSION "\n");
+		exec_path = find_other_exec_or_die(argv0, "initdb", "initdb (PostgreSQL) " PG_VERSION "\n");
 
 	if (pgdata_opt == NULL)
 		pgdata_opt = "";
@@ -2233,7 +2233,7 @@ main(int argc, char **argv)
 		}
 		else if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_ctl (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_ctl (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -474,7 +474,7 @@ main(int argc, char **argv)
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_dump (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_dump (PostgreSQL) " PG_VERSION);
 			exit_nicely(0);
 		}
 	}

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -31,7 +31,7 @@
 #include "pg_backup.h"
 
 /* version string we expect back from pg_dump */
-#define PGDUMP_VERSIONSTR "pg_dump (Percona Server for PostgreSQL) " PG_VERSION "\n"
+#define PGDUMP_VERSIONSTR "pg_dump (PostgreSQL) " PG_VERSION "\n"
 
 typedef struct
 {
@@ -214,7 +214,7 @@ main(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_dumpall (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_dumpall (PostgreSQL) " PG_VERSION);
 			exit_nicely(0);
 		}
 	}

--- a/src/bin/pg_dump/pg_restore.c
+++ b/src/bin/pg_dump/pg_restore.c
@@ -150,7 +150,7 @@ main(int argc, char **argv)
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_restore (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_restore (PostgreSQL) " PG_VERSION);
 			exit_nicely(0);
 		}
 	}

--- a/src/bin/pg_resetwal/pg_resetwal.c
+++ b/src/bin/pg_resetwal/pg_resetwal.c
@@ -132,7 +132,7 @@ main(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_resetwal (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_resetwal (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -168,7 +168,7 @@ main(int argc, char **argv)
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_rewind (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_rewind (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_test_fsync/pg_test_fsync.c
+++ b/src/bin/pg_test_fsync/pg_test_fsync.c
@@ -167,7 +167,7 @@ handle_args(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_test_fsync (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_test_fsync (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_test_timing/pg_test_timing.c
+++ b/src/bin/pg_test_timing/pg_test_timing.c
@@ -61,7 +61,7 @@ handle_args(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_test_timing (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_test_timing (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_upgrade/exec.c
+++ b/src/bin/pg_upgrade/exec.c
@@ -448,7 +448,7 @@ check_exec(const char *dir, const char *program, bool check_version)
 	{
 		pg_strip_crlf(line);
 
-		snprintf(versionstr, sizeof(versionstr), "%s (Percona Server for PostgreSQL) " PG_VERSION, program);
+		snprintf(versionstr, sizeof(versionstr), "%s (PostgreSQL) " PG_VERSION, program);
 
 		if (strcmp(line, versionstr) != 0)
 			pg_fatal("check for \"%s\" failed: incorrect version: found \"%s\", expected \"%s\"",

--- a/src/bin/pg_upgrade/option.c
+++ b/src/bin/pg_upgrade/option.c
@@ -95,7 +95,7 @@ parseCommandLine(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_upgrade (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_upgrade (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_verifybackup/pg_verifybackup.c
+++ b/src/bin/pg_verifybackup/pg_verifybackup.c
@@ -211,7 +211,7 @@ main(int argc, char **argv)
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_verifybackup (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_verifybackup (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}
@@ -310,7 +310,7 @@ main(int argc, char **argv)
 
 		pg_waldump_path = pg_malloc(MAXPGPATH);
 		ret = find_other_exec(argv[0], "pg_waldump",
-							  "pg_waldump (Percona Server for PostgreSQL) " PG_VERSION "\n",
+							  "pg_waldump (PostgreSQL) " PG_VERSION "\n",
 							  pg_waldump_path);
 		if (ret < 0)
 		{

--- a/src/bin/pg_waldump/pg_waldump.c
+++ b/src/bin/pg_waldump/pg_waldump.c
@@ -844,7 +844,7 @@ main(int argc, char **argv)
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_waldump (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pg_waldump (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -6723,7 +6723,7 @@ main(int argc, char **argv)
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pgbench (Percona Server for PostgreSQL) " PG_VERSION);
+			puts("pgbench (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/psql/startup.c
+++ b/src/bin/psql/startup.c
@@ -838,7 +838,7 @@ process_psqlrc_file(char *filename)
 static void
 showVersion(void)
 {
-	puts("psql (Percona Server for PostgreSQL) " PG_VERSION);
+	puts("psql (PostgreSQL) " PG_VERSION);
 }
 
 

--- a/src/fe_utils/option_utils.c
+++ b/src/fe_utils/option_utils.c
@@ -33,7 +33,7 @@ handle_help_version_opts(int argc, char *argv[],
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			printf("%s (Percona Server for PostgreSQL) " PG_VERSION "\n", fixed_progname);
+			printf("%s (PostgreSQL) " PG_VERSION "\n", fixed_progname);
 			exit(0);
 		}
 	}

--- a/src/include/port.h
+++ b/src/include/port.h
@@ -140,7 +140,7 @@ extern int	find_other_exec(const char *argv0, const char *target,
 extern char *pipe_read_line(char *cmd);
 
 /* Doesn't belong here, but this is used with find_other_exec(), so... */
-#define PG_BACKEND_VERSIONSTR "postgres (Percona Server for PostgreSQL) " PG_VERSION "\n"
+#define PG_BACKEND_VERSIONSTR "postgres (PostgreSQL) " PG_VERSION "\n"
 
 #ifdef EXEC_BACKEND
 /* Disable ASLR before exec, for developer builds only (in exec.c) */

--- a/src/interfaces/ecpg/preproc/ecpg.c
+++ b/src/interfaces/ecpg/preproc/ecpg.c
@@ -162,7 +162,7 @@ main(int argc, char *const argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			printf("ecpg (Percona Server for PostgreSQL) %s\n", PG_VERSION);
+			printf("ecpg (PostgreSQL) %s\n", PG_VERSION);
 			exit(0);
 		}
 	}

--- a/src/test/isolation/isolation_main.c
+++ b/src/test/isolation/isolation_main.c
@@ -19,7 +19,7 @@ char		saved_argv0[MAXPGPATH];
 char		isolation_exec[MAXPGPATH];
 bool		looked_up_isolation_exec = false;
 
-#define PG_ISOLATION_VERSIONSTR "isolationtester (Percona Server for PostgreSQL) " PG_VERSION "\n"
+#define PG_ISOLATION_VERSIONSTR "isolationtester (PostgreSQL) " PG_VERSION "\n"
 
 /*
  * start an isolation tester process for specified file (including

--- a/src/test/isolation/isolationtester.c
+++ b/src/test/isolation/isolationtester.c
@@ -99,7 +99,7 @@ main(int argc, char **argv)
 		switch (opt)
 		{
 			case 'V':
-				puts("isolationtester (Percona Server for PostgreSQL) " PG_VERSION);
+				puts("isolationtester (PostgreSQL) " PG_VERSION);
 				exit(0);
 			default:
 				fprintf(stderr, "Usage: isolationtester [CONNINFO]\n");

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2140,7 +2140,7 @@ regression_main(int argc, char *argv[],
 				help();
 				exit(0);
 			case 'V':
-				puts("pg_regress (Percona Server for PostgreSQL) " PG_VERSION);
+				puts("pg_regress (PostgreSQL) " PG_VERSION);
 				exit(0);
 			case 1:
 


### PR DESCRIPTION
The original part of the version is kept as is, and Percona specific information is added after.

For example, psql displays the following after this commit:

SELECT version();
PostgreSQL 17.0.1 (Percona Server for PostgreSQL) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 6 4-bit

Where the addition is ".1 (Percona Server for PostgreSQL)", with the ".1" being the Percona version number.

Similarly, commands show the same information:

bin/pg_ctl --version
pg_ctl (PostgreSQL) 17.0.1 (Percona Server for PostgreSQL)