### PR TITLE
Expose percona_ext as a meson variable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -430,6 +430,7 @@ meson_bin = find_program(meson_binpath, native: true)
 cdata.set('USE_ASSERT_CHECKING', get_option('cassert') ? 1 : false)
 cdata.set('USE_INJECTION_POINTS', get_option('injection_points') ? 1 : false)
 cdata.set('PERCONA_EXT', get_option('percona_ext') ? 1 : false)
+percona_ext = get_option('percona_ext')
 
 blocksize = get_option('blocksize').to_int() * 1024
 


### PR DESCRIPTION
As get_option returns an error for non existent variables, this is better for pg_tde