### PR TITLE
Removed outdated install instructions

### DIFF
--- a/contrib/pg_tde/documentation/docs/apt.md
+++ b/contrib/pg_tde/documentation/docs/apt.md
@@ -10,7 +10,7 @@ Check the [list of supported platforms](install.md#__tabbed_1_1).
 2. You need the `percona-release` repository management tool that enables the desired Percona repository for you.
 
 
-### Install `percona-release`
+### Install `percona-release` {.power-number}
 
 1. You need the following dependencies to install `percona-release`:
     
@@ -21,26 +21,26 @@ Check the [list of supported platforms](install.md#__tabbed_1_1).
     
     Install them with the following command:
     
-    ```bash
-    sudo apt-get install -y wget gnupg2 curl lsb-release
+    ```{.bash data-prompt="$"}
+    $ sudo apt-get install -y wget gnupg2 curl lsb-release
     ```
     
 2. Fetch the `percona-release` package
 
-    ```bash
-    sudo wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
+    ```{.bash data-prompt="$"}
+    $ sudo wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
     ```
 
 3. Install `percona-release`
 
-    ```bash
-    sudo dpkg -i percona-release_latest.generic_all.deb
+    ```{.bash data-prompt="$"}
+    $ sudo dpkg -i percona-release_latest.generic_all.deb
     ```
 
 4. Enable the Percona Distribution for PostgreSQL repository
 
     ```{.bash data-prompt="$"}
-    $ sudo percona-release enable ppg-{{pgversion17}} 
+    $ sudo percona-release enable-only ppg-{{pgversion17}} 
     ```
 
 6. Update the local cache
@@ -49,30 +49,30 @@ Check the [list of supported platforms](install.md#__tabbed_1_1).
     sudo apt-get update
     ```
 
-## Install `pg_tde`
+## Install `pg_tde` {.power-number}
 
 !!! important
 
-    The `pg_tde` {{release}} extension is a part of the `percona-postgresql-17` package. If you installed a previous version of `pg_tde` from the `percona-postgresql-17-pg-tde` package, do the following:
+    The `pg_tde` extension is a part of the `percona-postgresql-17` package. If you installed a previous version of `pg_tde` from the `percona-postgresql-17-pg-tde` package, do the following:
 
     1. Drop the extension using the `DROP EXTENSION` with `CASCADE` command.
 
-       The use of the `CASCADE` parameter deletes all tables that were created in the database with `pg_tde` enabled and also all dependencies upon the encrypted table (e.g. foreign keys in a non-encrypted table used in the encrypted one).    
+        The use of the `CASCADE` parameter deletes all tables that were created in the database with `pg_tde` enabled and also all dependencies upon the encrypted table (e.g. foreign keys in a non-encrypted table used in the encrypted one).     
 
-       ```sql
-       DROP EXTENSION pg_tde CASCADE
-       ```
+        ```sql
+        DROP EXTENSION pg_tde CASCADE
+        ```
 
     2. Uninstall the `percona-postgresql-17-pg-tde` package.  
 
 After all [preconditions](#preconditions) are met, run the following command to install `pg_tde`:
 
 
-```bash
-sudo apt-get install -y percona-postgresql-17 
+```{.bash data-prompt="$"}
+$ sudo apt-get install -y percona-postgresql-17 
 ```
 
 
 ## Next step 
 
-[Setup](setup.md){.md-button}
+[Setup :material-arrow-right:](setup.md){.md-button}

--- a/contrib/pg_tde/documentation/docs/contribute.md
+++ b/contrib/pg_tde/documentation/docs/contribute.md
@@ -64,7 +64,7 @@ You can run tests on your local machine with whatever operating system you have.
 ## Contribute to documentation
 
 `pg_tde` documentation is written in Markdown language, so you can [write the docs for your code changes](#write-the-docs) or
-[edit the existing documentation online via GitHub](#edit-documentation-online-vi-github). If you wish to have more control over the doc process, jump to how to [edit documentation locally](#edit-documentation-locally). 
+[edit the existing documentation online via GitHub](#edit-documentation-online-via-github). If you wish to have more control over the doc process, jump to how to [edit documentation locally](#edit-documentation-locally). 
 
 Before you start, learn what [Markdown] is and how to write it. For your convenience, there's also a [Markdown cheat sheet] to help you with the syntax. 
 

--- a/contrib/pg_tde/documentation/docs/faq.md
+++ b/contrib/pg_tde/documentation/docs/faq.md
@@ -98,9 +98,9 @@ Whenever the WAL is being read (by the recovery process or tools), the decision 
 
 It depends on your business requirements and the sensitivity of your data. Encrypting all data is a good practice but it can have a performance impact. 
 
-Consider encrypting only tables that store sensitive data. You can decide what tables to encrypt and with what key. The [Setup](setup.md) section in documentation focuses on this approach.
+Consider encrypting only tables that store sensitive data. You can decide what tables to encrypt and with what key. The [Set up multi-tenancy](multi-tenant-setup.md) section in the documentation focuses on this approach.
 
-We advise encrypting the whole database only if all your data is sensitive, like PII, or if there is no other way to comply with data safety requirements. See [How to configure global encryption](global-encryption.md).
+We advise encrypting the whole database only if all your data is sensitive, like PII, or if there is no other way to comply with data safety requirements.
 
 ## What cipher mechanisms are used by `pg_tde`?
 

--- a/contrib/pg_tde/documentation/docs/install.md
+++ b/contrib/pg_tde/documentation/docs/install.md
@@ -1,9 +1,8 @@
 # Installation
 
-Install `pg_tde` using one of available installation methods:
+Install `pg_tde` using one of the available installation methods:
 
-
-=== "Package manager" 
+=== ":octicons-terminal-16: Package manager" 
 
     The packages are available for the following operating systems:
     
@@ -15,67 +14,22 @@ Install `pg_tde` using one of available installation methods:
     - Debian 11 (Bullseye) 
     - Debian 12 (Bookworm)
 
-    [Install on Debian or Ubuntu](apt.md){.md-button}
-    [Install on RHEL or derivatives](yum.md){.md-button}
+    [Install on Debian or Ubuntu :material-arrow-right:](apt.md){.md-button}
+    [Install on RHEL or derivatives :material-arrow-right:](yum.md){.md-button}
 
-=== "Build from source"
+=== ":simple-docker: Docker"
 
-    To build `pg_tde` from source code, do the following:
+    `pg_tde` is a part of the Percona Distribution for PostgreSQL Docker image. Use this image to enjoy full encryption capabilities. Check below to get access to a detailed step-by-step guide. 
 
-    1. On Ubuntu/Debian: Install the following dependencies required for the build:
+    [Run in Docker :material-arrow-right:](https://docs.percona.com/postgresql/latest/docker.html)
 
-        ```sh
-        sudo apt install make gcc postgresql-server-dev-17 libcurl4-openssl-dev
-        ```
+=== ":octicons-download-16: Manual download"
 
-    2. [Install Percona Distribution for PostgreSQL 17 :octicons-link-external-16:](https://docs.percona.com/postgresql/17/installing.html) or [upstream PostgreSQL 17 :octicons-link-external-16:](https://www.postgresql.org/download/)
+    `pg_tde` is included in the Percona Distribution for PostgreSQL tarball. Check below to get access to a detailed step-by-step guide. 
 
-    3. If PostgreSQL is installed in a non standard directory, set the `PG_CONFIG` environment variable to point to the `pg_config` executable.
+    [Install from tarballs](https://docs.percona.com/postgresql/17/tarball.html) guide for instructions.
 
-    4. Clone the repository:  
-
-        ```
-        git clone git://github.com/percona/pg_tde
-        ```
-
-    5. Compile and install the extension
-
-        ```
-        cd pg_tde
-        make USE_PGXS=1
-        sudo make USE_PGXS=1 install
-        ```
-
-=== "Run in Docker"
-
-    !!! note
-
-        The steps below are for the deprecated PostgreSQL Community version of `pg_tde` and apply only to PostgreSQL 16. This `pg_tde` version provides only the `tde_heap_basic` access method for data encryption. 
-
-        To enjoy full encryption features, run the `pg_tde` version for Percona Server for PostgreSQL. [Use the Percona Distribution for PostgreSQL Docker image :octicons-link-external-16:](https://docs.percona.com/postgresql/17/docker.html). 
-
-    You can find Docker images on [Docker Hub](https://hub.docker.com/r/perconalab/pg_tde). Images are built on top of [postgres:16](https://hub.docker.com/_/postgres) official image.     
-
-    To run `pg_tde` in Docker, use the following command:    
-
-    ```
-    docker run --name pg-tde -e POSTGRES_PASSWORD=mysecretpassword -d perconalab/pg_tde
-    ```    
-
-    It builds and adds the `pg_tde` extension to PostgreSQL 16. The `postgresql.conf` contains the required modifications. The `pg_tde` extension is added to `template1` so that all new databases automatically have the `pg_tde` extension loaded. 
-
-    Keys are not created automatically. You must configure a key provider and a principal key for each database  where you wish to use encrypted tables. 
-
-    Connect to the container and establish the `psql` session there. Then, see the instructions in the [Setup](setup.md) section, starting with the 4th point, as the first 3 steps are already completed in the Docker image.
-
-    See [Docker Docs](https://hub.docker.com/_/postgres) on usage.    
-
-    You can also build a Docker image manually with:    
-
-    ```
-    docker build . -f ./docker/Dockerfile -t your-image-name
-    ```
 
 ## Next steps
 
-[Setup](setup.md){.md-button}
+[Setup :material-arrow-right:](setup.md){.md-button}

--- a/contrib/pg_tde/documentation/docs/multi-tenant-setup.md
+++ b/contrib/pg_tde/documentation/docs/multi-tenant-setup.md
@@ -4,7 +4,7 @@ The steps below describe how to set up multi-tenancy with `pg_tde`. Multi-tenanc
 
 If you don't need multi-tenancy, use the global key provider. See the configuration steps from the [Setup](setup.md) section.
 
-For how to enable WAL encryption, refer to the [WAL encryption](setup.md#wal-encryption) section.
+For how to enable WAL encryption, refer to the [WAL encryption](wal-encryption.md) section.
 
 --8<-- "kms-considerations.md"
 

--- a/contrib/pg_tde/documentation/docs/release-notes/release-notes.md
+++ b/contrib/pg_tde/documentation/docs/release-notes/release-notes.md
@@ -1,6 +1,6 @@
 # pg_tde release notes
 
-`pg_tde` extension brings in [Transparent Data Encryption (TDE)](tde.md) to PostgreSQL and enables you to keep sensitive data safe and secure.
+`pg_tde` extension brings in [Transparent Data Encryption (TDE)](../tde.md) to PostgreSQL and enables you to keep sensitive data safe and secure.
 
 [Get started](../install.md){.md-button}
 

--- a/contrib/pg_tde/documentation/docs/switch.md
+++ b/contrib/pg_tde/documentation/docs/switch.md
@@ -1,5 +1,0 @@
-# Switch from Percona Server for PostgreSQL to PostgreSQL Community
-
-Percona Server for PostgreSQL and PostgreSQL Community are binary compatible and enable you to switch from one to another. Here's how:
-
-1. If you used the `tde_heap` (tech preview feature) access method for encryption, either re-encrypt the data using the `tde_heap_basic` access method, or [decrypt](decrypt.md) it completely 

--- a/contrib/pg_tde/documentation/docs/yum.md
+++ b/contrib/pg_tde/documentation/docs/yum.md
@@ -4,29 +4,27 @@ This tutorial shows how to install `pg_tde` with [Percona Distribution for Postg
 
 Check the [list of supported platforms](install.md#__tabbed_1_1).
 
-## Install `percona-release`
+## Install `percona-release` {.power-number}
 
 You need the `percona-release` repository management tool that enables the desired Percona repository for you.
 
 1. Install `percona-release`:
 
-    ```bash
-    sudo yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm 
+    ```{.bash data-prompt="$"}
+    $ sudo yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm 
     ```
 
 2. Enable the repository.
 
-    Percona provides [two repositories](repo-overview.md) for Percona Distribution for PostgreSQL. We recommend enabling the Major release repository to timely receive the latest updates.
-
-    ```bash
-    sudo percona-release enable-only ppg-{{pgversion17}} 
+    ```{.bash data-prompt="$"}
+    $ sudo percona-release enable-only ppg-{{pgversion17}} 
     ```
 
-## Install `pg_tde`
+## Install `pg_tde` {.power-number}
 
 !!! important
 
-    The `pg_tde` {{release}} extension is a part of the `percona-postgresql17` package. If you installed a previous version of `pg_tde` from the `percona-pg_tde_17` package, do the following:
+    The `pg_tde` extension is a part of the `percona-postgresql17` package. If you installed a previous version of `pg_tde` from the `percona-pg_tde_17` package, do the following:
 
     1. Drop the extension using the `DROP EXTENSION` with `CASCADE` command.
 
@@ -38,11 +36,12 @@ You need the `percona-release` repository management tool that enables the desir
 
     2. Uninstall the `percona-pg_tde_17` package.  
     
+Run the following command to install `pg_tde`:
 
-```bash
-sudo yum -y install percona-postgresql17 
+```{.bash data-prompt="$"}
+$ sudo yum -y install percona-postgresql17 
 ```
 
 ## Next steps
 
-[Setup](setup.md){.md-button}
+[Setup :material-arrow-right:](setup.md){.md-button}


### PR DESCRIPTION
Removed outdated install instructions: 
* Deleted build from source steps, 
* Updated Docker tab with the link to distro tutorial, 
* Added manual download tab with the link to Distro tutorial

Fixed broken links
modified:   contrib/pg_tde/documentation/docs/apt.md
	modified:   contrib/pg_tde/documentation/docs/contribute.md
	modified:   contrib/pg_tde/documentation/docs/faq.md
	modified:   contrib/pg_tde/documentation/docs/install.md
	modified:   contrib/pg_tde/documentation/docs/multi-tenant-setup.md
	modified:   contrib/pg_tde/documentation/docs/release-notes/release-notes.md
	deleted:    contrib/pg_tde/documentation/docs/switch.md
	modified:   contrib/pg_tde/documentation/docs/yum.md


