### PR TITLE
PG-1450: Ignore empty names when looking for providers to modify

### DIFF
--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -17,9 +17,8 @@ ERROR:  Can't delete a provider which is currently in use
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  id | provider_name 
 ----+---------------
- -2 | file-keyring2
  -3 | file-provider
-(2 rows)
+(1 row)
 
 -- Should fail: no principal key for the database yet
 SELECT  key_provider_id, key_provider_name, principal_key_name

--- a/contrib/pg_tde/expected/delete_key_provider.out
+++ b/contrib/pg_tde/expected/delete_key_provider.out
@@ -1,0 +1,74 @@
+CREATE EXTENSION IF NOT EXISTS pg_tde;
+SELECT  * FROM pg_tde_principal_key_info();
+ERROR:  Principal key does not exists for the database
+HINT:  Use set_principal_key interface to set the principal key
+SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_key_provider_file 
+------------------------------
+                            1
+(1 row)
+
+SELECT * FROM pg_tde_list_all_key_providers();
+ id | provider_name | provider_type |                          options                           
+----+---------------+---------------+------------------------------------------------------------
+  1 | file-provider | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
+(1 row)
+
+SELECT pg_tde_delete_key_provider('file-provider');
+ pg_tde_delete_key_provider 
+----------------------------
+ 
+(1 row)
+
+SELECT * FROM pg_tde_list_all_key_providers();
+ id | provider_name | provider_type | options 
+----+---------------+---------------+---------
+(0 rows)
+
+SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_key_provider_file 
+------------------------------
+                            2
+(1 row)
+
+SELECT * FROM pg_tde_list_all_key_providers();
+ id | provider_name | provider_type |                          options                           
+----+---------------+---------------+------------------------------------------------------------
+  2 | file-provider | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
+(1 row)
+
+SELECT pg_tde_delete_key_provider('file-provider');
+ pg_tde_delete_key_provider 
+----------------------------
+ 
+(1 row)
+
+SELECT * FROM pg_tde_list_all_key_providers();
+ id | provider_name | provider_type | options 
+----+---------------+---------------+---------
+(0 rows)
+
+SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_key_provider_file 
+------------------------------
+                            3
+(1 row)
+
+SELECT * FROM pg_tde_list_all_key_providers();
+ id | provider_name | provider_type |                          options                           
+----+---------------+---------------+------------------------------------------------------------
+  3 | file-provider | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
+(1 row)
+
+SELECT pg_tde_delete_key_provider('file-provider');
+ pg_tde_delete_key_provider 
+----------------------------
+ 
+(1 row)
+
+SELECT * FROM pg_tde_list_all_key_providers();
+ id | provider_name | provider_type | options 
+----+---------------+---------------+---------
+(0 rows)
+
+DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -159,7 +159,6 @@ SELECT pg_tde_delete_global_key_provider('file-keyring2');
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  id | provider_name 
 ----+---------------
- -2 | file-keyring2
-(1 row)
+(0 rows)
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/meson.build
+++ b/contrib/pg_tde/meson.build
@@ -134,6 +134,7 @@ if get_variable('percona_ext', false)
       'test_issue_153_fix',
       'multi_insert',
       'keyprovider_dependency',
+      'delete_key_provider',
       'trigger_on_view',
       'change_access_method',
       'insert_update_delete',

--- a/contrib/pg_tde/sql/delete_key_provider.sql
+++ b/contrib/pg_tde/sql/delete_key_provider.sql
@@ -1,0 +1,20 @@
+CREATE EXTENSION IF NOT EXISTS pg_tde;
+
+SELECT  * FROM pg_tde_principal_key_info();
+
+SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+SELECT * FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_delete_key_provider('file-provider');
+SELECT * FROM pg_tde_list_all_key_providers();
+
+SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+SELECT * FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_delete_key_provider('file-provider');
+SELECT * FROM pg_tde_list_all_key_providers();
+
+SELECT pg_tde_add_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
+SELECT * FROM pg_tde_list_all_key_providers();
+SELECT pg_tde_delete_key_provider('file-provider');
+SELECT * FROM pg_tde_list_all_key_providers();
+
+DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -444,7 +444,7 @@ write_key_provider_info(KeyringProvideRecord *provider, Oid database_id,
 				seek_pos = before_pos;
 				break;
 			}
-			if (strcmp(existing_provider.provider_name, provider->provider_name) == 0)
+			if (strlen(existing_provider.provider_name) > 0 && strcmp(existing_provider.provider_name, provider->provider_name) == 0)
 			{
 				if (error_if_exists)
 				{


### PR DESCRIPTION
Modification looks are either based on provider id or name. Delete functionality uses id, and passes an empty name. This failed if an earlier record was already deleted, as the lookup found the record with the empty name instead of the correct id.

As empty names can only happen with deleted records, and we never want to delete rerord twice, the function now ignores those.
