### PR TITLE
Fix WAL encryption buffer size

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -43,6 +43,14 @@ static const XLogSmgr tde_xlog_smgr = {
 static void SetXLogPageIVPrefix(TimeLineID tli, XLogRecPtr lsn, char *iv_prefix);
 
 #ifndef FRONTEND
+
+/*
+ * Must be the same as in replication/walsender.c
+ *
+ * This is used to calculate the encryption buffer size.
+ */
+#define MAX_SEND_SIZE (XLOG_BLCKSZ * 16)
+
 static ssize_t TDEXLogWriteEncryptedPages(int fd, const void *buf, size_t count,
 										  off_t offset, TimeLineID tli,
 										  XLogSegNo segno);
@@ -104,7 +112,7 @@ TDEXLogEncryptBuffSize(void)
 	int			xbuffers;
 
 	xbuffers = (XLOGbuffers == -1) ? XLOGChooseNumBuffers() : XLOGbuffers;
-	return (Size) XLOG_BLCKSZ * xbuffers;
+	return Max(MAX_SEND_SIZE, mul_size(XLOG_BLCKSZ, xbuffers));
 }
 
 Size
@@ -112,10 +120,11 @@ TDEXLogEncryptStateSize(void)
 {
 	Size		sz;
 
-	sz = TYPEALIGN(PG_IO_ALIGN_SIZE, TDEXLogEncryptBuffSize());
-	sz = add_size(sz, sizeof(EncryptionStateData));
+	sz = sizeof(EncryptionStateData);
+	sz = add_size(sz, TDEXLogEncryptBuffSize());
+	sz = add_size(sz, PG_IO_ALIGN_SIZE);
 
-	return MAXALIGN(sz);
+	return sz;
 }
 
 /*
@@ -143,8 +152,13 @@ TDEXLogShmemInit(void)
 						TDEXLogEncryptStateSize(),
 						&foundBuf);
 
-	allocptr = ((char *) EncryptionState) + TYPEALIGN(PG_IO_ALIGN_SIZE, sizeof(EncryptionStateData));
+	memset(EncryptionState, 0, sizeof(EncryptionStateData));
+
+	allocptr = ((char *) EncryptionState) + sizeof(EncryptionStateData);
+	allocptr = (char *) TYPEALIGN(PG_IO_ALIGN_SIZE, allocptr);
 	EncryptionState->segBuf = allocptr;
+
+	Assert((char *) EncryptionState + TDEXLogEncryptStateSize() >= (char *) EncryptionState->segBuf + TDEXLogEncryptBuffSize());
 
 	pg_atomic_init_u64(&EncryptionState->enc_key_lsn, 0);
 
@@ -161,6 +175,8 @@ TDEXLogWriteEncryptedPages(int fd, const void *buf, size_t count, off_t offset,
 	char		iv_prefix[16] = {0,};
 	InternalKey *key = &EncryptionKey;
 	char	   *enc_buff = EncryptionState->segBuf;
+
+	Assert(count <= TDEXLogEncryptBuffSize());
 
 #ifdef TDE_XLOG_DEBUG
 	elog(DEBUG1, "write encrypted WAL, size: %lu, offset: %ld [%lX], seg: %X/%X, key_start_lsn: %X/%X",


### PR DESCRIPTION
1. We used to base the enc buffer size on `wal_buffers`. But walsender has its own constant send size, which might be bigger than wal_buffers and lead to an overflow and the corruption of neighboring objects in the shared memory. This commit ensures the enc buffer is big enough for wal_buffers and walsender.

2. It also fixes the enc buffer alignment.

For PG-1397, PG-1037