### PR TITLE
pg_tde_change_key_provider segfault fix

### DIFF
--- a/src/bin/pg_tde_change_key_provider/pg_tde_change_key_provider.c
+++ b/src/bin/pg_tde_change_key_provider/pg_tde_change_key_provider.c
@@ -153,7 +153,7 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
-	if (argc - argstart < 3)
+	if (argc - argstart <= 3)
 	{
 		help();
 		exit(1);


### PR DESCRIPTION
The tool possibly segfaulted when it received 3 incomplete arguments.

With this change it properly prints the help message instead.

PG-0

### Description
<!--- Describe your changes in detail -->


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

