### PR TITLE
Refuse to run` pg_tde_alter_key_provider` if cluster is running

### DIFF
--- a/contrib/pg_tde/src/pg_tde_alter_key_provider.c
+++ b/contrib/pg_tde/src/pg_tde_alter_key_provider.c
@@ -103,7 +103,7 @@ main(int argc, char *argv[])
 	char		json[BUFFER_SIZE * 2] = {0,};
 	ControlFileData *controlfile;
 	bool		crc_ok;
-	char		tdedir[1024] = {0,};
+	char		tdedir[MAXPGPATH] = {0,};
 	char	   *cptr = tdedir;
 	bool		provider_found = false;
 	GenericKeyring *keyring = NULL;


### PR DESCRIPTION
Copy the check from `pg_checksums` which adds some sanity checking by refusing to start if the cluster is already running. It takes no lock or anything like that so the cluster could be start while we run this tool but since it is quick the risk is pretty smaller, certainly smaller than for `pg_checksums`.