### PR TITLE
PG-1413: fix locking for WAL key update

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -969,6 +969,8 @@ pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path)
 				prev_key_pos;
 	InternalKey prev_key;
 
+	LWLockAcquire(lock_pk, LW_EXCLUSIVE);
+
 	fd = BasicOpenFile(keyfile_path, O_RDWR | PG_BINARY);
 	if (fd < 0)
 	{
@@ -981,7 +983,6 @@ pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path)
 	last_key_idx = ((lseek(fd, 0, SEEK_END) - TDE_FILE_HEADER_SIZE) / INTERNAL_KEY_DAT_LEN) - 1;
 	write_pos = TDE_FILE_HEADER_SIZE + (last_key_idx * INTERNAL_KEY_DAT_LEN) + offsetof(InternalKey, start_lsn);
 
-	LWLockAcquire(lock_pk, LW_EXCLUSIVE);
 	/* TODO: pgstat_report_wait_start / pgstat_report_wait_end */
 	if (pg_pwrite(fd, &lsn, sizeof(XLogRecPtr), write_pos) != sizeof(XLogRecPtr))
 	{


### PR DESCRIPTION
Key rotation creates a new _dat file and swaps with the existing one after all changes have been made. Therefore, the lock should be held before opening the descriptor while updating a WAL key's LSN.

What could have happened (and had happened) before this commit:
1. `pg_tde_wal_last_key_set_lsn()` opened a _dat descriptor
2. `pg_tde_perform_rotate_key()` aquires the lock
3. `pg_tde_perform_rotate_key()` performs a rotation and rewrites the _dat with a new copy (with a new fd).
4. `pg_tde_perform_rotate_key()` releases the lock
5. `pg_tde_wal_last_key_set_lsn()` acquires the lock
6. `pg_tde_wal_last_key_set_lsn()` writes changes to the old fd (into the void). As a result, the LSN of the key in the proper file remains unchanged.
