### PR TITLE
Make `pg_tde_is_encrypted()` a strict function

### DIFF
--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -1,5 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT  * FROM pg_tde_principal_key_info();
+SELECT * FROM pg_tde_principal_key_info();
 ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
 SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
@@ -72,8 +72,14 @@ SELECT pg_tde_is_encrypted('test_norm_pkey');
  f
 (1 row)
 
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT pg_tde_is_encrypted(NULL);
+ pg_tde_is_encrypted 
+---------------------
+ 
+(1 row)
+
+SELECT key_provider_id, key_provider_name, principal_key_name
+    FROM pg_tde_principal_key_info();
  key_provider_id | key_provider_name |  principal_key_name   
 -----------------+-------------------+-----------------------
                1 | file-vault        | test-db-principal-key

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -457,6 +457,7 @@ LANGUAGE plpgsql;
 
 CREATE FUNCTION pg_tde_is_encrypted(relation regclass)
 RETURNS boolean
+STRICT
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 

--- a/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
+++ b/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT  * FROM pg_tde_principal_key_info();
+SELECT * FROM pg_tde_principal_key_info();
 
 SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
@@ -29,8 +29,10 @@ SELECT pg_tde_is_encrypted('test_norm_id_seq');
 SELECT pg_tde_is_encrypted('test_enc_pkey');
 SELECT pg_tde_is_encrypted('test_norm_pkey');
 
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT pg_tde_is_encrypted(NULL);
+
+SELECT key_provider_id, key_provider_name, principal_key_name
+    FROM pg_tde_principal_key_info();
 
 DROP TABLE test_enc;
 DROP TABLE test_norm;

--- a/contrib/pg_tde/src/common/pg_tde_utils.c
+++ b/contrib/pg_tde/src/common/pg_tde_utils.c
@@ -33,19 +33,9 @@ PG_FUNCTION_INFO_V1(pg_tde_is_encrypted);
 Datum
 pg_tde_is_encrypted(PG_FUNCTION_ARGS)
 {
-	Oid			tableOid = InvalidOid;
+	Oid			tableOid = PG_GETARG_OID(0);
 	Oid			dbOid = MyDatabaseId;
 	TDEPrincipalKey *principalKey = NULL;
-
-	if (!PG_ARGISNULL(0))
-	{
-		tableOid = PG_GETARG_OID(0);
-	}
-
-	if (tableOid == InvalidOid)
-	{
-		PG_RETURN_BOOL(false);
-	}
 
 	LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
 	principalKey = GetPrincipalKey(dbOid, LW_SHARED);


### PR DESCRIPTION
This changes the behavior from returning false on `NULL`  input to returning `NULL` but it is a usability improvement since the behavior is more in line with other functions in PostgreSQL.

```
# SELECT pg_tde_is_encrypted(NULL);
 pg_relation_size 
------------------
                 
(1 row)
```

```
# SELECT pg_relation_size(NULL);
 pg_relation_size 
------------------
                 
(1 row)
```