### PR TITLE
PG-1417: Extension startup failure should be a fatal error

### DIFF
--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -111,7 +111,14 @@ _PG_init(void)
 {
 	if (!process_shared_preload_libraries_in_progress)
 	{
-		elog(ERROR, "pg_tde can only be loaded at server startup. Restart required.");
+		/*
+		 * psql/pg_restore continue on error by default, and change access
+		 * methods using set default_table_access_method. This error needs to
+		 * be FATAL and close the connection, otherwise these tools will
+		 * continue execution and create unencrypted tables when the intention
+		 * was to make them encrypted.
+		 */
+		elog(FATAL, "pg_tde can only be loaded at server startup. Restart required.");
 		return;
 	}
 


### PR DESCRIPTION
Earlier we modified the shared_preload_libraries check to a normal error instead of fatal, to avoid the server closing the connection on error.

This seemed like a change that makes the extension a bit more user friendly.

Unfortunately this has an unforeseen sideeffect of the pg_dump
+ pg_restore/psql combo possibly restoring a dump of an encrypted database in a possibly unencrypted version.

This is because:

* pg_dump doesn't use the `USING tde_heap` clause for `CREATE TABLE`, it sets the `default_table_access_method` instead
* both psql and pg_restore continue on errors by default, unless the -e command line argument is specified.

In practice this means that even if the `SET
default_table_access_method` call fails, the script continues, and creates tables using the "normal default", heap.

Fix:

revert the change, the extension startup failure should be a FATAL instead of a simple ERROR.

PG-0

### Description
<!--- Describe your changes in detail -->


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

