### PR TITLE
PG-1414 Fix reference to which fucntion to call in error message

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -266,7 +266,7 @@ pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocat
 	if (principal_key == NULL)
 	{
 		ereport(ERROR,
-				(errmsg("failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted WAL.")));
+				(errmsg("failed to retrieve principal key. Create one using pg_tde_set_server_principal_key before using encrypted WAL.")));
 
 		return;
 	}


### PR DESCRIPTION
The error message when we have no principal key for the WAL encryption referred to the wrong function.
