### PR TITLE
Remove leftovers from the old WAL encryption

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -77,7 +77,7 @@ TDEXlogCheckSane(void)
 {
 	if (EncryptXLog)
 	{
-		InternalKey *key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL, true);
+		InternalKey *key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL);
 
 		if (key == NULL)
 		{

--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -71,22 +71,6 @@ static InternalKey EncryptionKey =
 
 static int	XLOGChooseNumBuffers(void);
 
-/*  This can't be a GUC check hook, because that would run too soon during startup */
-void
-TDEXlogCheckSane(void)
-{
-	if (EncryptXLog)
-	{
-		InternalKey *key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID), TDE_KEY_TYPE_GLOBAL);
-
-		if (key == NULL)
-		{
-			ereport(ERROR,
-					(errmsg("WAL encryption can only be enabled with a properly configured principal key. Disable pg_tde.wal_encrypt and create one using pg_tde_set_server_principal_key() or pg_tde_set_global_principal_key() before enabling it.")));
-		}
-	}
-}
-
 static int
 XLOGChooseNumBuffers(void)
 {

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -98,9 +98,8 @@ pg_tde_set_db_file_paths(Oid dbOid, char *map_path, char *keydata_path)
 		join_path_components(keydata_path, pg_tde_get_tde_data_dir(), psprintf(PG_TDE_KEYDATA_FILENAME, dbOid));
 }
 
-extern InternalKey *GetRelationKey(RelFileLocator rel, uint32 entry_type, bool no_map_ok);
+extern InternalKey *GetRelationKey(RelFileLocator rel, uint32 entry_type);
 extern InternalKey *GetSMGRRelationKey(RelFileLocatorBackend rel);
-extern InternalKey *GetTdeGlobaleRelationKey(RelFileLocator rel);
 
 extern void pg_tde_delete_tde_files(Oid dbOid);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -98,7 +98,6 @@ pg_tde_set_db_file_paths(Oid dbOid, char *map_path, char *keydata_path)
 		join_path_components(keydata_path, pg_tde_get_tde_data_dir(), psprintf(PG_TDE_KEYDATA_FILENAME, dbOid));
 }
 
-extern InternalKey *GetRelationKey(RelFileLocator rel, uint32 entry_type);
 extern InternalKey *GetSMGRRelationKey(RelFileLocatorBackend rel);
 
 extern void pg_tde_delete_tde_files(Oid dbOid);

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
@@ -15,8 +15,5 @@
 extern Size TDEXLogEncryptStateSize(void);
 extern void TDEXLogShmemInit(void);
 extern void TDEXLogSmgrInit(void);
-#ifndef FRONTEND
-extern void TDEXlogCheckSane(void);
-#endif
 
 #endif							/* PG_TDE_XLOGENCRYPT_H */

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -93,8 +93,6 @@ tde_shmem_startup(void)
 
 	TDEXLogShmemInit();
 	TDEXLogSmgrInit();
-
-	TDEXlogCheckSane();
 }
 
 void


### PR DESCRIPTION
This removes two thins:

1. Entirely dead code
2. A sanity check, `TDEXlogCheckSane()`, which no longer makes sense.

@dAdAbird Am I right in that the sanity check no longer makes sense? Since we generate WAL keys automatically we should get the proper error form that code path and not ever fail here. Do we need to add an assert instead?