### PR TITLE
Do not allocate internal keys in top memory context

### DIFF
--- a/contrib/pg_tde/src/encryption/enc_tde.c
+++ b/contrib/pg_tde/src/encryption/enc_tde.c
@@ -1,7 +1,6 @@
 #include "pg_tde_defines.h"
 
 #include "postgres.h"
-#include "utils/memutils.h"
 
 #include "access/pg_tde_tdemap.h"
 #include "encryption/enc_tde.h"
@@ -194,24 +193,12 @@ AesDecryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, InternalKey **p_r
 {
 	unsigned char iv[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-#ifndef FRONTEND
-	MemoryContext oldcontext;
-#endif
-
 	/* Ensure we are getting a valid pointer here */
 	Assert(principal_key);
 
 	memcpy(iv, &dbOid, sizeof(Oid));
 
-#ifndef FRONTEND
-	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
-#endif
-
 	*p_rel_key_data = (InternalKey *) palloc(sizeof(InternalKey));
-
-#ifndef FRONTEND
-	MemoryContextSwitchTo(oldcontext);
-#endif
 
 	/* Fill in the structure */
 	memcpy(*p_rel_key_data, enc_rel_key_data, sizeof(InternalKey));

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -108,7 +108,6 @@ extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
 extern bool pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info, bool truncate_existing, bool update_header);
 extern bool pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern bool pg_tde_write_map_keydata_files(off_t map_size, char *m_file_data, off_t keydata_size, char *k_file_data);
-extern InternalKey *pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, bool no_map_ok);
 
 const char *tde_sprint_key(InternalKey *k);
 


### PR DESCRIPTION
Since all places which use the keys first copy them into long-lived memory we do not need to do that when allocating.

