### PR TITLE
Replace `memcpy()` of structs with assigningment

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -362,7 +362,6 @@ static int
 pg_tde_file_header_write(char *tde_filename, int fd, TDEPrincipalKeyInfo *principal_key_info, off_t *bytes_written)
 {
 	TDEFileHeader fheader;
-	size_t		sz = sizeof(TDEPrincipalKeyInfo);
 
 	Assert(principal_key_info);
 
@@ -370,8 +369,7 @@ pg_tde_file_header_write(char *tde_filename, int fd, TDEPrincipalKeyInfo *princi
 	fheader.file_version = PG_TDE_FILEMAGIC;
 
 	/* Fill in the data */
-	memset(&fheader.principal_key_info, 0, sz);
-	memcpy(&fheader.principal_key_info, principal_key_info, sz);
+	fheader.principal_key_info = *principal_key_info;
 
 	/* TODO: pgstat_report_wait_start / pgstat_report_wait_end */
 	*bytes_written = pg_pwrite(fd, &fheader, TDE_FILE_HEADER_SIZE, 0);
@@ -1392,13 +1390,13 @@ pg_tde_get_principal_key_info(Oid dbOid)
 	close(fd);
 
 	/*
-	 * It's not a new file. So we can memcpy the principal key info from the
+	 * It's not a new file. So we can copy the principal key info from the
 	 * header
 	 */
 	if (!is_new_file)
 	{
 		principal_key_info = palloc_object(TDEPrincipalKeyInfo);
-		memcpy(principal_key_info, &fheader.principal_key_info, sizeof(TDEPrincipalKeyInfo));
+		*principal_key_info = fheader.principal_key_info;
 	}
 
 	return principal_key_info;

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -496,7 +496,7 @@ write_key_provider_info(KeyringProvideRecord *provider, Oid database_id,
 
 			xlrec.database_id = database_id;
 			xlrec.offset_in_file = curr_pos;
-			memcpy(&xlrec.provider, provider, sizeof(KeyringProvideRecord));
+			xlrec.provider = *provider;
 
 			XLogBeginInsert();
 			XLogRegisterData((char *) &xlrec, sizeof(KeyringProviderXLRecord));

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -459,7 +459,7 @@ push_principal_key_to_cache(TDEPrincipalKey *principalKey)
 									   &databaseId, &found);
 
 	if (!found)
-		memcpy(cacheEntry, principalKey, sizeof(TDEPrincipalKey));
+		*cacheEntry = *principalKey;
 	dshash_release_lock(get_principal_key_Hash(), cacheEntry);
 
 	/* we don't want principal keys to end up paged to the swap */
@@ -596,7 +596,7 @@ pg_tde_set_principal_key_internal(char *principal_key_name, enum global_status g
 		existingDefaultKey = GetPrincipalKeyNoDefault(dbOid, LW_SHARED);
 		if (existingDefaultKey != NULL)
 		{
-			memcpy(&existingKeyCopy, existingDefaultKey, sizeof(TDEPrincipalKey));
+			existingKeyCopy = *existingDefaultKey;
 		}
 		LWLockRelease(tde_lwlock_enc_keys());
 	}
@@ -764,7 +764,7 @@ get_principal_key_from_keyring(Oid dbOid, bool pushToCache)
 
 	principalKey = palloc_object(TDEPrincipalKey);
 
-	memcpy(&principalKey->keyInfo, principalKeyInfo, sizeof(principalKey->keyInfo));
+	principalKey->keyInfo = *principalKeyInfo;
 	memcpy(principalKey->keyData, keyInfo->data.data, keyInfo->data.len);
 	principalKey->keyLength = keyInfo->data.len;
 
@@ -863,7 +863,7 @@ GetPrincipalKey(Oid dbOid, LWLockMode lockMode)
 	}
 
 	newPrincipalKey = palloc_object(TDEPrincipalKey);
-	memcpy(newPrincipalKey, principalKey, sizeof(TDEPrincipalKey));
+	*newPrincipalKey = *principalKey;
 	newPrincipalKey->keyInfo.databaseId = dbOid;
 
 	create_principal_key_info(&newPrincipalKey->keyInfo);
@@ -985,7 +985,7 @@ pg_tde_rotate_default_key_for_database(TDEPrincipalKey *oldKey, TDEPrincipalKey 
 
 	TDEPrincipalKey *newKey = palloc_object(TDEPrincipalKey);
 
-	memcpy(newKey, newKeyTemplate, sizeof(TDEPrincipalKey));
+	*newKey = *newKeyTemplate;
 	newKey->keyInfo.databaseId = oldKey->keyInfo.databaseId;
 
 	/* key rotation */

--- a/contrib/pg_tde/src/encryption/enc_tde.c
+++ b/contrib/pg_tde/src/encryption/enc_tde.c
@@ -174,7 +174,7 @@ AesEncryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, InternalKey *rel_
 	memcpy(iv, &dbOid, sizeof(Oid));
 
 	*p_enc_rel_key_data = palloc_object(InternalKey);
-	memcpy(*p_enc_rel_key_data, rel_key_data, sizeof(InternalKey));
+	**p_enc_rel_key_data = *rel_key_data;
 
 	AesEncrypt(principal_key->keyData, iv, (unsigned char *) rel_key_data, INTERNAL_KEY_LEN, (unsigned char *) *p_enc_rel_key_data, (int *) enc_key_bytes);
 }
@@ -201,7 +201,7 @@ AesDecryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, InternalKey **p_r
 	*p_rel_key_data = palloc_object(InternalKey);
 
 	/* Fill in the structure */
-	memcpy(*p_rel_key_data, enc_rel_key_data, sizeof(InternalKey));
+	**p_rel_key_data = *enc_rel_key_data;
 	(*p_rel_key_data)->ctx = NULL;
 
 	AesDecrypt(principal_key->keyData, iv, (unsigned char *) enc_rel_key_data, INTERNAL_KEY_LEN, (unsigned char *) *p_rel_key_data, (int *) key_bytes);

--- a/contrib/pg_tde/src/transam/pg_tde_xact_handler.c
+++ b/contrib/pg_tde/src/transam/pg_tde_xact_handler.c
@@ -89,7 +89,7 @@ RegisterEntryForDeletion(const RelFileLocator *rlocator, off_t map_entry_offset,
 
 	pending = (PendingMapEntryDelete *) MemoryContextAlloc(TopMemoryContext, sizeof(PendingMapEntryDelete));
 	pending->map_entry_offset = map_entry_offset;
-	memcpy(&pending->rlocator, rlocator, sizeof(RelFileLocator));
+	pending->rlocator = *rlocator;
 	pending->atCommit = atCommit;	/* delete if abort */
 	pending->nestLevel = GetCurrentTransactionNestLevel();
 	pending->next = pendingDeletes;


### PR DESCRIPTION
Replace `memcpy()` with normal assignment where it make sense to improve type checking.

PG-0

### Description
<!--- Describe your changes in detail -->


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

