### PR TITLE
PG-1425 & PG-1418: Fix typo

### DIFF
--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -264,7 +264,7 @@ You can also verify if the table in a custom schema is encrypted. Pass the schem
 SELECT pg_tde_is_encrypted('schema.table_name');
 ```
 
-This can additoonally be used the verify that indexes and sequences are encrypted.
+This can additionally be used the verify that indexes and sequences are encrypted.
 
 ### pg_tde_principal_key_info
 

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -264,7 +264,7 @@ You can also verify if the table in a custom schema is encrypted. Pass the schem
 SELECT pg_tde_is_encrypted('schema.table_name');
 ```
 
-This can additionally be used the verify that indexes and sequences are encrypted.
+This can additionally be used to verify that indexes and sequences are encrypted.
 
 ### pg_tde_principal_key_info
 

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -234,7 +234,7 @@ The `ensure_new_key` parameter instructs the function how to handle a principal 
 
 Creates or rotates the default principal key for the server using the specified key provider.
 
-The default key is automatically used as a principal key by any database that doesn't have a specific principal key created the first time an encrypted database object is created.
+The default key is automatically used as a principal key by any database that doesn't have a specific principal key already created when the first encrypted database object is created.
 
 ```
 SELECT pg_tde_set_default_principal_key('name-of-the-principal-key','provider-name','ensure_new_key');


### PR DESCRIPTION
PG-1425 & PG-1418

### Description
You can also verify if the table in a custom schema is encrypted. Pass the schema name for the function as follows:

SELECT pg_tde_is_encrypted('schema.table_name');
This can additoonally be used the verify that indexes and sequences are encrypted.

AND

Can be rephrased to:

The default key is automatically used as a principal key by any database that doesn't have a specific principal key already created when the first encrypted database object is created.


