### PR TITLE
PoC: PG-1442 Encrypt catalog tables using the default key

### DIFF
--- a/ci_scripts/tde_setup_global.sql
+++ b/ci_scripts/tde_setup_global.sql
@@ -2,7 +2,8 @@ CREATE SCHEMA tde;
 CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
 
 SELECT tde.pg_tde_add_global_key_provider_file('reg_file-global', '/tmp/pg_tde_test_keyring.per');
-SELECT tde.pg_tde_set_server_principal_key('global-principal-key', 'reg_file-global');
+SELECT tde.pg_tde_set_server_principal_key('wal-principal-key', 'reg_file-global');
+SELECT tde.pg_tde_set_default_principal_key('default-principal-key', 'reg_file-global', false);
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 ALTER SYSTEM SET default_table_access_method = 'tde_heap';
 ALTER SYSTEM SET search_path = "$user",public,tde;

--- a/ci_scripts/tde_setup_global.sql
+++ b/ci_scripts/tde_setup_global.sql
@@ -3,8 +3,9 @@ CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
 
 SELECT tde.pg_tde_add_global_key_provider_file('reg_file-global', '/tmp/pg_tde_test_keyring.per');
 SELECT tde.pg_tde_set_server_principal_key('wal-principal-key', 'reg_file-global');
-SELECT tde.pg_tde_set_default_principal_key('default-principal-key', 'reg_file-global', false);
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 ALTER SYSTEM SET default_table_access_method = 'tde_heap';
 ALTER SYSTEM SET search_path = "$user",public,tde;
+CHECKPOINT;
+SELECT tde.pg_tde_set_default_principal_key('default-principal-key', 'reg_file-global', false);
 -- restart required

--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -46,11 +46,14 @@ SELECT current_database() AS regress_database
 CREATE DATABASE regress_pg_tde_other;
 \c regress_pg_tde_other
 CREATE EXTENSION pg_tde;
--- Should fail: no principal key for the database yet
+-- TODO
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
-ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+ key_provider_id | key_provider_name |  principal_key_name   
+-----------------+-------------------+-----------------------
+              -3 | file-provider     | default-principal-key
+(1 row)
+
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
 	id SERIAL,

--- a/contrib/pg_tde/sql/default_principal_key.sql
+++ b/contrib/pg_tde/sql/default_principal_key.sql
@@ -34,7 +34,7 @@ CREATE DATABASE regress_pg_tde_other;
 
 CREATE EXTENSION pg_tde;
 
--- Should fail: no principal key for the database yet
+-- TODO
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
 

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -32,17 +32,16 @@ tde_smgr_get_key(SMgrRelation reln, RelFileLocator *old_locator, bool can_create
 	TdeCreateEvent *event;
 	InternalKey *key;
 
-	if (IsCatalogRelationOid(reln->smgr_rlocator.locator.relNumber))
-	{
-		/* do not try to encrypt/decrypt catalog tables */
-		return NULL;
-	}
-
 	/* see if we have a key for the relation, and return if yes */
 	key = GetSMGRRelationKey(reln->smgr_rlocator);
 	if (key != NULL)
 	{
 		return key;
+	}
+
+	if (IsCatalogRelationOid(reln->smgr_rlocator.locator.relNumber) && can_create)
+	{
+		return pg_tde_create_smgr_key(&reln->smgr_rlocator);
 	}
 
 	event = GetCurrentTdeCreateEvent();


### PR DESCRIPTION
Quick and dirty PoC which implements encryption of the system catalog if there is a default key configured. To test it do the following.

```
CREATE DATABASE foo;

CREATE EXTENSION IF NOT EXISTS pg_tde;
SELECT pg_tde_add_key_provider_file('PG_TDE_GLOBAL', 'file-provider','/tmp/default.per');
SELECT pg_tde_set_default_principal_key('default-principal-key', 'PG_TDE_GLOBAL', 'file-provider', false);

CREATE DATABASE bar;

CHECKPOINT;
```

In `foo`:

```
CREATE TABLE zzz_foo AS SELECT generate_series(1, 10000); CHECKPOINT;
```

In `bar`:

```
CREATE TABLE zzz_bar AS SELECT generate_series(1, 10000); CHECKPOINT;
```

Check:

```
$ strings data/base/16384/1259 | grep ^pg_ | wc -l
484
$ strings data/base/16384/1259 | grep zzz
zzz_foo
$ strings data/base/16452/1259 | grep ^pg_ | wc -l
0
$ strings data/base/16452/1259 | grep zzz
```