### PR TITLE
PG-1457 Key management funcs renaming

### DIFF
--- a/ci_scripts/backup/pg_basebackup_test.sh
+++ b/ci_scripts/backup/pg_basebackup_test.sh
@@ -104,8 +104,8 @@ setup_tde_heap(){
     sudo -u "$PG_USER" psql -p $PG_PORT -c "DROP DATABASE IF EXISTS $DB_NAME;"
     sudo -u "$PG_USER" psql -p $PG_PORT -c "CREATE DATABASE $DB_NAME;"
     sudo -u "$PG_USER" psql -d "$DB_NAME" -p "$PG_PORT" -c "CREATE EXTENSION IF NOT EXISTS pg_tde;"
-    sudo -u "$PG_USER" psql -d "$DB_NAME" -p "$PG_PORT" -c "SELECT pg_tde_add_key_provider_file('file-vault','$KEYLOCATION');"
-    sudo -u "$PG_USER" psql -d "$DB_NAME" -p "$PG_PORT" -c "SELECT pg_tde_set_principal_key('test-db-master-key','file-vault');"
+    sudo -u "$PG_USER" psql -d "$DB_NAME" -p "$PG_PORT" -c "SELECT pg_tde_add_database_key_provider_file('file-vault','$KEYLOCATION');"
+    sudo -u "$PG_USER" psql -d "$DB_NAME" -p "$PG_PORT" -c "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-master-key','file-vault');"
     sudo -u "$PG_USER" psql -p $PG_PORT -c "ALTER DATABASE $DB_NAME SET default_table_access_method='tde_heap';"
     sudo -u "$PG_USER" psql -p $PG_PORT -c "SELECT pg_reload_conf();"
 }

--- a/ci_scripts/tde_setup.sql
+++ b/ci_scripts/tde_setup.sql
@@ -1,4 +1,4 @@
 CREATE SCHEMA IF NOT EXISTS tde;
 CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
-SELECT tde.pg_tde_add_key_provider_file('reg_file-vault', '/tmp/pg_tde_test_keyring.per');
-SELECT tde.pg_tde_set_principal_key('test-db-principal-key', 'reg_file-vault');
+SELECT tde.pg_tde_add_database_key_provider_file('reg_file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT tde.pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key', 'reg_file-vault');

--- a/ci_scripts/tde_setup_global.sql
+++ b/ci_scripts/tde_setup_global.sql
@@ -2,7 +2,7 @@ CREATE SCHEMA tde;
 CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
 
 SELECT tde.pg_tde_add_global_key_provider_file('reg_file-global', '/tmp/pg_tde_test_keyring.per');
-SELECT tde.pg_tde_set_server_principal_key_global_provider('global-principal-key', 'reg_file-global');
+SELECT tde.pg_tde_set_server_principal_key_global_provider('server-principal-key', 'reg_file-global');
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 ALTER SYSTEM SET default_table_access_method = 'tde_heap';
 ALTER SYSTEM SET search_path = "$user",public,tde;

--- a/ci_scripts/tde_setup_global.sql
+++ b/ci_scripts/tde_setup_global.sql
@@ -2,7 +2,7 @@ CREATE SCHEMA tde;
 CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
 
 SELECT tde.pg_tde_add_global_key_provider_file('reg_file-global', '/tmp/pg_tde_test_keyring.per');
-SELECT tde.pg_tde_set_server_principal_key('global-principal-key', 'reg_file-global');
+SELECT tde.pg_tde_set_server_principal_key_global_provider('global-principal-key', 'reg_file-global');
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 ALTER SYSTEM SET default_table_access_method = 'tde_heap';
 ALTER SYSTEM SET search_path = "$user",public,tde;

--- a/ci_scripts/tde_setup_global.sql
+++ b/ci_scripts/tde_setup_global.sql
@@ -2,7 +2,7 @@ CREATE SCHEMA tde;
 CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
 
 SELECT tde.pg_tde_add_global_key_provider_file('reg_file-global', '/tmp/pg_tde_test_keyring.per');
-SELECT tde.pg_tde_set_server_principal_key_global_provider('server-principal-key', 'reg_file-global');
+SELECT tde.pg_tde_set_server_principal_key_using_global_key_provider('server-principal-key', 'reg_file-global');
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 ALTER SYSTEM SET default_table_access_method = 'tde_heap';
 ALTER SYSTEM SET search_path = "$user",public,tde;

