### PR TITLE
Make more functions and global variables static 

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -133,6 +133,7 @@ static InternalKey *pg_tde_read_one_keydata(int keydata_fd, int32 key_index, TDE
 static int	pg_tde_open_file(char *tde_filename, TDEPrincipalKeyInfo *principal_key_info, bool update_header, int fileFlags, bool *is_new_file, off_t *curr_pos);
 static InternalKey *pg_tde_get_key_from_cache(const RelFileLocator *rlocator, uint32 key_type);
 static WALKeyCacheRec *pg_tde_add_wal_key_to_cache(InternalKey *cached_key, XLogRecPtr start_lsn);
+static InternalKey *pg_tde_put_key_into_cache(const RelFileLocator *locator, InternalKey *key);
 
 #ifndef FRONTEND
 
@@ -1646,7 +1647,7 @@ pg_tde_add_wal_key_to_cache(InternalKey *cached_key, XLogRecPtr start_lsn)
  *
  * TODO: add tests.
  */
-InternalKey *
+static InternalKey *
 pg_tde_put_key_into_cache(const RelFileLocator *rlocator, InternalKey *key)
 {
 	static long pageSize = 0;

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -26,10 +26,29 @@
 #include "access/pg_tde_xlog.h"
 #include "encryption/enc_tde.h"
 
+static void tdeheap_rmgr_redo(XLogReaderState *record);
+static void tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record);
+static const char *tdeheap_rmgr_identify(uint8 info);
+
+#define RM_TDERMGR_NAME	"test_tdeheap_custom_rmgr"
+
+static const RmgrData tdeheap_rmgr = {
+	.rm_name = RM_TDERMGR_NAME,
+	.rm_redo = tdeheap_rmgr_redo,
+	.rm_desc = tdeheap_rmgr_desc,
+	.rm_identify = tdeheap_rmgr_identify,
+};
+
+void
+RegisterTdeRmgr(void)
+{
+	RegisterCustomRmgr(RM_TDERMGR_ID, &tdeheap_rmgr);
+}
+
 /*
  * TDE fork XLog
  */
-void
+static void
 tdeheap_rmgr_redo(XLogReaderState *record)
 {
 	uint8		info = XLogRecGetInfo(record) & ~XLR_INFO_MASK;
@@ -96,7 +115,7 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 	}
 }
 
-void
+static void
 tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 {
 	uint8		info = XLogRecGetInfo(record) & ~XLR_INFO_MASK;
@@ -139,7 +158,7 @@ tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 	}
 }
 
-const char *
+static const char *
 tdeheap_rmgr_identify(uint8 info)
 {
 	if ((info & ~XLR_INFO_MASK) == XLOG_TDE_ADD_RELATION_KEY)

--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -34,12 +34,17 @@
 #include "port/atomics.h"
 #endif
 
+static void SetXLogPageIVPrefix(TimeLineID tli, XLogRecPtr lsn, char *iv_prefix);
+static ssize_t tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
+									 TimeLineID tli, XLogSegNo segno, int segSize);
+static ssize_t tdeheap_xlog_seg_write(int fd, const void *buf, size_t count,
+									  off_t offset, TimeLineID tli,
+									  XLogSegNo segno);
+
 static const XLogSmgr tde_xlog_smgr = {
 	.seg_read = tdeheap_xlog_seg_read,
 	.seg_write = tdeheap_xlog_seg_write,
 };
-
-static void SetXLogPageIVPrefix(TimeLineID tli, XLogRecPtr lsn, char *iv_prefix);
 
 #ifndef FRONTEND
 static Size TDEXLogEncryptBuffSize(void);
@@ -206,7 +211,7 @@ TDEXLogSmgrInit(void)
 	SetXLogSmgr(&tde_xlog_smgr);
 }
 
