### PR TITLE
Use `palloc_object()` and `palloc_array()` for type safety

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -1339,7 +1339,7 @@ pg_tde_read_one_keydata(int keydata_fd, int32 key_index, TDEPrincipalKey *princi
 	}
 
 	/* Allocate and fill in the structure */
-	enc_rel_key_data = (InternalKey *) palloc(sizeof(InternalKey));
+	enc_rel_key_data = palloc_object(InternalKey);
 	enc_rel_key_data->ctx = NULL;
 
 	/* Read the encrypted key */
@@ -1397,10 +1397,8 @@ pg_tde_get_principal_key_info(Oid dbOid)
 	 */
 	if (!is_new_file)
 	{
-		size_t		sz = sizeof(TDEPrincipalKeyInfo);
-
-		principal_key_info = (TDEPrincipalKeyInfo *) palloc(sz);
-		memcpy(principal_key_info, &fheader.principal_key_info, sz);
+		principal_key_info = palloc_object(TDEPrincipalKeyInfo);
+		memcpy(principal_key_info, &fheader.principal_key_info, sizeof(TDEPrincipalKeyInfo));
 	}
 
 	return principal_key_info;
@@ -1617,8 +1615,7 @@ pg_tde_add_wal_key_to_cache(InternalKey *cached_key, XLogRecPtr start_lsn)
 
 	oldCtx = MemoryContextSwitchTo(TopMemoryContext);
 #endif
-	wal_rec = (WALKeyCacheRec *) palloc(sizeof(WALKeyCacheRec));
-	memset(wal_rec, 0, sizeof(WALKeyCacheRec));
+	wal_rec = palloc0_object(WALKeyCacheRec);
 #ifndef FRONTEND
 	MemoryContextSwitchTo(oldCtx);
 #endif

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -681,7 +681,7 @@ scan_key_provider_file(ProviderScanType scanType, void *scanKey, Oid dbOid)
 				providers_list = lappend(providers_list, keyring);
 #else
 				if (providers_list == NULL)
-					providers_list = palloc(sizeof(providers_list));
+					providers_list = palloc_object(SimplePtrList);
 				simple_ptr_list_append(providers_list, keyring);
 #endif
 			}

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -354,7 +354,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 		return false;
 	}
 
-	new_principal_key = palloc(sizeof(TDEPrincipalKey));
+	new_principal_key = palloc_object(TDEPrincipalKey);
 	new_principal_key->keyInfo.databaseId = dbOid;
 	new_principal_key->keyInfo.keyringId = new_keyring->keyring_id;
 	memcpy(new_principal_key->keyInfo.name, keyInfo->name, TDE_KEY_NAME_LEN);
@@ -762,7 +762,7 @@ get_principal_key_from_keyring(Oid dbOid, bool pushToCache)
 		return NULL;
 	}
 
-	principalKey = palloc(sizeof(TDEPrincipalKey));
+	principalKey = palloc_object(TDEPrincipalKey);
 
 	memcpy(&principalKey->keyInfo, principalKeyInfo, sizeof(principalKey->keyInfo));
 	memcpy(principalKey->keyData, keyInfo->data.data, keyInfo->data.len);
@@ -862,7 +862,7 @@ GetPrincipalKey(Oid dbOid, LWLockMode lockMode)
 		return NULL;
 	}
 
-	newPrincipalKey = palloc(sizeof(TDEPrincipalKey));
+	newPrincipalKey = palloc_object(TDEPrincipalKey);
 	memcpy(newPrincipalKey, principalKey, sizeof(TDEPrincipalKey));
 	newPrincipalKey->keyInfo.databaseId = dbOid;
 
