### PR TITLE
PG-1392 Encrypt all relation forks

### DIFF
--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -26,15 +26,6 @@ typedef struct TDESMgrRelationData
 
 typedef TDESMgrRelationData *TDESMgrRelation;
 
-/*
- * we only encrypt main and init forks
- */
-static inline bool
-tde_is_encryption_required(TDESMgrRelation tdereln, ForkNumber forknum)
-{
-	return (tdereln->encrypted_relation && (forknum == MAIN_FORKNUM || forknum == INIT_FORKNUM));
-}
-
 static InternalKey *
 tde_smgr_get_key(SMgrRelation reln, RelFileLocator *old_locator, bool can_create)
 {
@@ -90,7 +81,7 @@ tde_mdwritev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
 	InternalKey *int_key = &tdereln->relKey;
 
-	if (!tde_is_encryption_required(tdereln, forknum))
+	if (!tdereln->encrypted_relation)
 	{
 		mdwritev(reln, forknum, blocknum, buffers, nblocks, skipFsync);
 	}
@@ -131,7 +122,7 @@ tde_mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
 	InternalKey *int_key = &tdereln->relKey;
 
-	if (!tde_is_encryption_required(tdereln, forknum))
+	if (!tdereln->encrypted_relation)
 	{
 		mdextend(reln, forknum, blocknum, buffer, skipFsync);
 	}
@@ -165,7 +156,7 @@ tde_mdreadv(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 
 	mdreadv(reln, forknum, blocknum, buffers, nblocks);
 
-	if (!tde_is_encryption_required(tdereln, forknum))
+	if (!tdereln->encrypted_relation)
 		return;
 
 	AesInit();


### PR DESCRIPTION
It is unclear to me why we stopped encrypting the FSM and visbility map forks in commit e514ac5cc14553630b9010fe47ce77e0cdbf12c8 which sadly does not explain why we stopped doing so. Both of them leak metadata that we do not have to. Especially once we also encrypt the catalogs.