### PR TITLE
PG-1356 Updated URLs to point to a prod URL

### DIFF
--- a/contrib/pg_tde/documentation/_resource/overrides/main.html
+++ b/contrib/pg_tde/documentation/_resource/overrides/main.html
@@ -4,7 +4,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  This is a Beta version of Percona Transparent Encryption extension and it is 
+  This is a Beta2 version of Percona Transparent Encryption extension and it is 
   <strong>not recommended for production environments</strong> yet. We encourage you to test it and <a href= "https://forums.percona.com/c/postgresql/pg-tde-transparent-data-encryption-tde/82">give your feedback</a>.
   This will help us improve the product and make it production-ready faster.
 {% endblock %}
@@ -24,8 +24,8 @@
                  {% endif %}
                  <meta property="og:type" content="website" />
                  <meta property="og:title" content="{{ title }}" />
-                 <meta property="og:image" content="https://percona.github.io/pg_tde/main/documentation/_images/pg_tde.png">
-                 <meta property="og:url" content="https://percona.github.io/pg_tde/main/">
+                 <meta property="og:image" content="https://docs.percona.com/pg-tde/_images/pg_tde.png">
+                 <meta property="og:url" content="https://docs.percona.com/pg-tde/">
      {% endblock %}
  
 {% block site_nav %}

--- a/contrib/pg_tde/documentation/mkdocs.yml
+++ b/contrib/pg_tde/documentation/mkdocs.yml
@@ -7,9 +7,9 @@ copyright: >
   <a href="https://www.percona.com/about">Percona LLC</a> and/or its affiliates © 2025 — <a href="#__consent">Cookie Consent</a>
 
  
-repo_name: percona/pg_tde
-repo_url: https://github.com/percona/pg_tde
-edit_uri: edit/main/documentation/docs/
+repo_name: percona/postgres
+repo_url: https://github.com/percona/postgres
+edit_uri: edit/TDE_REL_17_STABLE/contrib/pg_tde/documentation/docs
 
 use_directory_urls: false
 
@@ -156,6 +156,7 @@ extra:
 
 nav:
   - Home: index.md
+  - get-help.md
   - features.md
   - Get started:
     - "Install": "install.md"

--- a/contrib/pg_tde/documentation/variables.yml
+++ b/contrib/pg_tde/documentation/variables.yml
@@ -1,4 +1,4 @@
 #Variables used throughout the docs
 
-release: 'Beta'
+release: 'Beta2'
 pgversion17: '17.2'


### PR DESCRIPTION

PG-1356

 Updated URLs to point to a prod URL
	modified:   contrib/pg_tde/documentation/_resource/overrides/main.html
	modified:   contrib/pg_tde/documentation/mkdocs.yml
	modified:   contrib/pg_tde/documentation/variables.yml