### PR TITLE
PG-1451: Event trigger ddl_end doesn't fire on failure

### DIFF
--- a/contrib/pg_tde/expected/no_provider_error.out
+++ b/contrib/pg_tde/expected/no_provider_error.out
@@ -1,0 +1,8 @@
+CREATE EXTENSION pg_tde;
+-- should fail
+CREATE TABLE t1 (n INT) USING tde_heap;
+ERROR:  failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.
+-- should work
+CREATE TABLE t2 (n INT) USING heap;
+DROP TABLE t2;
+DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/meson.build
+++ b/contrib/pg_tde/meson.build
@@ -142,6 +142,7 @@ if get_variable('percona_ext', false)
       'kmip_test',
       'alter_index',
       'merge_join',
+      'no_provider_error',
   ]
 
   tap_tests += [

--- a/contrib/pg_tde/sql/no_provider_error.sql
+++ b/contrib/pg_tde/sql/no_provider_error.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION pg_tde;
+
+-- should fail
+CREATE TABLE t1 (n INT) USING tde_heap;
+
+-- should work
+CREATE TABLE t2 (n INT) USING heap;
+
+DROP TABLE t2;
+
+DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/src/include/pg_tde_event_capture.h
+++ b/contrib/pg_tde/src/include/pg_tde_event_capture.h
@@ -9,9 +9,12 @@
 
 #include "postgres.h"
 #include "nodes/parsenodes.h"
+#include "access/transam.h"
 
 typedef struct TdeCreateEvent
 {
+	FullTransactionId tid;		/* transaction id of the last event trigger,
+								 * or 0 */
 	bool		encryptMode;	/* true when the table uses encryption */
 	Oid			baseTableOid;	/* Oid of table on which index is being
 								 * created on. For create table statement this
@@ -24,5 +27,7 @@ typedef struct TdeCreateEvent
 } TdeCreateEvent;
 
 extern TdeCreateEvent *GetCurrentTdeCreateEvent(void);
+
+extern void validateCurrentEventTriggerState(bool mightStartTransaction);
 
 #endif

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -227,6 +227,14 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 	TdeCreateEvent *event = GetCurrentTdeCreateEvent();
 
 	/*
+	 * Make sure that even if a statement failed, and an event trigger end
+	 * trigger didn't fire, we don't accidentaly create encrypted files when
+	 * we don't have to. event above is a pointer, so it will reflect the
+	 * correct state even if this changes it.
+	 */
+	validateCurrentEventTriggerState(false);
+
+	/*
 	 * This is the only function that gets called during actual CREATE
 	 * TABLE/INDEX (EVENT TRIGGER)
 	 */


### PR DESCRIPTION
Our logic expected the start/end triggers to fire always in pairs, always one end trigger for one start trigger.

This is not the case, and it is clearly documented in the postgres documentation: end triggers are not executed on failed statements.

This completely broke the internal logic for encryption, and it never worked after an error, requiring restarting the connection.

Fix: instead of relying on start-end pairs, now we check the current transaction id both in the event trigger start function, and during file creation. If the transaction changed during the setup of the current event trigger data, we reset it.

PG-0

### Description
<!--- Describe your changes in detail -->


### Links
<!--- Please provide links to any related PRs in this or other repositories --->