-ssize_t
+static ssize_t
 tdeheap_xlog_seg_write(int fd, const void *buf, size_t count, off_t offset,
 					   TimeLineID tli, XLogSegNo segno)
 {
@@ -239,7 +244,7 @@ tdeheap_xlog_seg_write(int fd, const void *buf, size_t count, off_t offset,
 /*
  * Read the XLog pages from the segment file and dectypt if need.
  */
-ssize_t
+static ssize_t
 tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 					  TimeLineID tli, XLogSegNo segno, int segSize)
 {

--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -42,6 +42,7 @@ static const XLogSmgr tde_xlog_smgr = {
 static void SetXLogPageIVPrefix(TimeLineID tli, XLogRecPtr lsn, char *iv_prefix);
 
 #ifndef FRONTEND
+static Size TDEXLogEncryptBuffSize(void);
 static ssize_t TDEXLogWriteEncryptedPages(int fd, const void *buf, size_t count,
 										  off_t offset, TimeLineID tli,
 										  XLogSegNo segno);
@@ -97,7 +98,7 @@ XLOGChooseNumBuffers(void)
 /*
  * Defines the size of the XLog encryption buffer
  */
-Size
+static Size
 TDEXLogEncryptBuffSize(void)
 {
 	int			xbuffers;

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -100,6 +100,8 @@ static Datum pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
 
 static void key_provider_startup_cleanup(int tde_tbl_count, XLogExtensionInstall *ext_info, bool redo, void *arg);
 static const char *get_keyring_provider_typename(ProviderType p_type);
+static List *GetAllKeyringProviders(Oid dbOid);
+static void cleanup_key_provider_info(Oid databaseId);
 
 static Size initialize_shared_state(void *start_address);
 static Size required_shared_mem_size(void);
@@ -177,7 +179,7 @@ get_keyring_provider_typename(ProviderType p_type)
 	return NULL;
 }
 
-List *
+static List *
 GetAllKeyringProviders(Oid dbOid)
 {
 	return scan_key_provider_file(PROVIDER_SCAN_ALL, NULL, dbOid);
@@ -189,7 +191,7 @@ redo_key_provider_info(KeyringProviderXLRecord *xlrec)
 	return write_key_provider_info(&xlrec->provider, xlrec->database_id, xlrec->offset_in_file, false, false);
 }
 
-void
+static void
 cleanup_key_provider_info(Oid databaseId)
 {
 	/* Remove the key provider info file */

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -85,6 +85,7 @@ static Size cache_area_size(void);
 static Size required_shared_mem_size(void);
 static void shared_memory_shutdown(int code, Datum arg);
 static void principal_key_startup_cleanup(int tde_tbl_count, XLogExtensionInstall *ext_info, bool redo, void *arg);
+static void cleanup_principal_key_info(Oid databaseId);
 static void clear_principal_key_cache(Oid databaseId);
 static inline dshash_table *get_principal_key_Hash(void);
 static TDEPrincipalKey *get_principal_key_from_cache(Oid dbOid);
@@ -527,7 +528,7 @@ principal_key_startup_cleanup(int tde_tbl_count, XLogExtensionInstall *ext_info,
 	cleanup_principal_key_info(ext_info->database_id);
 }
 
-void
+static void
 cleanup_principal_key_info(Oid databaseId)
 {
 	clear_principal_key_cache(databaseId);

--- a/contrib/pg_tde/src/encryption/enc_aes.c
+++ b/contrib/pg_tde/src/encryption/enc_aes.c
@@ -43,10 +43,10 @@
  * 16 byte blocks.
  */
 
-
 const EVP_CIPHER *cipher = NULL;
 const EVP_CIPHER *cipher2 = NULL;
-int			cipher_block_size = 0;
+
+static int	cipher_block_size = 0;
 
 void
 AesInit(void)

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -112,6 +112,4 @@ extern InternalKey *pg_tde_get_key_from_file(const RelFileLocator *rlocator, uin
 
 const char *tde_sprint_key(InternalKey *k);
 
-extern InternalKey *pg_tde_put_key_into_cache(const RelFileLocator *locator, InternalKey *key);
-
 #endif							/* PG_TDE_MAP_H */

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog.h
@@ -12,8 +12,6 @@
 #ifndef FRONTEND
 
 #include "postgres.h"
-#include "access/xlog.h"
-#include "access/xlog_internal.h"
 
 /* TDE XLOG resource manager */
 #define XLOG_TDE_ADD_RELATION_KEY		0x00
@@ -26,11 +24,8 @@
 
 /* ID 140 is registered for Percona TDE extension: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
 #define RM_TDERMGR_ID	140
-#define RM_TDERMGR_NAME	"test_tdeheap_custom_rmgr"
 
-extern void tdeheap_rmgr_redo(XLogReaderState *record);
-extern void tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record);
-extern const char *tdeheap_rmgr_identify(uint8 info);
+extern void RegisterTdeRmgr(void);
 
 #endif							/* !FRONTEND */
 #endif							/* PG_TDE_XLOG_H */

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
@@ -15,7 +15,6 @@
 extern Size TDEXLogEncryptStateSize(void);
 extern void TDEXLogShmemInit(void);
 extern void TDEXLogSmgrInit(void);
-extern void XLogInitGUC(void);
 #ifndef FRONTEND
 extern void TDEXlogCheckSane(void);
 #endif

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
@@ -12,8 +12,6 @@
 #include "postgres.h"
 #include "access/xlog_smgr.h"
 
-extern Size TDEXLogEncryptBuffSize(void);
-
 extern Size TDEXLogEncryptStateSize(void);
 extern void TDEXLogShmemInit(void);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
@@ -14,13 +14,6 @@
 
 extern Size TDEXLogEncryptStateSize(void);
 extern void TDEXLogShmemInit(void);
-
-extern ssize_t tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
-									 TimeLineID tli, XLogSegNo segno, int segSize);
-extern ssize_t tdeheap_xlog_seg_write(int fd, const void *buf, size_t count,
-									  off_t offset, TimeLineID tli,
-									  XLogSegNo segno);
-
 extern void TDEXLogSmgrInit(void);
 extern void XLogInitGUC(void);
 #ifndef FRONTEND

--- a/contrib/pg_tde/src/include/catalog/tde_keyring.h
+++ b/contrib/pg_tde/src/include/catalog/tde_keyring.h
@@ -29,11 +29,9 @@ typedef struct KeyringProviderXLRecord
 	KeyringProvideRecord provider;
 } KeyringProviderXLRecord;
 
-extern List *GetAllKeyringProviders(Oid dbOid);
 extern GenericKeyring *GetKeyProviderByName(const char *provider_name, Oid dbOid);
 extern GenericKeyring *GetKeyProviderByID(int provider_id, Oid dbOid);
 extern ProviderType get_keyring_provider_from_typename(char *provider_type);
-extern void cleanup_key_provider_info(Oid databaseId);
 extern void InitializeKeyProviderInfo(void);
 extern uint32 save_new_key_provider_info(KeyringProvideRecord *provider,
 										 Oid databaseId, bool write_xlog);

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -62,10 +62,7 @@ extern bool create_principal_key_info(TDEPrincipalKeyInfo *principalKeyInfo);
 extern bool update_principal_key_info(TDEPrincipalKeyInfo *principal_key_info);
 
 extern Oid	GetPrincipalKeyProviderId(void);
-extern bool AlterPrincipalKeyKeyring(const char *provider_name);
 extern bool xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec);
-
-extern void PrincipalKeyGucInit(void);
 
 extern TDEPrincipalKey *get_principal_key_from_keyring(Oid dbOid, bool pushToCache);
 

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -48,7 +48,6 @@ typedef struct XLogPrincipalKeyRotate
 #define SizeoOfXLogPrincipalKeyRotate	offsetof(XLogPrincipalKeyRotate, buff)
 
 extern void InitializePrincipalKeyInfo(void);
-extern void cleanup_principal_key_info(Oid databaseId);
 
 #ifndef FRONTEND
 extern LWLock *tde_lwlock_enc_keys(void);

--- a/contrib/pg_tde/src/include/encryption/enc_aes.h
+++ b/contrib/pg_tde/src/include/encryption/enc_aes.h
@@ -12,7 +12,7 @@
 
 #include <stdint.h>
 
-void		AesInit(void);
+extern void AesInit(void);
 extern void Aes128EncryptedZeroBlocks(void *ctxPtr, const unsigned char *key, const char *iv_prefix, uint64_t blockNumber1, uint64_t blockNumber2, unsigned char *out);
 
 /* Only used for testing */

--- a/contrib/pg_tde/src/include/keyring/keyring_api.h
+++ b/contrib/pg_tde/src/include/keyring/keyring_api.h
@@ -14,9 +14,7 @@
 
 extern bool RegisterKeyProvider(const TDEKeyringRoutine *routine, ProviderType type);
 
-extern KeyringReturnCodes KeyringStoreKey(GenericKeyring *keyring, KeyInfo *key, bool throw_error);
 extern KeyInfo *KeyringGetKey(GenericKeyring *keyring, const char *key_name, bool throw_error, KeyringReturnCodes *returnCode);
 extern KeyInfo *KeyringGenerateNewKeyAndStore(GenericKeyring *keyring, const char *key_name, unsigned key_len, bool throw_error);
-extern KeyInfo *KeyringGenerateNewKey(const char *key_name, unsigned key_len);
 
 #endif							/* KEYRING_API_H */

--- a/contrib/pg_tde/src/include/keyring/keyring_curl.h
+++ b/contrib/pg_tde/src/include/keyring/keyring_curl.h
@@ -27,6 +27,6 @@ typedef struct CurlString
 
 extern CURL *keyringCurl;
 
-bool		curlSetupSession(const char *url, const char *caFile, CurlString *outStr);
+extern bool curlSetupSession(const char *url, const char *caFile, CurlString *outStr);
 
 #endif							/* //KEYRING_CURL_H */

--- a/contrib/pg_tde/src/include/keyring/keyring_kmip.h
+++ b/contrib/pg_tde/src/include/keyring/keyring_kmip.h
@@ -14,6 +14,6 @@
 
 extern bool InstallKmipKeyring(void);
 
-void		kmip_ereport(bool throw_error, const char *msg, int errCode);
+extern void kmip_ereport(bool throw_error, const char *msg, int errCode);
 
 #endif							/* // KEYRING_KMIP_H */

--- a/contrib/pg_tde/src/include/pg_tde.h
+++ b/contrib/pg_tde/src/include/pg_tde.h
@@ -21,6 +21,4 @@ extern void on_ext_install(pg_tde_on_ext_install_callback function, void *arg);
 
 extern void extension_install_redo(XLogExtensionInstall *xlrec);
 
-extern void pg_tde_init_data_dir(void);
-
 #endif							/* PG_TDE_H */

--- a/contrib/pg_tde/src/include/pg_tde_guc.h
+++ b/contrib/pg_tde/src/include/pg_tde_guc.h
@@ -20,7 +20,7 @@ extern bool AllowInheritGlobalProviders;
 extern bool EncryptXLog;
 extern bool EnforceEncryption;
 
-void		TdeGucInit(void);
+extern void TdeGucInit(void);
 
 #endif
 #endif							/* TDE_GUC_H */

--- a/contrib/pg_tde/src/include/transam/pg_tde_xact_handler.h
+++ b/contrib/pg_tde/src/include/transam/pg_tde_xact_handler.h
@@ -9,12 +9,9 @@
 #define PG_TDE_XACT_HANDLER_H
 
 #include "postgres.h"
-#include "access/xact.h"
+#include "storage/relfilelocator.h"
 
-extern void pg_tde_xact_callback(XactEvent event, void *arg);
-extern void pg_tde_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
-									SubTransactionId parentSubid, void *arg);
-
+extern void RegisterTdeXactCallbacks(void);
 extern void RegisterEntryForDeletion(const RelFileLocator *rlocator, off_t map_entry_offset, bool atCommit);
 
 

--- a/contrib/pg_tde/src/keyring/keyring_api.c
+++ b/contrib/pg_tde/src/keyring/keyring_api.c
@@ -23,11 +23,14 @@ typedef struct KeyProviders
 } KeyProviders;
 
 #ifndef FRONTEND
-List	   *registeredKeyProviders = NIL;
+static List *registeredKeyProviders = NIL;
 #else
-SimplePtrList registeredKeyProviders = {NULL, NULL};
+static SimplePtrList registeredKeyProviders = {NULL, NULL};
 #endif
+
 static KeyProviders *find_key_provider(ProviderType type);
+static KeyringReturnCodes KeyringStoreKey(GenericKeyring *keyring, KeyInfo *key, bool throw_error);
+static KeyInfo *KeyringGenerateNewKey(const char *key_name, unsigned key_len);
 
 #ifndef FRONTEND
 static KeyProviders *
@@ -117,7 +120,7 @@ KeyringGetKey(GenericKeyring *keyring, const char *key_name, bool throw_error, K
 	return kp->routine->keyring_get_key(keyring, key_name, throw_error, returnCode);
 }
 
-KeyringReturnCodes
+static KeyringReturnCodes
 KeyringStoreKey(GenericKeyring *keyring, KeyInfo *key, bool throw_error)
 {
 	KeyProviders *kp = find_key_provider(keyring->type);
@@ -132,7 +135,7 @@ KeyringStoreKey(GenericKeyring *keyring, KeyInfo *key, bool throw_error)
 	return kp->routine->keyring_store_key(keyring, key, throw_error);
 }
 
-KeyInfo *
+static KeyInfo *
 KeyringGenerateNewKey(const char *key_name, unsigned key_len)
 {
 	KeyInfo    *key;

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -62,7 +62,7 @@ static JsonParseErrorType json_resp_scalar(void *state, char *token, JsonTokenTy
 static JsonParseErrorType json_resp_object_field_start(void *state, char *fname, bool isnull);
 static JsonParseErrorType parse_json_response(JsonVaultRespState *parse, JsonLexContext *lex);
 
-struct curl_slist *curlList = NULL;
+static struct curl_slist *curlList = NULL;
 
 static bool curl_setup_token(VaultV2Keyring *keyring);
 static char *get_keyring_vault_url(VaultV2Keyring *keyring, const char *key_name, char *out, size_t out_size);

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -117,8 +117,7 @@ _PG_init(void)
 	prev_shmem_startup_hook = shmem_startup_hook;
 	shmem_startup_hook = tde_shmem_startup;
 
-	RegisterXactCallback(pg_tde_xact_callback, NULL);
-	RegisterSubXactCallback(pg_tde_subxact_callback, NULL);
+	RegisterTdeXactCallbacks();
 	InstallFileKeyring();
 	InstallVaultV2Keyring();
 	InstallKmipKeyring();

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -45,13 +45,6 @@
 
 PG_MODULE_MAGIC;
 
-static const RmgrData tdeheap_rmgr = {
-	.rm_name = RM_TDERMGR_NAME,
-	.rm_redo = tdeheap_rmgr_redo,
-	.rm_desc = tdeheap_rmgr_desc,
-	.rm_identify = tdeheap_rmgr_identify
-};
-
 struct OnExtInstall
 {
 	pg_tde_on_ext_install_callback function;
@@ -129,7 +122,7 @@ _PG_init(void)
 	InstallFileKeyring();
 	InstallVaultV2Keyring();
 	InstallKmipKeyring();
-	RegisterCustomRmgr(RM_TDERMGR_ID, &tdeheap_rmgr);
+	RegisterTdeRmgr();
 
 	RegisterStorageMgr();
 }

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -53,6 +53,7 @@ struct OnExtInstall
 
 static struct OnExtInstall on_ext_install_list[MAX_ON_INSTALLS];
 static int	on_ext_install_index = 0;
+static void pg_tde_init_data_dir(void);
 static void run_extension_install_callbacks(XLogExtensionInstall *xlrec, bool redo);
 void		_PG_init(void);
 Datum		pg_tde_extension_initialize(PG_FUNCTION_ARGS);
@@ -175,7 +176,7 @@ on_ext_install(pg_tde_on_ext_install_callback function, void *arg)
 }
 
 /* Creates a tde directory for internal files if not exists */
-void
+static void
 pg_tde_init_data_dir(void)
 {
 	struct stat st;

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -31,12 +31,9 @@
 #include "executor/spi.h"
 
 /* Global variable that gets set at ddl start and cleard out at ddl end*/
-TdeCreateEvent tdeCurrentCreateEvent = {.relation = NULL};
-
-bool		alterSetAccessMethod = false;
-
-int			event_trigger_level = 0;
-
+static TdeCreateEvent tdeCurrentCreateEvent = {.relation = NULL};
+static bool alterSetAccessMethod = false;
+static int	event_trigger_level = 0;
 
 static void reset_current_tde_create_event(void);
 static Oid	get_tde_table_am_oid(void);

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -270,7 +270,6 @@ tde_mdopen(SMgrRelation reln)
 	mdopen(reln);
 }
 
-static SMgrId tde_smgr_id;
 static const struct f_smgr tde_smgr = {
 	.name = "tde",
 	.smgr_init = mdinit,
@@ -295,8 +294,6 @@ static const struct f_smgr tde_smgr = {
 void
 RegisterStorageMgr(void)
 {
-	tde_smgr_id = smgr_register(&tde_smgr, sizeof(TDESMgrRelationData));
-
 	/* TODO: figure out how this part should work in a real extension */
-	storage_manager_id = tde_smgr_id;
+	storage_manager_id = smgr_register(&tde_smgr, sizeof(TDESMgrRelationData));
 }


### PR DESCRIPTION
To make the code easier to understand I took a pass over our header files with the aim to reduce the size of our internal 
APIs between files. Some things I did:

- Added `static` to functions only used in one file
- Made some callback functions static by adding a function which registers and only exposing that one
- Added `static` to global variables only used in one file
- Removed prototypes for functions which no longer exist