@@ -983,7 +983,7 @@ pg_tde_rotate_default_key_for_database(TDEPrincipalKey *oldKey, TDEPrincipalKey 
 {
 	bool		is_rotated;
 
-	TDEPrincipalKey *newKey = palloc(sizeof(TDEPrincipalKey));
+	TDEPrincipalKey *newKey = palloc_object(TDEPrincipalKey);
 
 	memcpy(newKey, newKeyTemplate, sizeof(TDEPrincipalKey));
 	newKey->keyInfo.databaseId = oldKey->keyInfo.databaseId;

--- a/contrib/pg_tde/src/encryption/enc_tde.c
+++ b/contrib/pg_tde/src/encryption/enc_tde.c
@@ -173,7 +173,7 @@ AesEncryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, InternalKey *rel_
 
 	memcpy(iv, &dbOid, sizeof(Oid));
 
-	*p_enc_rel_key_data = (InternalKey *) palloc(sizeof(InternalKey));
+	*p_enc_rel_key_data = palloc_object(InternalKey);
 	memcpy(*p_enc_rel_key_data, rel_key_data, sizeof(InternalKey));
 
 	AesEncrypt(principal_key->keyData, iv, (unsigned char *) rel_key_data, INTERNAL_KEY_LEN, (unsigned char *) *p_enc_rel_key_data, (int *) enc_key_bytes);
@@ -198,7 +198,7 @@ AesDecryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, InternalKey **p_r
 
 	memcpy(iv, &dbOid, sizeof(Oid));
 
-	*p_rel_key_data = (InternalKey *) palloc(sizeof(InternalKey));
+	*p_rel_key_data = palloc_object(InternalKey);
 
 	/* Fill in the structure */
 	memcpy(*p_rel_key_data, enc_rel_key_data, sizeof(InternalKey));

--- a/contrib/pg_tde/src/keyring/keyring_api.c
+++ b/contrib/pg_tde/src/keyring/keyring_api.c
@@ -83,7 +83,7 @@ RegisterKeyProvider(const TDEKeyringRoutine *routine, ProviderType type)
 #ifndef FRONTEND
 	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
 #endif
-	kp = palloc(sizeof(KeyProviders));
+	kp = palloc_object(KeyProviders);
 	kp->routine = (TDEKeyringRoutine *) routine;
 	kp->type = type;
 #ifndef FRONTEND

--- a/contrib/pg_tde/src/keyring/keyring_file.c
+++ b/contrib/pg_tde/src/keyring/keyring_file.c
@@ -55,7 +55,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 	if (fd < 0)
 		return NULL;
 
-	key = palloc(sizeof(KeyInfo));
+	key = palloc_object(KeyInfo);
 	while (true)
 	{
 		bytes_read = pg_pread(fd, key, sizeof(KeyInfo), curr_pos);

--- a/contrib/pg_tde/src/keyring/keyring_kmip.c
+++ b/contrib/pg_tde/src/keyring/keyring_kmip.c
@@ -31,6 +31,8 @@ extern void RegisterKeyProvider(const TDEKeyringRoutine *routine, ProviderType t
 extern void *palloc(size_t);
 extern void pfree(void *);
 
+#define palloc_object(type) ((type *) palloc(sizeof(type)))
+
 static void set_key_by_name(GenericKeyring *keyring, KeyInfo *key);
 static KeyInfo *get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *return_code);
 
@@ -230,7 +232,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 
 	/* 2. get key */
 
-	key = palloc(sizeof(KeyInfo));
+	key = palloc_object(KeyInfo);
 
 	{
 		char	   *keyp = NULL;

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -277,7 +277,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 	elog(DEBUG1, "Retrieved base64 key: %s", responseKey);
 #endif
 
-	key = palloc(sizeof(KeyInfo));
+	key = palloc_object(KeyInfo);
 	key->data.len = pg_b64_decode(responseKey, strlen(responseKey), (char *) key->data.data, MAX_KEY_DATA_SIZE);
 
 	if (key->data.len > MAX_KEY_DATA_SIZE)

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -108,7 +108,7 @@ tde_mdwritev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 	{
 		unsigned char *local_blocks = palloc(BLCKSZ * (nblocks + 1));
 		unsigned char *local_blocks_aligned = (unsigned char *) TYPEALIGN(PG_IO_ALIGN_SIZE, local_blocks);
-		void	  **local_buffers = palloc(sizeof(void *) * nblocks);
+		void	  **local_buffers = palloc_array(void *, nblocks);
 
 		AesInit();
 


### PR DESCRIPTION
These macros were added in PostgreSQL 16 but backported to all the way back to PostgreSQL 16. They provide an extra level of type safety.

What do you think? I am not a fan of the `void *` example but I like the rest.