--- a/contrib/pg_tde/README.md
+++ b/contrib/pg_tde/README.md
@@ -112,16 +112,16 @@ _See [Make Builds for Developers](https://github.com/percona/pg_tde/wiki/Make-bu
 
         ```sql
         -- For Vault-V2 key provider
-        -- pg_tde_add_key_provider_vault_v2(provider_name, vault_token, vault_url, vault_mount_path, vault_ca_path)
-        SELECT pg_tde_add_key_provider_vault_v2(
+        -- pg_tde_add_database_key_provider_vault_v2(provider_name, vault_token, vault_url, vault_mount_path, vault_ca_path)
+        SELECT pg_tde_add_database_key_provider_vault_v2(
             'vault-provider',
             json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/token' ),
             json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/url' ),
             to_json('secret'::text), NULL);
 
         -- For File key provider
-        -- pg_tde_add_key_provider_file(provider_name, file_path);
-        SELECT pg_tde_add_key_provider_file('file','/tmp/pgkeyring');
+        -- pg_tde_add_database_key_provider_file(provider_name, file_path);
+        SELECT pg_tde_add_database_key_provider_file('file','/tmp/pgkeyring');
         ```
 
         **Note: The `File` provided is intended for development and stores the keys unencrypted in the specified data file.**
@@ -129,8 +129,8 @@ _See [Make Builds for Developers](https://github.com/percona/pg_tde/wiki/Make-bu
    5. Set the principal key for the database using the `pg_tde_set_principal_key` function.
 
         ```sql
-        -- pg_tde_set_principal_key(principal_key_name, provider_name);
-        SELECT pg_tde_set_principal_key('my-principal-key','file');
+        -- pg_tde_set_principal_key_using_database_key_provider(principal_key_name, provider_name);
+        SELECT pg_tde_set_principal_key_using_database_key_provider('my-principal-key','file');
         ```
    
    6. Specify `tde_heap` access method during table creation

--- a/contrib/pg_tde/documentation/docs/external-parameters.md
+++ b/contrib/pg_tde/documentation/docs/external-parameters.md
@@ -15,7 +15,7 @@ To use the file provider with a file location specified by the `remote` method,
 use the following command:
 
 ```
-SELECT pg_tde_add_key_provider_file(
+SELECT pg_tde_add_database_key_provider_file(
     'file-provider', 
     json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello' )
     );"
@@ -24,7 +24,7 @@ SELECT pg_tde_add_key_provider_file(
 Or to use the `file` method, use the following command:
 
 ```
-SELECT pg_tde_add_key_provider_file(
+SELECT pg_tde_add_database_key_provider_file(
     'file-provider', 
     json_object( 'type' VALUE 'remote', 'path' VALUE '/tmp/datafile-location' )
     );"

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -314,9 +314,9 @@ If any of the above checks fail, the function reports an error.
 SELECT pg_tde_verify_principal_key()
 ```
 
-### pg_tde_verify_global_principal_key
+### pg_tde_verify_server_principal_key
 
-This function checks that the global scope has a properly functional encryption setup, which means:
+This function checks that the server scope has a properly functional encryption setup, which means:
 
 * A key provider is configured
 * The key provider is accessible using the specified configuration
@@ -327,5 +327,5 @@ This function checks that the global scope has a properly functional encryption 
 If any of the above checks fail, the function reports an error.
 
 ```
-SELECT pg_tde_verify_principal_key()
+SELECT pg_tde_verify_server_principal_key()
 ```

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -72,7 +72,7 @@ You can change an existing key provider using the provided functions, which are 
 
 There are two functions to change existing providers: one to change a provider in the current database, and another one to change a provider in the global scope.
 
-* `pg_tde_change_key_provider_<type>('provider-name', <provider specific parameters>)`
+* `pg_tde_change_database_key_provider_<type>('provider-name', <provider specific parameters>)`
 * `pg_tde_change_global_key_provider_<type>('provider-name', <provider specific parameters>)`
 
 When you change a provider, the referred name must exist in the database local or a global scope.
@@ -97,7 +97,7 @@ SELECT pg_tde_add_global_key_provider_vault_v2('provider-name','secret_token','u
 These functions change the Vault provider:
 
 ```
-SELECT pg_tde_change_key_provider_vault_v2('provider-name','secret_token','url','mount','ca_path');
+SELECT pg_tde_change_database_key_provider_vault_v2('provider-name','secret_token','url','mount','ca_path');
 SELECT pg_tde_change_global_key_provider_vault_v2('provider-name','secret_token','url','mount','ca_path');
 ```
 
@@ -128,7 +128,7 @@ SELECT pg_tde_add_global_key_provider_kmip('provider-name','kmip-addr', `port`, 
 These functions change the KMIP provider:
 
 ```
-SELECT pg_tde_change_key_provider_kmip('provider-name','kmip-addr', `port`, '/path_to/server_certificate.pem', '/path_to/client_key.pem');
+SELECT pg_tde_change_database_key_provider_kmip('provider-name','kmip-addr', `port`, '/path_to/server_certificate.pem', '/path_to/client_key.pem');
 SELECT pg_tde_change_global_key_provider_kmip('provider-name','kmip-addr', `port`, '/path_to/server_certificate.pem', '/path_to/client_key.pem');
 ```
 
@@ -163,7 +163,7 @@ SELECT pg_tde_add_global_key_provider_file('provider-name','/path/to/the/key/pro
 Change a local keyfile provider:
 
 ```
-SELECT pg_tde_change_key_provider_file('provider-name','/path/to/the/key/provider/data.file');
+SELECT pg_tde_change_database_key_provider_file('provider-name','/path/to/the/key/provider/data.file');
 SELECT pg_tde_change_global_key_provider_file('provider-name','/path/to/the/key/provider/data.file');
 ```
 

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -14,8 +14,8 @@ The following functions are also provided for easier management of functionality
 
 Use these functions to grant or revoke permissions to manage permissions for the current database. They enable or disable all functions related to the providers and keys on the current database:
 
-* `pg_tde_grant_local_key_management_to_role(role)`
-* `pg_tde_revoke_local_key_management_from_role(role)`
+* `pg_tde_grant_database_key_management_to_role(role)`
+* `pg_tde_revoke_database_key_management_from_role(role)`
 
 ### Global scope key management
 

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -201,12 +201,12 @@ Use these functions to create a new principal key for a specific scope such as a
 
 Princial keys are stored on key providers by the name specified in this function - for example, when using the Vault provider, after creating a key named "foo", a key named "foo" will be visible on the Vault server at the specified mount point.
 
-### pg_tde_set_principal_key
+### pg_tde_set_principal_key_using_database_key_provider
 
 Creates or rotates the principal key for the current database using the specified database key provider and key name.
 
 ```
-SELECT pg_tde_set_principal_key('name-of-the-principal-key','provider-name','ensure_new_key');
+SELECT pg_tde_set_principal_key_using_database_key_provider('name-of-the-principal-key','provider-name','ensure_new_key');
 ```
 
  The `ensure_new_key` parameter instructs the function how to handle a principal key during key rotation:
@@ -215,12 +215,12 @@ SELECT pg_tde_set_principal_key('name-of-the-principal-key','provider-name','ens
   If the provider already stores a key by that name, the function returns an error.
 * If set to `false`, an existing principal key may be reused.
 
-### pg_tde_set_global_principal_key
+### pg_tde_set_principal_key_using_global_key_provider
 
 Creates or rotates the global principal key using the specified global key provider and the key name. This key is used for global settings like WAL encryption.
 
 ```
-SELECT pg_tde_set_global_principal_key('name-of-the-principal-key','provider-name','ensure_new_key');
+SELECT pg_tde_set_principal_key_using_global_key_provider('name-of-the-principal-key','provider-name','ensure_new_key');
 ```
 
  The `ensure_new_key` parameter instructs the function how to handle a principal key during key rotation:
@@ -229,12 +229,12 @@ SELECT pg_tde_set_global_principal_key('name-of-the-principal-key','provider-nam
   If the provider already stores a key by that name, the function returns an error.
 * If set to `false`, an existing principal key may be reused.
 
-### pg_tde_set_server_principal_key
+### pg_tde_set_server_principal_key_using_global_key_provider
 
-Creates or rotates the global principal key using the specified key provider. Use this function to set a principal key for WAL encryption.
+Creates or rotates the server principal key using the specified global key provider. Use this function to set a principal key for WAL encryption.
 
 ```
-SELECT pg_tde_set_server_principal_key('name-of-the-principal-key','provider-name','ensure_new_key');
+SELECT pg_tde_set_server_principal_key_using_global_key_provider('name-of-the-principal-key','provider-name','ensure_new_key');
 ```
 
 The `ensure_new_key` parameter instructs the function how to handle a principal key during key rotation:
@@ -244,14 +244,14 @@ The `ensure_new_key` parameter instructs the function how to handle a principal 
 * If set to `false`, an existing principal key may be reused.
 
 
-### pg_tde_set_default_principal_key
+### pg_tde_set_default_principal_key_using_global_key_provider
 
-Creates or rotates the default principal key for the server using the specified key provider.
+Creates or rotates the default principal key for the server using the specified global key provider.
 
 The default key is automatically used as a principal key  by any database that doesn't have an individual key provider and key configuration.
 
 ```
-SELECT pg_tde_set_default_principal_key('name-of-the-principal-key','provider-name','ensure_new_key');
+SELECT pg_tde_set_default_principal_key_using_global_key_provider('name-of-the-principal-key','provider-name','ensure_new_key');
 ```
 
 The `ensure_new_key` parameter instructs the function how to handle a principal key during key rotation:
@@ -290,12 +290,12 @@ Displays information about the principal key for the current database, if it exi
 SELECT pg_tde_principal_key_info()
 ```
 
-### pg_tde_global_principal_key_info
+### pg_tde_server_principal_key_info
 
-Displays information about the principal key for the global scope, if exists.
+Displays information about the principal key for the server scope, if exists.
 
 ```
-SELECT pg_tde_global_principal_key_info()
+SELECT pg_tde_server_principal_key_info()
 ```
 
 ### pg_tde_verify_principal_key

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -90,7 +90,7 @@ The Vault provider connects to a HashiCorp Vault or an OpenBao server, and store
 Use the following functions to add the Vault provider:
 
 ```
-SELECT pg_tde_add_key_provider_vault_v2('provider-name','secret_token','url','mount','ca_path');
+SELECT pg_tde_add_database_key_provider_vault_v2('provider-name','secret_token','url','mount','ca_path');
 SELECT pg_tde_add_global_key_provider_vault_v2('provider-name','secret_token','url','mount','ca_path');
 ```
 
@@ -121,7 +121,7 @@ The KMIP provider uses a remote KMIP server.
 Use these functions to add a KMIP provider: 
 
 ```
-SELECT pg_tde_add_key_provider_kmip('provider-name','kmip-addr', `port`, '/path_to/server_certificate.pem', '/path_to/client_key.pem');
+SELECT pg_tde_add_database_key_provider_kmip('provider-name','kmip-addr', `port`, '/path_to/server_certificate.pem', '/path_to/client_key.pem');
 SELECT pg_tde_add_global_key_provider_kmip('provider-name','kmip-addr', `port`, '/path_to/server_certificate.pem', '/path_to/client_key.pem');
 ```
 
@@ -156,7 +156,7 @@ This function is intended for development or quick testing, and stores the keys 
 Add a local keyfile provider:
 
 ```
-SELECT pg_tde_add_key_provider_file('provider-name','/path/to/the/key/provider/data.file');
+SELECT pg_tde_add_database_key_provider_file('provider-name','/path/to/the/key/provider/data.file');
 SELECT pg_tde_add_global_key_provider_file('provider-name','/path/to/the/key/provider/data.file');
 ```
 
@@ -178,7 +178,7 @@ All parameters can be either strings, or JSON objects [referencing remote parame
 
 These functions delete an existing provider in the current database or in the global scope:
 
-* `pg_tde_delete_key_provider('provider-name)`
+* `pg_tde_delete_database_key_provider('provider-name)`
 * `pg_tde_delete_global_key_provider('provider-name)`
 
 You can only delete key providers that are not currently in use. An error is returned if the current principal key is using the provider you are trying to delete.
@@ -189,7 +189,7 @@ If the use of global key providers is enabled via the `pg_tde.inherit_global` GU
 
 These functions list the details of all key providers for the current database or for the global scope, including all configuration values:
 
-* `pg_tde_list_all_key_providers()`
+* `pg_tde_list_all_database_key_providers()`
 * `pg_tde_list_all_global_key_providers()`
 
 **All configuration values include possibly sensitive values, such as passwords. Never specify these directly, use the remote configuration option instead.**

--- a/contrib/pg_tde/documentation/docs/multi-tenant-setup.md
+++ b/contrib/pg_tde/documentation/docs/multi-tenant-setup.md
@@ -61,7 +61,7 @@ You must do these steps for every database where you have created the extension.
         For testing purposes, you can use the PyKMIP server which enables you to set up required certificates. To use a real KMIP server, make sure to obtain the valid certificates issued by the key management appliance. 
 
         ```
-        SELECT pg_tde_add_key_provider_kmip('provider-name','kmip-addr', 5696, '/path_to/server_certificate.pem', '/path_to/client_key.pem');
+        SELECT pg_tde_add_database_key_provider_kmip('provider-name','kmip-addr', 5696, '/path_to/server_certificate.pem', '/path_to/client_key.pem');
         ```
 
         where:
@@ -75,7 +75,7 @@ You must do these steps for every database where you have created the extension.
         <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
         ```
-        SELECT pg_tde_add_key_provider_kmip('kmip','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_key_jane_doe.pem');
+        SELECT pg_tde_add_database_key_provider_kmip('kmip','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_key_jane_doe.pem');
         ```
 
     === "With HashiCorp Vault"
@@ -83,7 +83,7 @@ You must do these steps for every database where you have created the extension.
         The Vault server setup is out of scope of this document.
 
         ```sql
-        SELECT pg_tde_add_key_provider_vault_v2('provider-name','root_token','url','mount','ca_path');
+        SELECT pg_tde_add_database_key_provider_vault_v2('provider-name','root_token','url','mount','ca_path');
         ``` 
 
         where: 
@@ -104,20 +104,20 @@ You must do these steps for every database where you have created the extension.
         This setup is intended for development and stores the keys unencrypted in the specified data file.    
 
         ```sql
-        SELECT pg_tde_add_key_provider_file('provider-name','/path/to/the/keyring/data.file');
+        SELECT pg_tde_add_database_key_provider_file('provider-name','/path/to/the/keyring/data.file');
         ```
 
 	    <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
 	    ```sql
-	    SELECT pg_tde_add_key_provider_file('file-keyring','/tmp/pg_tde_test_local_keyring.per');
+	    SELECT pg_tde_add_database_key_provider_file('file-keyring','/tmp/pg_tde_test_local_keyring.per');
 	    ```
        
        
 2. Add a principal key
 
     ```sql
-    SELECT pg_tde_set_principal_key('name-of-the-principal-key', 'provider-name','ensure_new_key');
+    SELECT pg_tde_set_principal_key_using_database_key_provider('name-of-the-principal-key', 'provider-name','ensure_new_key');
     ```
 
     where:
@@ -129,7 +129,7 @@ You must do these steps for every database where you have created the extension.
     <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
     ```sql
-    SELECT pg_tde_set_principal_key('test-db-master-key','file-vault','ensure_new_key');
+    SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-master-key','file-vault','ensure_new_key');
     ```
 
     The key is auto-generated.

--- a/contrib/pg_tde/documentation/docs/multi-tenant-setup.md
+++ b/contrib/pg_tde/documentation/docs/multi-tenant-setup.md
@@ -96,7 +96,7 @@ You must do these steps for every database where you have created the extension.
         <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
 	    ```
-	    SELECT pg_tde_add_key_provider_file_vault_v2('my-vault','http://vault.vault.svc.cluster.local:8200,'secret/data','hvs.zPuyktykA...example...ewUEnIRVaKoBzs2', NULL);
+	    SELECT pg_tde_add_database_key_provider_file_vault_v2('my-vault','http://vault.vault.svc.cluster.local:8200,'secret/data','hvs.zPuyktykA...example...ewUEnIRVaKoBzs2', NULL);
 	    ```
 
     === "With a keyring file"

--- a/contrib/pg_tde/documentation/docs/setup.md
+++ b/contrib/pg_tde/documentation/docs/setup.md
@@ -112,7 +112,7 @@ Load the `pg_tde` at startup time. The extension requires additional shared memo
 2. Add a default principal key
 
     ```sql
-    SELECT pg_tde_set_default_principal_key_global_provider('name-of-the-principal-key','provider-name','ensure_new_key');
+    SELECT pg_tde_set_default_principal_key_using_global_key_provider('name-of-the-principal-key','provider-name','ensure_new_key');
     ```
 
     where:

--- a/contrib/pg_tde/documentation/docs/setup.md
+++ b/contrib/pg_tde/documentation/docs/setup.md
@@ -112,7 +112,7 @@ Load the `pg_tde` at startup time. The extension requires additional shared memo
 2. Add a default principal key
 
     ```sql
-    SELECT pg_tde_set_default_principal_key('name-of-the-principal-key','provider-name','ensure_new_key');
+    SELECT pg_tde_set_default_principal_key_global_provider('name-of-the-principal-key','provider-name','ensure_new_key');
     ```
 
     where:
@@ -124,7 +124,7 @@ Load the `pg_tde` at startup time. The extension requires additional shared memo
     <i warning>:material-information: Warning:</i> This example is for testing purposes only. Replace the key name and provider name with your values:
 
     ```sql
-    SELECT pg_tde_set_global_principal_key('test-db-master-key','file-vault','ensure_new_key');
+    SELECT pg_tde_set_principal_key_global_provider('test-db-master-key','file-vault','ensure_new_key');
     ```
 
     The key is auto-generated.

--- a/contrib/pg_tde/documentation/docs/setup.md
+++ b/contrib/pg_tde/documentation/docs/setup.md
@@ -124,7 +124,7 @@ Load the `pg_tde` at startup time. The extension requires additional shared memo
     <i warning>:material-information: Warning:</i> This example is for testing purposes only. Replace the key name and provider name with your values:
 
     ```sql
-    SELECT pg_tde_set_principal_key_global_provider('test-db-master-key','file-vault','ensure_new_key');
+    SELECT pg_tde_set_principal_key_using_global_key_provider('test-db-master-key','file-vault','ensure_new_key');
     ```
 
     The key is auto-generated.

--- a/contrib/pg_tde/documentation/docs/wal-encryption.md
+++ b/contrib/pg_tde/documentation/docs/wal-encryption.md
@@ -61,7 +61,7 @@ Here's what to do:
 3. Create principal key
     
     ```sql
-    SELECT pg_tde_set_server_principal_key('principal-key', 'provider-name');
+    SELECT pg_tde_set_server_principal_key_global_provider('principal-key', 'provider-name');
     ```
 
 4. Enable WAL level encryption using the `ALTER SYSTEM` command. You need the privileges of the superuser to run this command:

--- a/contrib/pg_tde/documentation/docs/wal-encryption.md
+++ b/contrib/pg_tde/documentation/docs/wal-encryption.md
@@ -61,7 +61,7 @@ Here's what to do:
 3. Create principal key
     
     ```sql
-    SELECT pg_tde_set_server_principal_key_global_provider('principal-key', 'provider-name');
+    SELECT pg_tde_set_server_principal_key_using_global_key_provider('principal-key', 'provider-name');
     ```
 
 4. Enable WAL level encryption using the `ALTER SYSTEM` command. You need the privileges of the superuser to run this command:

--- a/contrib/pg_tde/documentation/docs/wal-encryption.md
+++ b/contrib/pg_tde/documentation/docs/wal-encryption.md
@@ -32,7 +32,7 @@ Here's what to do:
         <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
         ```
-        SELECT pg_tde_add_key_global_provider_kmip('kmip','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_key_jane_doe.pem');
+        SELECT pg_tde_add_key_using_global_key_provider_kmip('kmip','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_key_jane_doe.pem');
         ```
 
     === "With HashiCorp Vault"

--- a/contrib/pg_tde/expected/access_control.out
+++ b/contrib/pg_tde/expected/access_control.out
@@ -2,14 +2,14 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 CREATE USER regress_pg_tde_access_control;
 SET ROLE regress_pg_tde_access_control;
 -- should throw access denied
-SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
-ERROR:  permission denied for function pg_tde_add_key_provider_file
-SELECT pg_tde_set_principal_key('test-db-principal-key', 'file-vault');
-ERROR:  permission denied for function pg_tde_set_principal_key
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+ERROR:  permission denied for function pg_tde_add_database_key_provider_file
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key', 'file-vault');
+ERROR:  permission denied for function pg_tde_set_principal_key_using_database_key_provider
 RESET ROLE;
-SELECT pg_tde_grant_local_key_management_to_role('regress_pg_tde_access_control');
- pg_tde_grant_local_key_management_to_role 
--------------------------------------------
+SELECT pg_tde_grant_database_key_management_to_role('regress_pg_tde_access_control');
+ pg_tde_grant_database_key_management_to_role 
+----------------------------------------------
  
 (1 row)
 
@@ -21,25 +21,25 @@ SELECT pg_tde_grant_key_viewer_to_role('regress_pg_tde_access_control');
 
 SET ROLE regress_pg_tde_access_control;
 -- should now be allowed
-SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_add_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            2
+SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     2
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key', 'file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key', 'file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type |                           options                            
 ----+---------------+---------------+--------------------------------------------------------------
   1 | file-vault    | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
@@ -61,8 +61,8 @@ SELECT pg_tde_revoke_key_viewer_from_role('regress_pg_tde_access_control');
 
 SET ROLE regress_pg_tde_access_control;
 -- verify the view access is revoked
-SELECT * FROM pg_tde_list_all_key_providers();
-ERROR:  permission denied for function pg_tde_list_all_key_providers
+SELECT * FROM pg_tde_list_all_database_key_providers();
+ERROR:  permission denied for function pg_tde_list_all_database_key_providers
 SELECT principal_key_name, key_provider_name, key_provider_id FROM pg_tde_principal_key_info();
 ERROR:  permission denied for function pg_tde_principal_key_info
 RESET ROLE;

--- a/contrib/pg_tde/expected/alter_index.out
+++ b/contrib/pg_tde/expected/alter_index.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/cache_alloc.out
+++ b/contrib/pg_tde/expected/cache_alloc.out
@@ -1,14 +1,14 @@
 -- Just checking there are no mem debug WARNINGs during the cache population
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/change_access_method.out
+++ b/contrib/pg_tde/expected/change_access_method.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regressi
                                   -3
 (1 row)
 
-SELECT pg_tde_set_default_principal_key_global_provider('default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key_global_provider 
---------------------------------------------------
+SELECT pg_tde_set_default_principal_key_using_global_key_provider('default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key_using_global_key_provider 
+------------------------------------------------------------
  
 (1 row)
 
@@ -67,9 +67,9 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 (1 row)
 
 \c :regress_database
-SELECT pg_tde_set_default_principal_key_global_provider('new-default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key_global_provider 
---------------------------------------------------
+SELECT pg_tde_set_default_principal_key_using_global_key_provider('new-default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key_using_global_key_provider 
+------------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regressi
                                   -3
 (1 row)
 
-SELECT pg_tde_set_default_principal_key('default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key 
-----------------------------------
+SELECT pg_tde_set_default_principal_key_global_provider('default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key_global_provider 
+--------------------------------------------------
  
 (1 row)
 
@@ -67,9 +67,9 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 (1 row)
 
 \c :regress_database
-SELECT pg_tde_set_default_principal_key('new-default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key 
-----------------------------------
+SELECT pg_tde_set_default_principal_key_global_provider('new-default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key_global_provider 
+--------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/default_principal_key_1.out
+++ b/contrib/pg_tde/expected/default_principal_key_1.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regressi
                                   -4
 (1 row)
 
-SELECT pg_tde_set_default_principal_key_global_provider('default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key_global_provider 
---------------------------------------------------
+SELECT pg_tde_set_default_principal_key_using_global_provider('default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key_using_global_provider 
+--------------------------------------------------------
  
 (1 row)
 
@@ -68,9 +68,9 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 (1 row)
 
 \c :regress_database
-SELECT pg_tde_set_default_principal_key_global_provider('default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key_global_provider 
---------------------------------------------------
+SELECT pg_tde_set_default_principal_key_using_global_provider('default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key_using_global_provider 
+--------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/default_principal_key_1.out
+++ b/contrib/pg_tde/expected/default_principal_key_1.out
@@ -68,7 +68,7 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 (1 row)
 
 \c :regress_database
-SELECT pg_tde_set_default_principal_key_using_global_key_provider('default-principal-key', 'file-provider', false);
+SELECT pg_tde_set_default_principal_key_using_global_key_provider('new-default-principal-key', 'file-provider', false);
  pg_tde_set_default_principal_key_using_global_key_provider 
 ------------------------------------------------------------
  

--- a/contrib/pg_tde/expected/default_principal_key_1.out
+++ b/contrib/pg_tde/expected/default_principal_key_1.out
@@ -7,7 +7,7 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regressi
 
 SELECT pg_tde_set_default_principal_key_using_global_key_provider('default-principal-key', 'file-provider', false);
  pg_tde_set_default_principal_key_using_global_key_provider 
---------------------------------------------------------
+------------------------------------------------------------
  
 (1 row)
 
@@ -70,7 +70,7 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 \c :regress_database
 SELECT pg_tde_set_default_principal_key_using_global_key_provider('default-principal-key', 'file-provider', false);
  pg_tde_set_default_principal_key_using_global_key_provider 
---------------------------------------------------------
+------------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/default_principal_key_1.out
+++ b/contrib/pg_tde/expected/default_principal_key_1.out
@@ -5,8 +5,8 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regressi
                                   -4
 (1 row)
 
-SELECT pg_tde_set_default_principal_key_using_global_provider('default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key_using_global_provider 
+SELECT pg_tde_set_default_principal_key_using_global_key_provider('default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key_using_global_key_provider 
 --------------------------------------------------------
  
 (1 row)
@@ -68,8 +68,8 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 (1 row)
 
 \c :regress_database
-SELECT pg_tde_set_default_principal_key_using_global_provider('default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key_using_global_provider 
+SELECT pg_tde_set_default_principal_key_using_global_key_provider('default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key_using_global_key_provider 
 --------------------------------------------------------
  
 (1 row)

--- a/contrib/pg_tde/expected/default_principal_key_1.out
+++ b/contrib/pg_tde/expected/default_principal_key_1.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regressi
                                   -4
 (1 row)
 
-SELECT pg_tde_set_default_principal_key('default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key 
-----------------------------------
+SELECT pg_tde_set_default_principal_key_global_provider('default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key_global_provider 
+--------------------------------------------------
  
 (1 row)
 
@@ -68,9 +68,9 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 (1 row)
 
 \c :regress_database
-SELECT pg_tde_set_default_principal_key('new-default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key 
-----------------------------------
+SELECT pg_tde_set_default_principal_key_global_provider('default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key_global_provider 
+--------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/delete_key_provider.out
+++ b/contrib/pg_tde/expected/delete_key_provider.out
@@ -2,71 +2,71 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT  * FROM pg_tde_principal_key_info();
 ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
-SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type |                          options                           
 ----+---------------+---------------+------------------------------------------------------------
   1 | file-provider | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
 (1 row)
 
-SELECT pg_tde_delete_key_provider('file-provider');
- pg_tde_delete_key_provider 
-----------------------------
+SELECT pg_tde_delete_database_key_provider('file-provider');
+ pg_tde_delete_database_key_provider 
+-------------------------------------
  
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type | options 
 ----+---------------+---------------+---------
 (0 rows)
 
-SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            2
+SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     2
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type |                          options                           
 ----+---------------+---------------+------------------------------------------------------------
   2 | file-provider | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
 (1 row)
 
-SELECT pg_tde_delete_key_provider('file-provider');
- pg_tde_delete_key_provider 
-----------------------------
+SELECT pg_tde_delete_database_key_provider('file-provider');
+ pg_tde_delete_database_key_provider 
+-------------------------------------
  
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type | options 
 ----+---------------+---------------+---------
 (0 rows)
 
-SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            3
+SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     3
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type |                          options                           
 ----+---------------+---------------+------------------------------------------------------------
   3 | file-provider | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
 (1 row)
 
-SELECT pg_tde_delete_key_provider('file-provider');
- pg_tde_delete_key_provider 
-----------------------------
+SELECT pg_tde_delete_database_key_provider('file-provider');
+ pg_tde_delete_database_key_provider 
+-------------------------------------
  
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type | options 
 ----+---------------+---------------+---------
 (0 rows)

--- a/contrib/pg_tde/expected/insert_update_delete.out
+++ b/contrib/pg_tde/expected/insert_update_delete.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -50,7 +50,7 @@ SELECT pg_tde_verify_principal_key();
 
 SELECT pg_tde_change_database_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
 ERROR:  key provider "not-existent-provider" does not exists
-HINT:  Use pg_tde_add_database_key_provider interface to create the key provider
+HINT:  Create the key provider 
 SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                           options                           
 ----+----------------+---------------+-------------------------------------------------------------

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -2,32 +2,32 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT  * FROM pg_tde_principal_key_info();
 ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
-SELECT pg_tde_add_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
+SELECT pg_tde_add_database_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type | options 
 ----+---------------+---------------+---------
 (0 rows)
 
-SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type |                          options                           
 ----+---------------+---------------+------------------------------------------------------------
   1 | file-provider | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
 (1 row)
 
-SELECT pg_tde_add_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            2
+SELECT pg_tde_add_database_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     2
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                           options                           
 ----+----------------+---------------+-------------------------------------------------------------
   1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
@@ -36,9 +36,9 @@ SELECT * FROM pg_tde_list_all_key_providers();
 
 SELECT pg_tde_verify_principal_key();
 ERROR:  principal key not configured for current database
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 
@@ -50,8 +50,8 @@ SELECT pg_tde_verify_principal_key();
 
 SELECT pg_tde_change_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
 ERROR:  key provider "not-existent-provider" does not exists
-HINT:  Use pg_tde_add_key_provider interface to create the key provider
-SELECT * FROM pg_tde_list_all_key_providers();
+HINT:  Use pg_tde_add_database_key_provider interface to create the key provider
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                           options                           
 ----+----------------+---------------+-------------------------------------------------------------
   1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
@@ -64,7 +64,7 @@ SELECT pg_tde_change_key_provider_file('file-provider','/tmp/pg_tde_test_keyring
                                1
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                             options                              
 ----+----------------+---------------+------------------------------------------------------------------
   1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring_other.per"}
@@ -75,7 +75,7 @@ SELECT pg_tde_verify_principal_key();
 ERROR:  failed to retrieve principal key test-db-principal-key from keyring with ID 1
 SELECT pg_tde_change_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                             options                              
 ----+----------------+---------------+------------------------------------------------------------------
   1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring_other.per"}
@@ -103,9 +103,9 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 
 -- TODO: verify that we can also can change the type of it
 -- fails
-SELECT pg_tde_delete_key_provider('file-provider');
+SELECT pg_tde_delete_database_key_provider('file-provider');
 ERROR:  Can't delete a provider which is currently in use
-SELECT id, provider_name FROM pg_tde_list_all_key_providers();
+SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
  id | provider_name  
 ----+----------------
   1 | file-provider
@@ -113,13 +113,13 @@ SELECT id, provider_name FROM pg_tde_list_all_key_providers();
 (2 rows)
 
 -- works
-SELECT pg_tde_delete_key_provider('file-provider2');
- pg_tde_delete_key_provider 
-----------------------------
+SELECT pg_tde_delete_database_key_provider('file-provider2');
+ pg_tde_delete_database_key_provider 
+-------------------------------------
  
 (1 row)
 
-SELECT id, provider_name FROM pg_tde_list_all_key_providers();
+SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
  id | provider_name 
 ----+---------------
   1 | file-provider
@@ -132,7 +132,7 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  -2 | file-keyring2
 (2 rows)
 
-SELECT pg_tde_set_principal_key_global_provider('test-db-principal-key', 'file-keyring', false);
+SELECT pg_tde_set_principal_key_using_global_key_provider('test-db-principal-key', 'file-keyring', false);
  pg_tde_set_principal_key_global_provider 
 ------------------------------------------
  

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -132,9 +132,9 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  -2 | file-keyring2
 (2 rows)
 
-SELECT pg_tde_set_global_principal_key('test-db-principal-key', 'file-keyring', false);
- pg_tde_set_global_principal_key 
----------------------------------
+SELECT pg_tde_set_principal_key_global_provider('test-db-principal-key', 'file-keyring', false);
+ pg_tde_set_principal_key_global_provider 
+------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -50,7 +50,7 @@ SELECT pg_tde_verify_principal_key();
 
 SELECT pg_tde_change_database_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
 ERROR:  key provider "not-existent-provider" does not exists
-HINT:  Create the key provider 
+HINT:  Create the key provider
 SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                           options                           
 ----+----------------+---------------+-------------------------------------------------------------

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -133,8 +133,8 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 (2 rows)
 
 SELECT pg_tde_set_principal_key_using_global_key_provider('test-db-principal-key', 'file-keyring', false);
- pg_tde_set_principal_key_global_provider 
-------------------------------------------
+ pg_tde_set_principal_key_using_global_key_provider 
+----------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -48,7 +48,7 @@ SELECT pg_tde_verify_principal_key();
  
 (1 row)
 
-SELECT pg_tde_change_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_change_database_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
 ERROR:  key provider "not-existent-provider" does not exists
 HINT:  Use pg_tde_add_database_key_provider interface to create the key provider
 SELECT * FROM pg_tde_list_all_database_key_providers();
@@ -58,10 +58,10 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
   2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
-SELECT pg_tde_change_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_other.per');
- pg_tde_change_key_provider_file 
----------------------------------
-                               1
+SELECT pg_tde_change_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_other.per');
+ pg_tde_change_database_key_provider_file 
+------------------------------------------
+                                        1
 (1 row)
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
@@ -73,7 +73,7 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
 
 SELECT pg_tde_verify_principal_key();
 ERROR:  failed to retrieve principal key test-db-principal-key from keyring with ID 1
-SELECT pg_tde_change_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
+SELECT pg_tde_change_database_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
 SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                             options                              

--- a/contrib/pg_tde/expected/key_provider_1.out
+++ b/contrib/pg_tde/expected/key_provider_1.out
@@ -2,32 +2,32 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT  * FROM pg_tde_principal_key_info();
 ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
-SELECT pg_tde_add_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
+SELECT pg_tde_add_database_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type | options 
 ----+---------------+---------------+---------
 (0 rows)
 
-SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type |                          options                           
 ----+---------------+---------------+------------------------------------------------------------
   1 | file-provider | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
 (1 row)
 
-SELECT pg_tde_add_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            2
+SELECT pg_tde_add_database_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     2
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                           options                           
 ----+----------------+---------------+-------------------------------------------------------------
   1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
@@ -36,9 +36,9 @@ SELECT * FROM pg_tde_list_all_key_providers();
 
 SELECT pg_tde_verify_principal_key();
 ERROR:  principal key not configured for current database
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 
@@ -48,23 +48,23 @@ SELECT pg_tde_verify_principal_key();
  
 (1 row)
 
-SELECT pg_tde_change_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_change_database_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
 ERROR:  key provider "not-existent-provider" does not exists
-HINT:  Use pg_tde_add_key_provider interface to create the key provider
-SELECT * FROM pg_tde_list_all_key_providers();
+HINT:  Create the key provider
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                           options                           
 ----+----------------+---------------+-------------------------------------------------------------
   1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
   2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
-SELECT pg_tde_change_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_other.per');
- pg_tde_change_key_provider_file 
----------------------------------
-                               1
+SELECT pg_tde_change_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_other.per');
+ pg_tde_change_database_key_provider_file 
+------------------------------------------
+                                        1
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                             options                              
 ----+----------------+---------------+------------------------------------------------------------------
   1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring_other.per"}
@@ -73,9 +73,9 @@ SELECT * FROM pg_tde_list_all_key_providers();
 
 SELECT pg_tde_verify_principal_key();
 ERROR:  failed to retrieve principal key test-db-principal-key from keyring with ID 1
-SELECT pg_tde_change_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
+SELECT pg_tde_change_database_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                             options                              
 ----+----------------+---------------+------------------------------------------------------------------
   1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring_other.per"}
@@ -104,9 +104,9 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 
 -- TODO: verify that we can also can change the type of it
 -- fails
-SELECT pg_tde_delete_key_provider('file-provider');
+SELECT pg_tde_delete_database_key_provider('file-provider');
 ERROR:  Can't delete a provider which is currently in use
-SELECT id, provider_name FROM pg_tde_list_all_key_providers();
+SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
  id | provider_name  
 ----+----------------
   1 | file-provider
@@ -114,13 +114,13 @@ SELECT id, provider_name FROM pg_tde_list_all_key_providers();
 (2 rows)
 
 -- works
-SELECT pg_tde_delete_key_provider('file-provider2');
- pg_tde_delete_key_provider 
-----------------------------
+SELECT pg_tde_delete_database_key_provider('file-provider2');
+ pg_tde_delete_database_key_provider 
+-------------------------------------
  
 (1 row)
 
-SELECT id, provider_name FROM pg_tde_list_all_key_providers();
+SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
  id | provider_name 
 ----+---------------
   1 | file-provider
@@ -134,9 +134,9 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  -3 | file-keyring2
 (3 rows)
 
-SELECT pg_tde_set_global_principal_key('test-db-principal-key', 'file-keyring', false);
- pg_tde_set_global_principal_key 
----------------------------------
+SELECT pg_tde_set_global_principal_key_using_global_key_provider('test-db-principal-key', 'file-keyring', false);
+ pg_tde_set_global_principal_key_using_global_key_provider 
+-----------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/key_provider_1.out
+++ b/contrib/pg_tde/expected/key_provider_1.out
@@ -134,9 +134,9 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  -3 | file-keyring2
 (3 rows)
 
-SELECT pg_tde_set_global_principal_key_using_global_key_provider('test-db-principal-key', 'file-keyring', false);
- pg_tde_set_global_principal_key_using_global_key_provider 
------------------------------------------------------------
+SELECT pg_tde_set_principal_key_using_global_key_provider('test-db-principal-key', 'file-keyring', false);
+ pg_tde_set_principal_key_using_global_key_provider 
+----------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/keyprovider_dependency.out
+++ b/contrib/pg_tde/expected/keyprovider_dependency.out
@@ -1,23 +1,23 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('mk-file','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('mk-file','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_add_key_provider_file('free-file','/tmp/pg_tde_test_keyring_2.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            2
+SELECT pg_tde_add_database_key_provider_file('free-file','/tmp/pg_tde_test_keyring_2.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     2
 (1 row)
 
-SELECT pg_tde_add_key_provider_vault_v2('V2-vault','vault-token','percona.com/vault-v2/percona','/mount/dev','ca-cert-auth');
- pg_tde_add_key_provider_vault_v2 
-----------------------------------
-                                3
+SELECT pg_tde_add_database_key_provider_vault_v2('V2-vault','vault-token','percona.com/vault-v2/percona','/mount/dev','ca-cert-auth');
+ pg_tde_add_database_key_provider_vault_v2 
+-------------------------------------------
+                                         3
 (1 row)
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name | provider_type |                                                                    options                                                                    
 ----+---------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------
   1 | mk-file       | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
@@ -25,9 +25,9 @@ SELECT * FROM pg_tde_list_all_key_providers();
   3 | V2-vault      | vault-v2      | {"type" : "vault-v2", "url" : "percona.com/vault-v2/percona", "token" : "vault-token", "mountPath" : "/mount/dev", "caPath" : "ca-cert-auth"}
 (3 rows)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','mk-file');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','mk-file');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/kmip_test.out
+++ b/contrib/pg_tde/expected/kmip_test.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION pg_tde;
-SELECT pg_tde_add_key_provider_kmip('kmip-prov','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_key_jane_doe.pem');
- pg_tde_add_key_provider_kmip 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_kmip('kmip-prov','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_key_jane_doe.pem');
+ pg_tde_add_database_key_provider_kmip 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_set_principal_key('kmip-principal-key','kmip-prov');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('kmip-principal-key','kmip-prov');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -2,15 +2,15 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT * FROM pg_tde_principal_key_info();
 ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/recreate_storage.out
+++ b/contrib/pg_tde/expected/recreate_storage.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/relocate.out
+++ b/contrib/pg_tde/expected/relocate.out
@@ -3,10 +3,10 @@ SET client_min_messages = 'warning';
 DROP EXTENSION IF EXISTS pg_tde;
 CREATE SCHEMA other;
 CREATE EXTENSION pg_tde SCHEMA other;
-SELECT other.pg_tde_add_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT other.pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
 SELECT other.pg_tde_grant_key_viewer_to_role('public');

--- a/contrib/pg_tde/expected/subtransaction.out
+++ b/contrib/pg_tde/expected/subtransaction.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/tablespace.out
+++ b/contrib/pg_tde/expected/tablespace.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/toast_decrypt.out
+++ b/contrib/pg_tde/expected/toast_decrypt.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            1
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/toast_decrypt_1.out
+++ b/contrib/pg_tde/expected/toast_decrypt_1.out
@@ -1,14 +1,14 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 NOTICE:  extension "pg_tde" already exists, skipping
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
- pg_tde_add_key_provider_file 
-------------------------------
-                            2
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     2
 (1 row)
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 \getenv root_token ROOT_TOKEN
-SELECT pg_tde_add_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
- pg_tde_add_key_provider_vault_v2 
-----------------------------------
-                                1
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
+ pg_tde_add_database_key_provider_vault_v2 
+-------------------------------------------
+                            		     1
 (1 row)
 
 -- FAILS
-SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-incorrect');
+SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-incorrect');
 ERROR:  Invalid HTTP response from keyring provider "vault-incorrect": 404
 CREATE TABLE test_enc(
 	  id SERIAL,
@@ -16,15 +16,15 @@ CREATE TABLE test_enc(
 	) USING tde_heap;
 ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_principal_key before using encrypted tables
-SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
- pg_tde_add_key_provider_vault_v2 
-----------------------------------
-                                2
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
+ pg_tde_add_database_key_provider_vault_v2 
+-------------------------------------------
+                             		     2
 (1 row)
 
-SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');
- pg_tde_set_principal_key 
---------------------------
+SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-v2');
+ pg_tde_set_principal_key_using_database_key_provider 
+------------------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
-                            		     1
+                                         1
 (1 row)
 
 -- FAILS
@@ -19,7 +19,7 @@ HINT:  create one using pg_tde_set_principal_key before using encrypted tables
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
-                             		     2
+                                         2
 (1 row)
 
 SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-v2');

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -101,10 +101,6 @@ BEGIN ATOMIC
                             'certPath' VALUE kmip_cert_path));
 END;
 
-CREATE FUNCTION pg_tde_set_default_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
-RETURNS VOID
-AS 'MODULE_PATHNAME'
-LANGUAGE C;
 
 CREATE FUNCTION pg_tde_list_all_key_providers
     (OUT id INT,
@@ -466,12 +462,17 @@ RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_global_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_server_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_server_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_server_principal_key_global_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+RETURNS VOID
+LANGUAGE C
+AS 'MODULE_PATHNAME';
+
+CREATE FUNCTION pg_tde_set_default_principal_key_global_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
@@ -499,7 +500,7 @@ RETURNS TABLE ( principal_key_name text,
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_global_principal_key_info()
+CREATE FUNCTION pg_tde_server_principal_key_info()
 RETURNS TABLE ( principal_key_name text,
                 key_provider_name text,     
                 key_provider_id integer,
@@ -578,10 +579,9 @@ BEGIN
 
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_delete_global_key_provider(text) TO %I', target_role);
 
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_global_principal_key(text, text, BOOLEAN) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_server_principal_key(text, text, BOOLEAN) TO %I', target_role);
-
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_default_principal_key(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_principal_key_global_provider(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_server_principal_key_global_provider(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_default_principal_key_global_provider(text, text, BOOLEAN) TO %I', target_role);
 END;
 $$;
 
@@ -627,7 +627,7 @@ BEGIN
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_list_all_global_key_providers() TO %I', target_role);
 
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_principal_key_info() TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_global_principal_key_info() TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_server_principal_key_info() TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_verify_principal_key() TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_verify_global_principal_key() TO %I', target_role);
 END;
@@ -660,10 +660,9 @@ BEGIN
 
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_delete_global_key_provider(text) FROM %I', target_role);
 
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_global_principal_key(text, text, BOOLEAN) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_server_principal_key(text, text, BOOLEAN) FROM %I', target_role);
-
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_default_principal_key(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_principal_key_global_provider(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_server_principal_key_global_provider(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_default_principal_key_global_provider(text, text, BOOLEAN) FROM %I', target_role);
 END;
 $$;
 
@@ -709,7 +708,7 @@ BEGIN
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_list_all_global_key_providers() FROM %I', target_role);
 
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_principal_key_info() FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_global_principal_key_info() FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_server_principal_key_info() FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_verify_principal_key() FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_verify_global_principal_key() FROM %I', target_role);
 END;

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -4,32 +4,32 @@
 \echo Use "CREATE EXTENSION pg_tde" to load this file. \quit
 
 -- Key Provider Management
-CREATE FUNCTION pg_tde_add_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
+CREATE FUNCTION pg_tde_add_database_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
 RETURNS INT
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_add_key_provider_file(provider_name TEXT, file_path TEXT)
+CREATE FUNCTION pg_tde_add_database_key_provider_file(provider_name TEXT, file_path TEXT)
 RETURNS INT
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
-    SELECT pg_tde_add_key_provider('file', provider_name,
+    SELECT pg_tde_add_database_key_provider('file', provider_name,
                 json_object('type' VALUE 'file', 'path' VALUE COALESCE(file_path, '')));
 END;
 
-CREATE FUNCTION pg_tde_add_key_provider_file(provider_name TEXT, file_path JSON)
+CREATE FUNCTION pg_tde_add_database_key_provider_file(provider_name TEXT, file_path JSON)
 RETURNS INT
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
-    SELECT pg_tde_add_key_provider('file', provider_name,
+    SELECT pg_tde_add_database_key_provider('file', provider_name,
                 json_object('type' VALUE 'file', 'path' VALUE file_path));
 END;
 
-CREATE FUNCTION pg_tde_add_key_provider_vault_v2(provider_name TEXT,
+CREATE FUNCTION pg_tde_add_database_key_provider_vault_v2(provider_name TEXT,
                                                 vault_token TEXT,
                                                 vault_url TEXT,
                                                 vault_mount_path TEXT,
@@ -39,7 +39,7 @@ LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
-    SELECT pg_tde_add_key_provider('vault-v2', provider_name,
+    SELECT pg_tde_add_database_key_provider('vault-v2', provider_name,
                             json_object('type' VALUE 'vault-v2',
                             'url' VALUE COALESCE(vault_url, ''),
                             'token' VALUE COALESCE(vault_token, ''),
@@ -47,7 +47,7 @@ BEGIN ATOMIC
                             'caPath' VALUE COALESCE(vault_ca_path, '')));
 END;
 
-CREATE FUNCTION pg_tde_add_key_provider_vault_v2(provider_name TEXT,
+CREATE FUNCTION pg_tde_add_database_key_provider_vault_v2(provider_name TEXT,
                                                 vault_token JSON,
                                                 vault_url JSON,
                                                 vault_mount_path JSON,
@@ -57,7 +57,7 @@ LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
-    SELECT pg_tde_add_key_provider('vault-v2', provider_name,
+    SELECT pg_tde_add_database_key_provider('vault-v2', provider_name,
                             json_object('type' VALUE 'vault-v2',
                             'url' VALUE vault_url,
                             'token' VALUE vault_token,
@@ -65,7 +65,7 @@ BEGIN ATOMIC
                             'caPath' VALUE vault_ca_path));
 END;
 
-CREATE FUNCTION pg_tde_add_key_provider_kmip(provider_name TEXT,
+CREATE FUNCTION pg_tde_add_database_key_provider_kmip(provider_name TEXT,
                                              kmip_host TEXT,
                                              kmip_port INT,
                                              kmip_ca_path TEXT,
@@ -75,7 +75,7 @@ LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
-    SELECT pg_tde_add_key_provider('kmip', provider_name,
+    SELECT pg_tde_add_database_key_provider('kmip', provider_name,
                             json_object('type' VALUE 'kmip',
                             'host' VALUE COALESCE(kmip_host, ''),
                             'port' VALUE kmip_port,
@@ -83,7 +83,7 @@ BEGIN ATOMIC
                             'certPath' VALUE COALESCE(kmip_cert_path, '')));
 END;
 
-CREATE FUNCTION pg_tde_add_key_provider_kmip(provider_name TEXT,
+CREATE FUNCTION pg_tde_add_database_key_provider_kmip(provider_name TEXT,
                                              kmip_host JSON,
                                              kmip_port JSON,
                                              kmip_ca_path JSON,
@@ -93,7 +93,7 @@ LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
-    SELECT pg_tde_add_key_provider('kmip', provider_name,
+    SELECT pg_tde_add_database_key_provider('kmip', provider_name,
                             json_object('type' VALUE 'kmip',
                             'host' VALUE kmip_host,
                             'port' VALUE kmip_port,
@@ -102,7 +102,7 @@ BEGIN ATOMIC
 END;
 
 
-CREATE FUNCTION pg_tde_list_all_key_providers
+CREATE FUNCTION pg_tde_list_all_database_key_providers
     (OUT id INT,
     OUT provider_name TEXT,
     OUT provider_type TEXT,
@@ -219,32 +219,32 @@ BEGIN ATOMIC
 END;
 
 -- Key Provider Management
-CREATE FUNCTION pg_tde_change_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
+CREATE FUNCTION pg_tde_change_database_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
 RETURNS INT
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_change_key_provider_file(provider_name TEXT, file_path TEXT)
+CREATE FUNCTION pg_tde_change_database_key_provider_file(provider_name TEXT, file_path TEXT)
 RETURNS INT
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
-    SELECT pg_tde_change_key_provider('file', provider_name,
+    SELECT pg_tde_change_database_key_provider('file', provider_name,
                 json_object('type' VALUE 'file', 'path' VALUE COALESCE(file_path, '')));
 END;
 
-CREATE FUNCTION pg_tde_change_key_provider_file(provider_name TEXT, file_path JSON)
+CREATE FUNCTION pg_tde_change_database_key_provider_file(provider_name TEXT, file_path JSON)
 RETURNS INT
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
-    SELECT pg_tde_change_key_provider('file', provider_name,
+    SELECT pg_tde_change_database_key_provider('file', provider_name,
                 json_object('type' VALUE 'file', 'path' VALUE file_path));
 END;
 
-CREATE FUNCTION pg_tde_change_key_provider_vault_v2(provider_name TEXT,
+CREATE FUNCTION pg_tde_change_database_key_provider_vault_v2(provider_name TEXT,
                                                     vault_token TEXT,
                                                     vault_url TEXT,
                                                     vault_mount_path TEXT,
@@ -254,7 +254,7 @@ LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
-    SELECT pg_tde_change_key_provider('vault-v2', provider_name,
+    SELECT pg_tde_change_database_key_provider('vault-v2', provider_name,
                             json_object('type' VALUE 'vault-v2',
                             'url' VALUE COALESCE(vault_url, ''),
                             'token' VALUE COALESCE(vault_token, ''),
@@ -262,7 +262,7 @@ BEGIN ATOMIC
                             'caPath' VALUE COALESCE(vault_ca_path, '')));
 END;
 
-CREATE FUNCTION pg_tde_change_key_provider_vault_v2(provider_name TEXT,
+CREATE FUNCTION pg_tde_change_database_key_provider_vault_v2(provider_name TEXT,
                                                     vault_token JSON,
                                                     vault_url JSON,
                                                     vault_mount_path JSON,
@@ -272,7 +272,7 @@ LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
-    SELECT pg_tde_change_key_provider('vault-v2', provider_name,
+    SELECT pg_tde_change_database_key_provider('vault-v2', provider_name,
                             json_object('type' VALUE 'vault-v2',
                             'url' VALUE vault_url,
                             'token' VALUE vault_token,
@@ -280,7 +280,7 @@ BEGIN ATOMIC
                             'caPath' VALUE vault_ca_path));
 END;
 
-CREATE FUNCTION pg_tde_change_key_provider_kmip(provider_name TEXT,
+CREATE FUNCTION pg_tde_change_database_key_provider_kmip(provider_name TEXT,
                                                 kmip_host TEXT,
                                                 kmip_port INT,
                                                 kmip_ca_path TEXT,
@@ -290,7 +290,7 @@ LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
-    SELECT pg_tde_change_key_provider('kmip', provider_name,
+    SELECT pg_tde_change_database_key_provider('kmip', provider_name,
                             json_object('type' VALUE 'kmip',
                             'host' VALUE COALESCE(kmip_host, ''),
                             'port' VALUE kmip_port,
@@ -298,7 +298,7 @@ BEGIN ATOMIC
                             'certPath' VALUE COALESCE(kmip_cert_path, '')));
 END;
 
-CREATE FUNCTION pg_tde_change_key_provider_kmip(provider_name TEXT,
+CREATE FUNCTION pg_tde_change_database_key_provider_kmip(provider_name TEXT,
                                                 kmip_host JSON,
                                                 kmip_port JSON,
                                                 kmip_ca_path JSON,
@@ -308,7 +308,7 @@ LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
-    SELECT pg_tde_change_key_provider('kmip', provider_name,
+    SELECT pg_tde_change_database_key_provider('kmip', provider_name,
                             json_object('type' VALUE 'kmip',
                             'host' VALUE kmip_host,
                             'port' VALUE kmip_port,
@@ -457,25 +457,25 @@ STRICT
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_principal_key_using_database_key_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_server_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_principal_key_using_global_key_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_server_principal_key_global_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_server_principal_key_using_global_key_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_default_principal_key_global_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_default_principal_key_using_global_key_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
-LANGUAGE C
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
 
 CREATE FUNCTION pg_tde_extension_initialize()
 RETURNS VOID
@@ -513,7 +513,7 @@ RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_delete_key_provider(provider_name TEXT)
+CREATE FUNCTION pg_tde_delete_database_key_provider(provider_name TEXT)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
@@ -579,40 +579,40 @@ BEGIN
 
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_delete_global_key_provider(text) TO %I', target_role);
 
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_principal_key_global_provider(text, text, BOOLEAN) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_server_principal_key_global_provider(text, text, BOOLEAN) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_default_principal_key_global_provider(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_principal_key_using_global_key_provider(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_server_principal_key_using_global_key_provider(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_default_principal_key_using_global_key_provider(text, text, BOOLEAN) TO %I', target_role);
 END;
 $$;
 
-CREATE FUNCTION pg_tde_grant_local_key_management_to_role(
+CREATE FUNCTION pg_tde_grant_database_key_management_to_role(
     target_role TEXT)
 RETURNS VOID
 LANGUAGE plpgsql
 SET search_path = @extschema@
 AS $$
 BEGIN
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_key_provider(text, text, JSON) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider(text, text, JSON) TO %I', target_role);
 
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_key_provider_file(text, json) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_key_provider_file(text, text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_key_provider_vault_v2(text, text, text, text, text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_key_provider_vault_v2(text, JSON, JSON, JSON, JSON) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_key_provider_kmip(text, text, int, text, text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_key_provider_kmip(text, JSON, JSON, JSON, JSON) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_file(text, json) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_file(text, text) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_vault_v2(text, text, text, text, text) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_vault_v2(text, JSON, JSON, JSON, JSON) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_kmip(text, text, int, text, text) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_kmip(text, JSON, JSON, JSON, JSON) TO %I', target_role);
 
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_key_provider(text, text, JSON) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider(text, text, JSON) TO %I', target_role);
 
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_key_provider_file(text, json) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_key_provider_file(text, text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_key_provider_vault_v2(text, text, text,text,text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_key_provider_vault_v2(text, JSON, JSON,JSON,JSON) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_key_provider_kmip(text, text, int, text, text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_key_provider_kmip(text, JSON, JSON, JSON, JSON) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_file(text, json) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_file(text, text) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_vault_v2(text, text, text,text,text) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_vault_v2(text, JSON, JSON,JSON,JSON) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_kmip(text, text, int, text, text) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_kmip(text, JSON, JSON, JSON, JSON) TO %I', target_role);
 
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_delete_key_provider(text) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_delete_database_key_provider(text) TO %I', target_role);
 
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_principal_key(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_principal_key_using_database_key_provider(text, text, BOOLEAN) TO %I', target_role);
 END;
 $$;
 
@@ -623,7 +623,7 @@ LANGUAGE plpgsql
 SET search_path = @extschema@
 AS $$
 BEGIN
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_list_all_key_providers() TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_list_all_database_key_providers() TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_list_all_global_key_providers() TO %I', target_role);
 
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_principal_key_info() TO %I', target_role);
@@ -660,40 +660,40 @@ BEGIN
 
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_delete_global_key_provider(text) FROM %I', target_role);
 
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_principal_key_global_provider(text, text, BOOLEAN) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_server_principal_key_global_provider(text, text, BOOLEAN) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_default_principal_key_global_provider(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_principal_key_using_global_key_provider(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_server_principal_key_using_global_key_provider(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_default_principal_key_using_global_key_provider(text, text, BOOLEAN) FROM %I', target_role);
 END;
 $$;
 
-CREATE FUNCTION pg_tde_revoke_local_key_management_from_role(
+CREATE FUNCTION pg_tde_revoke_database_key_management_from_role(
     target_role TEXT)
 RETURNS VOID
 LANGUAGE plpgsql
 SET search_path = @extschema@
 AS $$
 BEGIN
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_key_provider(text, text, JSON) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider(text, text, JSON) FROM %I', target_role);
 
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_key_provider_file(text, json) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_key_provider_file(text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_key_provider_vault_v2(text, text, text, text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_key_provider_vault_v2(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_key_provider_kmip(text, text, int, text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_key_provider_kmip(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_file(text, json) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_file(text, text) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_vault_v2(text, text, text, text, text) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_vault_v2(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_kmip(text, text, int, text, text) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_kmip(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
 
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_key_provider(text, text, JSON) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider(text, text, JSON) FROM %I', target_role);
 
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_key_provider_file(text, json) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_key_provider_file(text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_key_provider_vault_v2(text, text, text, text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_key_provider_vault_v2(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_key_provider_kmip(text, text, int, text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_key_provider_kmip(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_file(text, json) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_file(text, text) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_vault_v2(text, text, text, text, text) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_vault_v2(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_kmip(text, text, int, text, text) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_kmip(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
 
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_delete_key_provider(text) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_delete_database_key_provider(text) FROM %I', target_role);
 
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_principal_key(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_principal_key_using_database_key_provider(text, text, BOOLEAN) FROM %I', target_role);
 END;
 $$;
 
@@ -704,7 +704,7 @@ LANGUAGE plpgsql
 SET search_path = @extschema@
 AS $$
 BEGIN
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_list_all_key_providers() FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_list_all_database_key_providers() FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_list_all_global_key_providers() FROM %I', target_role);
 
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_principal_key_info() FROM %I', target_role);
@@ -722,12 +722,12 @@ SET search_path = @extschema@
 AS $$
 BEGIN
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_grant_global_key_management_to_role(TEXT) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_grant_local_key_management_to_role(TEXT) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_grant_database_key_management_to_role(TEXT) TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_grant_grant_management_to_role(TEXT) TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_grant_key_viewer_to_role(TEXT) TO %I', target_role);
 
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_revoke_global_key_management_from_role(TEXT) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_revoke_local_key_management_from_role(TEXT) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_revoke_database_key_management_from_role(TEXT) TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_revoke_grant_management_from_role(TEXT) TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_revoke_key_viewer_from_role(TEXT) TO %I', target_role);
 END;
@@ -741,19 +741,19 @@ SET search_path = @extschema@
 AS $$
 BEGIN
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_grant_global_key_management_to_role(TEXT) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_grant_local_key_management_to_role(TEXT) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_grant_database_key_management_to_role(TEXT) FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_grant_grant_management_to_role(TEXT) FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_grant_key_viewer_to_role(TEXT) FROM %I', target_role);
 
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_revoke_global_key_management_from_role(TEXT) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_revoke_local_key_management_from_role(TEXT) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_revoke_database_key_management_from_role(TEXT) FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_revoke_grant_management_from_role(TEXT) FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_revoke_key_viewer_from_role(TEXT) FROM %I', target_role);
 END;
 $$;
 
 -- Revoking all the privileges from the public role
-SELECT pg_tde_revoke_local_key_management_from_role('public');
+SELECT pg_tde_revoke_database_key_management_from_role('public');
 SELECT pg_tde_revoke_global_key_management_from_role('public');
 SELECT pg_tde_revoke_grant_management_from_role('public');
 SELECT pg_tde_revoke_key_viewer_from_role('public');

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -487,7 +487,7 @@ RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_verify_global_principal_key()
+CREATE FUNCTION pg_tde_verify_server_principal_key()
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
@@ -629,7 +629,7 @@ BEGIN
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_principal_key_info() TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_server_principal_key_info() TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_verify_principal_key() TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_verify_global_principal_key() TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_verify_server_principal_key() TO %I', target_role);
 END;
 $$;
 
@@ -710,7 +710,7 @@ BEGIN
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_principal_key_info() FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_server_principal_key_info() FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_verify_principal_key() FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_verify_global_principal_key() FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_verify_server_principal_key() FROM %I', target_role);
 END;
 $$;
 

--- a/contrib/pg_tde/sql/access_control.sql
+++ b/contrib/pg_tde/sql/access_control.sql
@@ -5,21 +5,21 @@ CREATE USER regress_pg_tde_access_control;
 SET ROLE regress_pg_tde_access_control;
 
 -- should throw access denied
-SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key', 'file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key', 'file-vault');
 
 RESET ROLE;
 
-SELECT pg_tde_grant_local_key_management_to_role('regress_pg_tde_access_control');
+SELECT pg_tde_grant_database_key_management_to_role('regress_pg_tde_access_control');
 SELECT pg_tde_grant_key_viewer_to_role('regress_pg_tde_access_control');
 
 SET ROLE regress_pg_tde_access_control;
 
 -- should now be allowed
-SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_add_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key', 'file-vault');
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key', 'file-vault');
+SELECT * FROM pg_tde_list_all_database_key_providers();
 SELECT principal_key_name, key_provider_name, key_provider_id FROM pg_tde_principal_key_info();
 
 RESET ROLE;
@@ -29,7 +29,7 @@ SELECT pg_tde_revoke_key_viewer_from_role('regress_pg_tde_access_control');
 SET ROLE regress_pg_tde_access_control;
 
 -- verify the view access is revoked
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
 SELECT principal_key_name, key_provider_name, key_provider_id FROM pg_tde_principal_key_info();
 
 RESET ROLE;

--- a/contrib/pg_tde/sql/alter_index.sql
+++ b/contrib/pg_tde/sql/alter_index.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 SET default_table_access_method = "tde_heap";
 

--- a/contrib/pg_tde/sql/cache_alloc.sql
+++ b/contrib/pg_tde/sql/cache_alloc.sql
@@ -2,8 +2,8 @@
 
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 do $$
     DECLARE idx integer;

--- a/contrib/pg_tde/sql/change_access_method.sql
+++ b/contrib/pg_tde/sql/change_access_method.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,

--- a/contrib/pg_tde/sql/default_principal_key.sql
+++ b/contrib/pg_tde/sql/default_principal_key.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_principal_key.per');
 
-SELECT pg_tde_set_default_principal_key('default-principal-key', 'file-provider', false);
+SELECT pg_tde_set_default_principal_key_global_provider('default-principal-key', 'file-provider', false);
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-provider');
@@ -53,7 +53,7 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 
 \c :regress_database
 
-SELECT pg_tde_set_default_principal_key('new-default-principal-key', 'file-provider', false);
+SELECT pg_tde_set_default_principal_key_global_provider('new-default-principal-key', 'file-provider', false);
 
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();

--- a/contrib/pg_tde/sql/default_principal_key.sql
+++ b/contrib/pg_tde/sql/default_principal_key.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_principal_key.per');
 
-SELECT pg_tde_set_default_principal_key_global_provider('default-principal-key', 'file-provider', false);
+SELECT pg_tde_set_default_principal_key_using_global_key_provider('default-principal-key', 'file-provider', false);
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-provider');
@@ -53,7 +53,7 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 
 \c :regress_database
 
-SELECT pg_tde_set_default_principal_key_global_provider('new-default-principal-key', 'file-provider', false);
+SELECT pg_tde_set_default_principal_key_using_global_key_provider('new-default-principal-key', 'file-provider', false);
 
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();

--- a/contrib/pg_tde/sql/delete_key_provider.sql
+++ b/contrib/pg_tde/sql/delete_key_provider.sql
@@ -2,19 +2,19 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT  * FROM pg_tde_principal_key_info();
 
-SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
-SELECT * FROM pg_tde_list_all_key_providers();
-SELECT pg_tde_delete_key_provider('file-provider');
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+SELECT * FROM pg_tde_list_all_database_key_providers();
+SELECT pg_tde_delete_database_key_provider('file-provider');
+SELECT * FROM pg_tde_list_all_database_key_providers();
 
-SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
-SELECT * FROM pg_tde_list_all_key_providers();
-SELECT pg_tde_delete_key_provider('file-provider');
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+SELECT * FROM pg_tde_list_all_database_key_providers();
+SELECT pg_tde_delete_database_key_provider('file-provider');
+SELECT * FROM pg_tde_list_all_database_key_providers();
 
-SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
-SELECT * FROM pg_tde_list_all_key_providers();
-SELECT pg_tde_delete_key_provider('file-provider');
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+SELECT * FROM pg_tde_list_all_database_key_providers();
+SELECT pg_tde_delete_database_key_provider('file-provider');
+SELECT * FROM pg_tde_list_all_database_key_providers();
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/insert_update_delete.sql
+++ b/contrib/pg_tde/sql/insert_update_delete.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 CREATE TABLE albums (
     id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -44,7 +44,7 @@ SELECT id, provider_name FROM pg_tde_list_all_key_providers();
 
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 
-SELECT pg_tde_set_global_principal_key('test-db-principal-key', 'file-keyring', false);
+SELECT pg_tde_set_principal_key_global_provider('test-db-principal-key', 'file-keyring', false);
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-keyring');

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -16,14 +16,14 @@ SELECT pg_tde_verify_principal_key();
 SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');
 SELECT pg_tde_verify_principal_key();
 
-SELECT pg_tde_change_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_change_database_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
 SELECT * FROM pg_tde_list_all_database_key_providers();
 
-SELECT pg_tde_change_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_other.per');
+SELECT pg_tde_change_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_other.per');
 SELECT * FROM pg_tde_list_all_database_key_providers();
 SELECT pg_tde_verify_principal_key();
 
-SELECT pg_tde_change_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
+SELECT pg_tde_change_database_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 SELECT * FROM pg_tde_list_all_database_key_providers();
 
 SELECT pg_tde_add_global_key_provider_file('file-keyring','/tmp/pg_tde_test_keyring.per');

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -2,29 +2,29 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT  * FROM pg_tde_principal_key_info();
 
-SELECT pg_tde_add_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_add_database_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
+SELECT * FROM pg_tde_list_all_database_key_providers();
 
-SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+SELECT * FROM pg_tde_list_all_database_key_providers();
 
-SELECT pg_tde_add_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_add_database_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
+SELECT * FROM pg_tde_list_all_database_key_providers();
 
 SELECT pg_tde_verify_principal_key();
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');
 SELECT pg_tde_verify_principal_key();
 
 SELECT pg_tde_change_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
 
 SELECT pg_tde_change_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_other.per');
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
 SELECT pg_tde_verify_principal_key();
 
 SELECT pg_tde_change_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
 
 SELECT pg_tde_add_global_key_provider_file('file-keyring','/tmp/pg_tde_test_keyring.per');
 
@@ -35,16 +35,16 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 -- TODO: verify that we can also can change the type of it
 
 -- fails
-SELECT pg_tde_delete_key_provider('file-provider');
-SELECT id, provider_name FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_delete_database_key_provider('file-provider');
+SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
 
 -- works
-SELECT pg_tde_delete_key_provider('file-provider2');
-SELECT id, provider_name FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_delete_database_key_provider('file-provider2');
+SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
 
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 
-SELECT pg_tde_set_principal_key_global_provider('test-db-principal-key', 'file-keyring', false);
+SELECT pg_tde_set_principal_key_using_global_key_provider('test-db-principal-key', 'file-keyring', false);
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-keyring');

--- a/contrib/pg_tde/sql/keyprovider_dependency.sql
+++ b/contrib/pg_tde/sql/keyprovider_dependency.sql
@@ -1,11 +1,11 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_key_provider_file('mk-file','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_add_key_provider_file('free-file','/tmp/pg_tde_test_keyring_2.per');
-SELECT pg_tde_add_key_provider_vault_v2('V2-vault','vault-token','percona.com/vault-v2/percona','/mount/dev','ca-cert-auth');
+SELECT pg_tde_add_database_key_provider_file('mk-file','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('free-file','/tmp/pg_tde_test_keyring_2.per');
+SELECT pg_tde_add_database_key_provider_vault_v2('V2-vault','vault-token','percona.com/vault-v2/percona','/mount/dev','ca-cert-auth');
 
-SELECT * FROM pg_tde_list_all_key_providers();
+SELECT * FROM pg_tde_list_all_database_key_providers();
 
-SELECT pg_tde_set_principal_key('test-db-principal-key','mk-file');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','mk-file');
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/kmip_test.sql
+++ b/contrib/pg_tde/sql/kmip_test.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION pg_tde;
 
-SELECT pg_tde_add_key_provider_kmip('kmip-prov','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_key_jane_doe.pem');
-SELECT pg_tde_set_principal_key('kmip-principal-key','kmip-prov');
+SELECT pg_tde_add_database_key_provider_kmip('kmip-prov','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_key_jane_doe.pem');
+SELECT pg_tde_set_principal_key_using_database_key_provider('kmip-principal-key','kmip-prov');
 
 CREATE TABLE test_enc(
 	  id SERIAL,

--- a/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
+++ b/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
@@ -2,8 +2,8 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT * FROM pg_tde_principal_key_info();
 
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 CREATE TABLE test_enc(
 	  id SERIAL,

--- a/contrib/pg_tde/sql/recreate_storage.sql
+++ b/contrib/pg_tde/sql/recreate_storage.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 SET default_table_access_method = "tde_heap";
 

--- a/contrib/pg_tde/sql/relocate.sql
+++ b/contrib/pg_tde/sql/relocate.sql
@@ -6,7 +6,7 @@ CREATE SCHEMA other;
 
 CREATE EXTENSION pg_tde SCHEMA other;
 
-SELECT other.pg_tde_add_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT other.pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
 
 SELECT other.pg_tde_grant_key_viewer_to_role('public');
 

--- a/contrib/pg_tde/sql/subtransaction.sql
+++ b/contrib/pg_tde/sql/subtransaction.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 
 BEGIN;                      -- Nesting level 1

--- a/contrib/pg_tde/sql/tablespace.sql
+++ b/contrib/pg_tde/sql/tablespace.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 CREATE TABLE test(num1 bigint, num2 double precision, t text) USING tde_heap;
 INSERT INTO test(num1, num2, t)

--- a/contrib/pg_tde/sql/toast_decrypt.sql
+++ b/contrib/pg_tde/sql/toast_decrypt.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 CREATE TABLE src (f1 TEXT STORAGE EXTERNAL) USING tde_heap;
 INSERT INTO src VALUES(repeat('abcdeF',1000));

--- a/contrib/pg_tde/sql/vault_v2_test.sql
+++ b/contrib/pg_tde/sql/vault_v2_test.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 \getenv root_token ROOT_TOKEN
 
-SELECT pg_tde_add_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
 -- FAILS
 SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-incorrect');
 
@@ -12,7 +12,7 @@ CREATE TABLE test_enc(
 	  PRIMARY KEY (id)
 	) USING tde_heap;
 
-SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
 SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-v2');
 
 CREATE TABLE test_enc(

--- a/contrib/pg_tde/sql/vault_v2_test.sql
+++ b/contrib/pg_tde/sql/vault_v2_test.sql
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
 -- FAILS
-SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-incorrect');
+SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-incorrect');
 
 CREATE TABLE test_enc(
 	  id SERIAL,
@@ -13,7 +13,7 @@ CREATE TABLE test_enc(
 	) USING tde_heap;
 
 SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
-SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');
+SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-v2');
 
 CREATE TABLE test_enc(
 	  id SERIAL,

--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -80,22 +80,6 @@ static void *EncryptionCryptCtx = NULL;
 
 static int	XLOGChooseNumBuffers(void);
 
-/*  This can't be a GUC check hook, because that would run too soon during startup */
-void
-TDEXlogCheckSane(void)
-{
-	if (EncryptXLog)
-	{
-		InternalKey *key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL, true);
-
-		if (key == NULL)
-		{
-			ereport(ERROR,
-					(errmsg("WAL encryption can only be enabled with a properly configured principal key. Disable pg_tde.wal_encrypt and create one using pg_tde_set_server_principal_key_using_global_key_provider() or pg_tde_set_principal_key_using_global_key_provider() before enabling it.")));
-		}
-	}
-}
-
 static int
 XLOGChooseNumBuffers(void)
 {

--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -91,7 +91,7 @@ TDEXlogCheckSane(void)
 		if (key == NULL)
 		{
 			ereport(ERROR,
-					(errmsg("WAL encryption can only be enabled with a properly configured principal key. Disable pg_tde.wal_encrypt and create one using pg_tde_set_server_principal_key_global_provider() or pg_tde_set_principal_key_global_provider() before enabling it.")));
+					(errmsg("WAL encryption can only be enabled with a properly configured principal key. Disable pg_tde.wal_encrypt and create one using pg_tde_set_server_principal_key_global_provider() or pg_tde_set_principal_key_using_global_key_provider() before enabling it.")));
 		}
 	}
 }

--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -80,6 +80,22 @@ static void *EncryptionCryptCtx = NULL;
 
 static int	XLOGChooseNumBuffers(void);
 
+/*  This can't be a GUC check hook, because that would run too soon during startup */
+void
+TDEXlogCheckSane(void)
+{
+	if (EncryptXLog)
+	{
+		InternalKey *key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL, true);
+
+		if (key == NULL)
+		{
+			ereport(ERROR,
+					(errmsg("WAL encryption can only be enabled with a properly configured principal key. Disable pg_tde.wal_encrypt and create one using pg_tde_set_server_principal_key_global_provider() or pg_tde_set_principal_key_global_provider() before enabling it.")));
+		}
+	}
+}
+
 static int
 XLOGChooseNumBuffers(void)
 {

--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -91,7 +91,7 @@ TDEXlogCheckSane(void)
 		if (key == NULL)
 		{
 			ereport(ERROR,
-					(errmsg("WAL encryption can only be enabled with a properly configured principal key. Disable pg_tde.wal_encrypt and create one using pg_tde_set_server_principal_key_global_provider() or pg_tde_set_principal_key_using_global_key_provider() before enabling it.")));
+					(errmsg("WAL encryption can only be enabled with a properly configured principal key. Disable pg_tde.wal_encrypt and create one using pg_tde_set_server_principal_key_using_global_key_provider() or pg_tde_set_principal_key_using_global_key_provider() before enabling it.")));
 		}
 	}
 }

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -921,7 +921,7 @@ GetKeyProviderByName(const char *provider_name, Oid dbOid)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("key provider \"%s\" does not exists", provider_name),
-				 errhint("Use pg_tde_add_key_provider interface to create the key provider")));
+				 errhint("Create the key provider")));
 	}
 	return keyring;
 }

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -76,22 +76,22 @@ static void simple_list_free(SimplePtrList *list);
 
 static List *scan_key_provider_file(ProviderScanType scanType, void *scanKey, Oid dbOid);
 
-PG_FUNCTION_INFO_V1(pg_tde_add_key_provider);
-Datum		pg_tde_add_key_provider(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(pg_tde_add_database_key_provider);
+Datum		pg_tde_add_database_key_provider(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(pg_tde_add_global_key_provider);
 Datum		pg_tde_add_global_key_provider(PG_FUNCTION_ARGS);
 
-PG_FUNCTION_INFO_V1(pg_tde_change_key_provider);
-Datum		pg_tde_change_key_provider(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(pg_tde_change_database_key_provider);
+Datum		pg_tde_change_database_key_provider(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(pg_tde_change_global_key_provider);
 Datum		pg_tde_change_global_key_provider(PG_FUNCTION_ARGS);
 
 static Datum pg_tde_list_all_key_providers_internal(const char *fname, bool global, PG_FUNCTION_ARGS);
 
-PG_FUNCTION_INFO_V1(pg_tde_list_all_key_providers);
-Datum		pg_tde_list_all_key_providers(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(pg_tde_list_all_database_key_providers);
+Datum		pg_tde_list_all_database_key_providers(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(pg_tde_list_all_global_key_providers);
 Datum		pg_tde_list_all_global_key_providers(PG_FUNCTION_ARGS);
@@ -206,7 +206,7 @@ cleanup_key_provider_info(Oid databaseId)
 }
 
 Datum
-pg_tde_change_key_provider(PG_FUNCTION_ARGS)
+pg_tde_change_database_key_provider(PG_FUNCTION_ARGS)
 {
 	return pg_tde_change_key_provider_internal(fcinfo, MyDatabaseId);
 }
@@ -256,7 +256,7 @@ pg_tde_change_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 }
 
 Datum
-pg_tde_add_key_provider(PG_FUNCTION_ARGS)
+pg_tde_add_database_key_provider(PG_FUNCTION_ARGS)
 {
 	return pg_tde_add_key_provider_internal(fcinfo, MyDatabaseId);
 }
@@ -301,15 +301,15 @@ pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 }
 
 Datum
-pg_tde_list_all_key_providers(PG_FUNCTION_ARGS)
+pg_tde_list_all_database_key_providers(PG_FUNCTION_ARGS)
 {
-	return pg_tde_list_all_key_providers_internal("pg_tde_list_all_key_providers", false, fcinfo);
+	return pg_tde_list_all_key_providers_internal("pg_tde_list_all_database_key_providers_database", false, fcinfo);
 }
 
 Datum
 pg_tde_list_all_global_key_providers(PG_FUNCTION_ARGS)
 {
-	return pg_tde_list_all_key_providers_internal("pg_tde_list_all_key_providers_global", true, fcinfo);
+	return pg_tde_list_all_key_providers_internal("pg_tde_list_all_database_key_providers_global", true, fcinfo);
 }
 
 static Datum

--- a/contrib/pg_tde/src/catalog/tde_keyring_parse_opts.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring_parse_opts.c
@@ -86,8 +86,8 @@ static const char *JK_FIELD_NAMES[JK_FIELDS_TOTAL] = {
 	[JK_FIELD_PATH] = "path",
 
 	/*
-	 * These values should match pg_tde_add_key_provider_vault_v2 and
-	 * pg_tde_add_key_provider_file SQL interfaces
+	 * These values should match pg_tde_add_database_key_provider_vault_v2 and
+	 * pg_tde_add_database_key_provider_file SQL interfaces
 	 */
 	[JF_FILE_PATH] = "path",
 	[JK_VAULT_TOKEN] = "token",

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -110,16 +110,16 @@ static bool pg_tde_verify_principal_key_internal(Oid databaseOid);
 
 static Datum pg_tde_delete_key_provider_internal(PG_FUNCTION_ARGS, int is_global);
 
-PG_FUNCTION_INFO_V1(pg_tde_set_default_principal_key);
-Datum		pg_tde_set_default_principal_key(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(pg_tde_set_default_principal_key_global_provider);
+Datum		pg_tde_set_default_principal_key_global_provider(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(pg_tde_set_principal_key);
 Datum		pg_tde_set_principal_key(PG_FUNCTION_ARGS);
 
-PG_FUNCTION_INFO_V1(pg_tde_set_global_principal_key);
+PG_FUNCTION_INFO_V1(pg_tde_set_principal_key_global_provider);
 Datum		pg_tde_set_principal_key(PG_FUNCTION_ARGS);
 
-PG_FUNCTION_INFO_V1(pg_tde_set_server_principal_key);
+PG_FUNCTION_INFO_V1(pg_tde_set_server_principal_key_global_provider);
 Datum		pg_tde_set_principal_key(PG_FUNCTION_ARGS);
 
 enum global_status
@@ -485,7 +485,7 @@ clear_principal_key_cache(Oid databaseId)
  */
 
 Datum
-pg_tde_set_default_principal_key(PG_FUNCTION_ARGS)
+pg_tde_set_default_principal_key_global_provider(PG_FUNCTION_ARGS)
 {
 	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
@@ -509,7 +509,7 @@ pg_tde_set_principal_key(PG_FUNCTION_ARGS)
 }
 
 Datum
-pg_tde_set_global_principal_key(PG_FUNCTION_ARGS)
+pg_tde_set_principal_key_global_provider(PG_FUNCTION_ARGS)
 {
 	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
@@ -521,7 +521,7 @@ pg_tde_set_global_principal_key(PG_FUNCTION_ARGS)
 }
 
 Datum
-pg_tde_set_server_principal_key(PG_FUNCTION_ARGS)
+pg_tde_set_server_principal_key_global_provider(PG_FUNCTION_ARGS)
 {
 	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
@@ -607,9 +607,9 @@ pg_tde_principal_key_info(PG_FUNCTION_ARGS)
 	return pg_tde_get_key_info(fcinfo, MyDatabaseId);
 }
 
-PG_FUNCTION_INFO_V1(pg_tde_global_principal_key_info);
+PG_FUNCTION_INFO_V1(pg_tde_server_principal_key_info);
 Datum
-pg_tde_global_principal_key_info(PG_FUNCTION_ARGS)
+pg_tde_server_principal_key_info(PG_FUNCTION_ARGS)
 {
 	return pg_tde_get_key_info(fcinfo, GLOBAL_DATA_TDE_OID);
 }

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -53,7 +53,7 @@ PG_FUNCTION_INFO_V1(pg_tde_delete_key_provider);
 PG_FUNCTION_INFO_V1(pg_tde_delete_global_key_provider);
 
 PG_FUNCTION_INFO_V1(pg_tde_verify_principal_key);
-PG_FUNCTION_INFO_V1(pg_tde_verify_global_principal_key);
+PG_FUNCTION_INFO_V1(pg_tde_verify_server_principal_key);
 
 typedef struct TdePrincipalKeySharedState
 {
@@ -621,7 +621,7 @@ pg_tde_verify_principal_key(PG_FUNCTION_ARGS)
 }
 
 Datum
-pg_tde_verify_global_principal_key(PG_FUNCTION_ARGS)
+pg_tde_verify_server_principal_key(PG_FUNCTION_ARGS)
 {
 	return pg_tde_verify_principal_key_internal(GLOBAL_DATA_TDE_OID);
 }

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -49,7 +49,7 @@
 
 #ifndef FRONTEND
 
-PG_FUNCTION_INFO_V1(pg_tde_delete_key_provider);
+PG_FUNCTION_INFO_V1(pg_tde_delete_database_key_provider);
 PG_FUNCTION_INFO_V1(pg_tde_delete_global_key_provider);
 
 PG_FUNCTION_INFO_V1(pg_tde_verify_principal_key);
@@ -110,17 +110,17 @@ static bool pg_tde_verify_principal_key_internal(Oid databaseOid);
 
 static Datum pg_tde_delete_key_provider_internal(PG_FUNCTION_ARGS, int is_global);
 
-PG_FUNCTION_INFO_V1(pg_tde_set_default_principal_key_global_provider);
-Datum		pg_tde_set_default_principal_key_global_provider(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(pg_tde_set_default_principal_key_using_global_key_provider);
+Datum		pg_tde_set_default_principal_key_using_global_key_provider(PG_FUNCTION_ARGS);
 
-PG_FUNCTION_INFO_V1(pg_tde_set_principal_key);
-Datum		pg_tde_set_principal_key(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(pg_tde_set_principal_key_using_database_key_provider);
+Datum		pg_tde_set_principal_key_using_database_key_provider(PG_FUNCTION_ARGS);
 
-PG_FUNCTION_INFO_V1(pg_tde_set_principal_key_global_provider);
-Datum		pg_tde_set_principal_key(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(pg_tde_set_principal_key_using_global_key_provider);
+Datum		pg_tde_set_principal_key_using_global_key_provider(PG_FUNCTION_ARGS);
 
-PG_FUNCTION_INFO_V1(pg_tde_set_server_principal_key_global_provider);
-Datum		pg_tde_set_principal_key(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(pg_tde_set_server_principal_key_using_global_key_provider);
+Datum		pg_tde_set_server_principal_key_using_global_key_provider(PG_FUNCTION_ARGS);
 
 enum global_status
 {
@@ -485,7 +485,7 @@ clear_principal_key_cache(Oid databaseId)
  */
 
 Datum
-pg_tde_set_default_principal_key_global_provider(PG_FUNCTION_ARGS)
+pg_tde_set_default_principal_key_using_global_key_provider(PG_FUNCTION_ARGS)
 {
 	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
@@ -497,7 +497,7 @@ pg_tde_set_default_principal_key_global_provider(PG_FUNCTION_ARGS)
 }
 
 Datum
-pg_tde_set_principal_key(PG_FUNCTION_ARGS)
+pg_tde_set_principal_key_using_database_key_provider(PG_FUNCTION_ARGS)
 {
 	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
@@ -509,7 +509,7 @@ pg_tde_set_principal_key(PG_FUNCTION_ARGS)
 }
 
 Datum
-pg_tde_set_principal_key_global_provider(PG_FUNCTION_ARGS)
+pg_tde_set_principal_key_using_global_key_provider(PG_FUNCTION_ARGS)
 {
 	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
@@ -521,7 +521,7 @@ pg_tde_set_principal_key_global_provider(PG_FUNCTION_ARGS)
 }
 
 Datum
-pg_tde_set_server_principal_key_global_provider(PG_FUNCTION_ARGS)
+pg_tde_set_server_principal_key_using_global_key_provider(PG_FUNCTION_ARGS)
 {
 	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
@@ -1030,7 +1030,7 @@ pg_tde_update_global_principal_key_everywhere(TDEPrincipalKey *oldKey, TDEPrinci
 }
 
 Datum
-pg_tde_delete_key_provider(PG_FUNCTION_ARGS)
+pg_tde_delete_database_key_provider(PG_FUNCTION_ARGS)
 {
 	return pg_tde_delete_key_provider_internal(fcinfo, 0);
 }

--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -45,8 +45,8 @@ $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -79,7 +79,7 @@ $rt_value = $node->start();
 
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
@@ -99,14 +99,14 @@ $rt_value = $node->start();
 
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 #Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_global_principal_key('rotated-principal-key', 'file-3', false);", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_global_provider('rotated-principal-key', 'file-3', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -118,7 +118,7 @@ $rt_value = $node->start();
 
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
@@ -128,7 +128,7 @@ PGTDE::append_to_file($stdout);
 # And maybe debug tools to show what's in a file keyring?
 
 #Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_global_principal_key('rotated-principal-keyX', 'file-2', false);", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_global_provider('rotated-principal-keyX', 'file-2', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -140,7 +140,7 @@ $rt_value = $node->start();
 
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
@@ -156,11 +156,11 @@ $rt_value = $node->stop();
 $rt_value = $node->start();
 
 # But now can't be changed to another global provider
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_set_global_principal_key('rotated-principal-keyX2', 'file-2', false);", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_set_principal_key_global_provider('rotated-principal-keyX2', 'file-2', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 
@@ -168,7 +168,7 @@ $stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('rotated
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -42,19 +42,19 @@ $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2g.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-3','/tmp/pg_tde_test_keyring_3.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_key_providers();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
@@ -67,7 +67,7 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;'
 PGTDE::append_to_file($stdout);
 
 #rotate key
-$stdout = $node->psql('postgres', "SELECT pg_tde_set_principal_key('rotated-principal-key1');", extra_params => ['-a']);
+$stdout = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('rotated-principal-key1');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -87,7 +87,7 @@ PGTDE::append_to_file($stdout);
 
 
 #Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('rotated-principal-key2','file-2');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -106,7 +106,7 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;'
 PGTDE::append_to_file($stdout);
 
 #Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_global_provider('rotated-principal-key', 'file-3', false);", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_global_key_provider('rotated-principal-key', 'file-3', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -128,7 +128,7 @@ PGTDE::append_to_file($stdout);
 # And maybe debug tools to show what's in a file keyring?
 
 #Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_global_provider('rotated-principal-keyX', 'file-2', false);", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_global_key_provider('rotated-principal-keyX', 'file-2', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -156,7 +156,7 @@ $rt_value = $node->stop();
 $rt_value = $node->start();
 
 # But now can't be changed to another global provider
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_set_principal_key_global_provider('rotated-principal-keyX2', 'file-2', false);", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_global_key_provider('rotated-principal-keyX2', 'file-2', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -164,7 +164,7 @@ PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('rotated-principal-key2','file-2');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -70,8 +70,8 @@ my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NO
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_file('file-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello' ));", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello' ));", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/004_file_config.pl
+++ b/contrib/pg_tde/t/004_file_config.pl
@@ -34,8 +34,8 @@ my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NO
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/005_multiple_extensions.pl
+++ b/contrib/pg_tde/t/005_multiple_extensions.pl
@@ -86,8 +86,8 @@ PGTDE::append_to_debug_file($stdout);
 ok($cmdret == 0, "CREATE postgis_tiger_geocoder EXTENSION");
 PGTDE::append_to_debug_file($stdout);
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -78,8 +78,8 @@ my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NO
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url' ), to_json('secret'::text), NULL);", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','vault-provider');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url' ), to_json('secret'::text), NULL);", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','vault-provider');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -49,8 +49,8 @@ $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');", extra_params => ['-a']);
 
 
 

--- a/contrib/pg_tde/t/008_key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/008_key_rotate_tablespace.pl
@@ -37,8 +37,8 @@ CREATE DATABASE tbc TABLESPACE = test_tblspace;
 $stdout = $node->safe_psql('tbc',
 	q{
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,
@@ -57,7 +57,7 @@ SELECT * FROM country_table;
 PGTDE::append_to_file($stdout);
 
 
-$cmdret = $node->psql('tbc', "SELECT pg_tde_set_principal_key('new-k', 'file-vault');", extra_params => ['-a']);
+$cmdret = $node->psql('tbc', "SELECT pg_tde_set_principal_key_using_database_key_provider('new-k', 'file-vault');", extra_params => ['-a']);
 ok($cmdret == 0, "ROTATE KEY");
 PGTDE::append_to_file($stdout);
 

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -33,7 +33,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key('global-db-principal-key', 'file-keyring-010');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('global-db-principal-key', 'file-keyring-010');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;', extra_params => ['-a']);

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -33,7 +33,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('global-db-principal-key', 'file-keyring-010');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('server-principal-key', 'file-keyring-010');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;', extra_params => ['-a']);

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -33,7 +33,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('server-principal-key', 'file-keyring-010');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_using_global_key_provider('server-principal-key', 'file-keyring-010');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;', extra_params => ['-a']);

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -37,7 +37,7 @@ PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_key_providers();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-key', 'file-vault');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -59,7 +59,7 @@ PGTDE::append_to_file("-- mv /tmp/change_key_provider_1.per /tmp/change_key_prov
 move('/tmp/change_key_provider_1.per', '/tmp/change_key_provider_2.per');
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_key_providers();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
@@ -85,7 +85,7 @@ PGTDE::append_to_file($stdout);
 # Change provider and do not move file
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_key_providers();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 (undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -35,11 +35,11 @@ my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NO
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('test-key', 'file-vault');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-key', 'file-vault');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
@@ -139,9 +139,9 @@ ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
 # Change provider and generate a new principal key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-$stdout = $node->psql('postgres', "SELECT pg_tde_set_principal_key('test-key', 'file-vault');", extra_params => ['-a']);
+$stdout = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-key', 'file-vault');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -57,7 +57,7 @@ PGTDE::append_to_file($stdout);
 # Change provider and move file
 PGTDE::append_to_file("-- mv /tmp/change_key_provider_1.per /tmp/change_key_provider_2.per");
 move('/tmp/change_key_provider_1.per', '/tmp/change_key_provider_2.per');
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -83,7 +83,7 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', ex
 PGTDE::append_to_file($stdout);
 
 # Change provider and do not move file
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -156,7 +156,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 # Restart the server
@@ -178,7 +178,7 @@ PGTDE::append_to_file($stderr);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 # Verify

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -1,17 +1,17 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 -- server restart
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 1
-SELECT pg_tde_add_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');
+SELECT pg_tde_add_database_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');
 2
 SELECT pg_tde_add_global_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2g.per');
 -1
 SELECT pg_tde_add_global_key_provider_file('file-3','/tmp/pg_tde_test_keyring_3.per');
 -2
-SELECT pg_tde_list_all_key_providers();
+SELECT pg_tde_list_all_database_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring.per""}")
 (2,file-2,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring_2.per""}")
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5),(6);
@@ -31,7 +31,7 @@ HINT:  Use set_principal_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
-SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');
+SELECT pg_tde_set_principal_key_using_database_key_provider('rotated-principal-key2','file-2');
 
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
@@ -45,7 +45,7 @@ HINT:  Use set_principal_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
-SELECT pg_tde_set_principal_key_global_provider('rotated-principal-key', 'file-3', false);
+SELECT pg_tde_set_principal_key_using_global_key_provider('rotated-principal-key', 'file-3', false);
 
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
@@ -59,7 +59,7 @@ HINT:  Use set_principal_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
-SELECT pg_tde_set_principal_key_global_provider('rotated-principal-keyX', 'file-2', false);
+SELECT pg_tde_set_principal_key_using_global_key_provider('rotated-principal-keyX', 'file-2', false);
 
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
@@ -81,7 +81,7 @@ SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_princi
 SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
-SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');
+SELECT pg_tde_set_principal_key_using_database_key_provider('rotated-principal-key2','file-2');
 
 SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
 2|file-2|rotated-principal-key2

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -25,7 +25,7 @@ SELECT * FROM test_enc ORDER BY id ASC;
 -- server restart
 SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
 1|file-vault|rotated-principal-key1
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
@@ -39,13 +39,13 @@ SELECT * FROM test_enc ORDER BY id ASC;
 -- server restart
 SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
 2|file-2|rotated-principal-key2
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
-SELECT pg_tde_set_global_principal_key('rotated-principal-key', 'file-3', false);
+SELECT pg_tde_set_principal_key_global_provider('rotated-principal-key', 'file-3', false);
 
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
@@ -53,13 +53,13 @@ SELECT * FROM test_enc ORDER BY id ASC;
 -- server restart
 SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
 -2|file-3|rotated-principal-key
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
-SELECT pg_tde_set_global_principal_key('rotated-principal-keyX', 'file-2', false);
+SELECT pg_tde_set_principal_key_global_provider('rotated-principal-keyX', 'file-2', false);
 
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
@@ -67,7 +67,7 @@ SELECT * FROM test_enc ORDER BY id ASC;
 -- server restart
 SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
 -1|file-2|rotated-principal-keyX
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
@@ -78,14 +78,14 @@ ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;
 psql:<stdin>:1: ERROR:  Usage of global key providers is disabled. Enable it with pg_tde.inherit_global_providers = ON
 SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
 -1|file-2|rotated-principal-keyX
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
 SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');
 
 SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
 2|file-2|rotated-principal-key2
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();
+SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
 DROP TABLE test_enc;

--- a/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
+++ b/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 1
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,
@@ -17,9 +17,9 @@ SELECT * FROM country_table;
 2|UK|Europe
 3|USA|North America
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 1
-SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,

--- a/contrib/pg_tde/t/expected/009_wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/009_wal_encrypt.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');
 -1
-SELECT pg_tde_set_server_principal_key('global-db-principal-key', 'file-keyring-010');
+SELECT pg_tde_set_server_principal_key_global_provider('global-db-principal-key', 'file-keyring-010');
 
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 -- server restart with wal encryption

--- a/contrib/pg_tde/t/expected/009_wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/009_wal_encrypt.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');
 -1
-SELECT pg_tde_set_server_principal_key_global_provider('server-principal-key', 'file-keyring-010');
+SELECT pg_tde_set_server_principal_key_using_global_key_provider('server-principal-key', 'file-keyring-010');
 
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 -- server restart with wal encryption

--- a/contrib/pg_tde/t/expected/009_wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/009_wal_encrypt.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');
 -1
-SELECT pg_tde_set_server_principal_key_global_provider('global-db-principal-key', 'file-keyring-010');
+SELECT pg_tde_set_server_principal_key_global_provider('server-principal-key', 'file-keyring-010');
 
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 -- server restart with wal encryption

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -1,9 +1,9 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');
 1
 SELECT pg_tde_list_all_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_1.per""}")
-SELECT pg_tde_set_principal_key('test-key', 'file-vault');
+SELECT pg_tde_set_principal_key_using_database_key_provider('test-key', 'file-vault');
 
 CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5), (6);
@@ -64,7 +64,7 @@ SELECT * FROM test_enc ORDER BY id;
 DROP EXTENSION pg_tde CASCADE;
 psql:<stdin>:1: NOTICE:  drop cascades to table test_enc
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');
 1
 0
 CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -15,7 +15,7 @@ SELECT * FROM test_enc ORDER BY id;
 1|5
 2|6
 -- mv /tmp/change_key_provider_1.per /tmp/change_key_provider_2.per
-SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');
+SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');
 1
 SELECT pg_tde_list_all_database_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_2.per""}")
@@ -34,7 +34,7 @@ t
 SELECT * FROM test_enc ORDER BY id;
 1|5
 2|6
-SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');
+SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');
 1
 SELECT pg_tde_list_all_database_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_3.per""}")
@@ -76,7 +76,7 @@ t
 SELECT * FROM test_enc ORDER BY id;
 1|5
 2|6
-SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');
+SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');
 1
 -- server restart
 SELECT pg_tde_verify_principal_key();
@@ -87,7 +87,7 @@ SELECT * FROM test_enc ORDER BY id;
 psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, incorrect principal key or corrupted key file
 CREATE TABLE test_enc2 (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
 psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, incorrect principal key or corrupted key file
-SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');
+SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');
 1
 SELECT pg_tde_verify_principal_key();
 

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');
 1
-SELECT pg_tde_list_all_key_providers();
+SELECT pg_tde_list_all_database_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_1.per""}")
 SELECT pg_tde_set_principal_key_using_database_key_provider('test-key', 'file-vault');
 
@@ -17,7 +17,7 @@ SELECT * FROM test_enc ORDER BY id;
 -- mv /tmp/change_key_provider_1.per /tmp/change_key_provider_2.per
 SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');
 1
-SELECT pg_tde_list_all_key_providers();
+SELECT pg_tde_list_all_database_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_2.per""}")
 SELECT pg_tde_verify_principal_key();
 
@@ -36,7 +36,7 @@ SELECT * FROM test_enc ORDER BY id;
 2|6
 SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');
 1
-SELECT pg_tde_list_all_key_providers();
+SELECT pg_tde_list_all_database_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_3.per""}")
 SELECT pg_tde_verify_principal_key();
 psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1

--- a/src/bin/pg_waldump/t/003_basic_encrypted.pl
+++ b/src/bin/pg_waldump/t/003_basic_encrypted.pl
@@ -28,7 +28,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');");;
-$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key('global-db-principal-key', 'file-keyring-wal');");
+$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('global-db-principal-key', 'file-keyring-wal');");
 
 $node->append_conf(
 	'postgresql.conf', q{

--- a/src/bin/pg_waldump/t/003_basic_encrypted.pl
+++ b/src/bin/pg_waldump/t/003_basic_encrypted.pl
@@ -28,7 +28,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');");;
-$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('global-db-principal-key', 'file-keyring-wal');");
+$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('server-principal-key', 'file-keyring-wal');");
 
 $node->append_conf(
 	'postgresql.conf', q{

--- a/src/bin/pg_waldump/t/003_basic_encrypted.pl
+++ b/src/bin/pg_waldump/t/003_basic_encrypted.pl
@@ -28,7 +28,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');");;
-$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('server-principal-key', 'file-keyring-wal');");
+$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_using_global_key_provider('server-principal-key', 'file-keyring-wal');");
 
 $node->append_conf(
 	'postgresql.conf', q{

--- a/src/bin/pg_waldump/t/004_save_fullpage_encrypted.pl
+++ b/src/bin/pg_waldump/t/004_save_fullpage_encrypted.pl
@@ -42,7 +42,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');");;
-$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('global-db-principal-key', 'file-keyring-wal');");
+$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('server-principal-key', 'file-keyring-wal');");
 
 $node->append_conf(
 	'postgresql.conf', q{

--- a/src/bin/pg_waldump/t/004_save_fullpage_encrypted.pl
+++ b/src/bin/pg_waldump/t/004_save_fullpage_encrypted.pl
@@ -42,7 +42,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');");;
-$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key('global-db-principal-key', 'file-keyring-wal');");
+$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('global-db-principal-key', 'file-keyring-wal');");
 
 $node->append_conf(
 	'postgresql.conf', q{

--- a/src/bin/pg_waldump/t/004_save_fullpage_encrypted.pl
+++ b/src/bin/pg_waldump/t/004_save_fullpage_encrypted.pl
@@ -42,7 +42,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');");;
-$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_global_provider('server-principal-key', 'file-keyring-wal');");
+$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_using_global_key_provider('server-principal-key', 'file-keyring-wal');");
 
 $node->append_conf(
 	'postgresql.conf', q{


### PR DESCRIPTION
PG-1457

### Description
<!--- Describe your changes in detail -->

1. All key provider management functions have scope in the name (`database` or `global`)
2. Key management function have key provider in the name (`using_database_key_provider` or `using_global_key_provider`)
3. Other scope dependent functions have scope in the name

### Links
<!--- Please provide links to any related PRs in this or other repositories --->

