### PR TITLE
PG-1401: correct encryption status during alter table set access method

### DIFF
--- a/contrib/pg_tde/expected/change_access_method.out
+++ b/contrib/pg_tde/expected/change_access_method.out
@@ -43,9 +43,21 @@ SELECT pg_tde_is_encrypted('country_table_country_id_seq');
  t
 (1 row)
 
+SELECT pg_tde_is_encrypted('country_table_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 -- Try changing the encrypted table to an unencrypted table
 ALTER TABLE country_table SET access method  heap;
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('country_table_pkey');
  pg_tde_is_encrypted 
 ---------------------
  f
@@ -74,6 +86,12 @@ SELECT pg_tde_is_encrypted('country_table');
 (1 row)
 
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('country_table_pkey');
  pg_tde_is_encrypted 
 ---------------------
  f
@@ -111,6 +129,12 @@ SELECT pg_tde_is_encrypted('country_table_country_id_seq');
  t
 (1 row)
 
+SELECT pg_tde_is_encrypted('country_table_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 ALTER TABLE country_table ADD y text;
 SELECT pg_tde_is_encrypted(('pg_toast.pg_toast_' || 'country_table'::regclass::oid)::regclass);
  pg_tde_is_encrypted 
@@ -129,10 +153,10 @@ CREATE TABLE country_table3 (
      country_name    text unique not null,
      continent        text not null
 ) USING heap;
-psql:sql/change_access_method.inc:67: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:75: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
  
 ALTER TABLE country_table SET access method  heap;
-psql:sql/change_access_method.inc:69: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:77: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 ALTER TABLE country_table2 SET access method  :tde_am;
 CREATE TABLE country_table3 (
      country_id        serial primary key,

--- a/contrib/pg_tde/expected/change_access_method_basic.out
+++ b/contrib/pg_tde/expected/change_access_method_basic.out
@@ -50,10 +50,22 @@ SELECT pg_tde_is_encrypted('country_table_country_id_seq');
  f
 (1 row)
 
+SELECT pg_tde_is_encrypted('country_table_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 -- Try changing the encrypted table to an unencrypted table
 ALTER TABLE country_table SET access method  heap;
-psql:sql/change_access_method.inc:24: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:26: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('country_table_pkey');
  pg_tde_is_encrypted 
 ---------------------
  f
@@ -87,26 +99,32 @@ SELECT pg_tde_is_encrypted('country_table_country_id_seq');
  f
 (1 row)
 
+SELECT pg_tde_is_encrypted('country_table_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 -- Change it back to encrypted
 ALTER TABLE country_table SET access method  :tde_am;
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:40: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 INSERT INTO country_table (country_name, continent)
      VALUES ('China', 'Asia'),
             ('Brazil', 'South America'),
             ('Australia', 'Oceania');
-psql:sql/change_access_method.inc:45: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:45: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:45: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:51: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:51: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:51: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 SELECT * FROM country_table;
-psql:sql/change_access_method.inc:46: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:52: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
  country_id | country_name |   continent   
 ------------+--------------+---------------
           1 | Japan        | Asia
@@ -132,9 +150,15 @@ SELECT pg_tde_is_encrypted('country_table_country_id_seq');
  f
 (1 row)
 
+SELECT pg_tde_is_encrypted('country_table_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
 ALTER TABLE country_table ADD y text;
-psql:sql/change_access_method.inc:51: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/change_access_method.inc:51: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:59: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/change_access_method.inc:59: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 SELECT pg_tde_is_encrypted(('pg_toast.pg_toast_' || 'country_table'::regclass::oid)::regclass);
  pg_tde_is_encrypted 
 ---------------------
@@ -152,21 +176,21 @@ CREATE TABLE country_table3 (
      country_name    text unique not null,
      continent        text not null
 ) USING heap;
-psql:sql/change_access_method.inc:67: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:75: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
  
 ALTER TABLE country_table SET access method  heap;
-psql:sql/change_access_method.inc:69: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:77: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 ALTER TABLE country_table2 SET access method  :tde_am;
-psql:sql/change_access_method.inc:71: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:79: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 CREATE TABLE country_table3 (
      country_id        serial primary key,
      country_name    text unique not null,
      continent        text not null
 ) using :tde_am;
-psql:sql/change_access_method.inc:77: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
+psql:sql/change_access_method.inc:85: ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
 DROP TABLE country_table;
 DROP TABLE country_table2;
 DROP TABLE country_table3;
-psql:sql/change_access_method.inc:81: ERROR:  table "country_table3" does not exist
+psql:sql/change_access_method.inc:89: ERROR:  table "country_table3" does not exist
 SET pg_tde.enforce_encryption = OFF;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/change_access_method.inc
+++ b/contrib/pg_tde/sql/change_access_method.inc
@@ -20,10 +20,14 @@ SELECT pg_tde_is_encrypted('country_table');
 
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
 
+SELECT pg_tde_is_encrypted('country_table_pkey');
+
 -- Try changing the encrypted table to an unencrypted table
 ALTER TABLE country_table SET access method  heap;
 
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+
+SELECT pg_tde_is_encrypted('country_table_pkey');
 
 -- Insert some more data 
 INSERT INTO country_table (country_name, continent)
@@ -36,6 +40,8 @@ SELECT pg_tde_is_encrypted('country_table');
 
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
 
+SELECT pg_tde_is_encrypted('country_table_pkey');
+
 -- Change it back to encrypted
 ALTER TABLE country_table SET access method  :tde_am;
 
@@ -47,6 +53,8 @@ SELECT * FROM country_table;
 SELECT pg_tde_is_encrypted('country_table');
 
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
+
+SELECT pg_tde_is_encrypted('country_table_pkey');
 
 ALTER TABLE country_table ADD y text;
 

--- a/contrib/pg_tde/src/include/pg_tde_event_capture.h
+++ b/contrib/pg_tde/src/include/pg_tde_event_capture.h
@@ -18,8 +18,9 @@ typedef struct TdeCreateEvent
 								 * contains InvalidOid */
 	RangeVar   *relation;		/* Reference to the parsed relation from
 								 * create statement */
-	bool		alterSequenceMode;	/* true when alter sequence is executed by
-									 * pg_tde */
+	bool		alterAccessMethodMode;	/* during ALTER ... SET ACCESS METHOD,
+										 * new file permissions shouldn't be
+										 * based on earlier encryption status. */
 } TdeCreateEvent;
 
 extern TdeCreateEvent *GetCurrentTdeCreateEvent(void);

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -238,7 +238,7 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 	 * Later calls then decide to encrypt or not based on the existence of the
 	 * key
 	 */
-	key = tde_smgr_get_key(reln, event->alterSequenceMode ? NULL : &relold, true);
+	key = tde_smgr_get_key(reln, event->alterAccessMethodMode ? NULL : &relold, true);
 
 	if (key)
 	{


### PR DESCRIPTION
Previously some files inherited the previous encryption status, for example leaving primary keys encrypted if they were ever encrypted before.

This commit fixes the issue by basing new encryption status only on the new encryption setting.

PG-0

### Description
<!--- Describe your changes in detail -->


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

