### PR TITLE
Remove Github pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,0 @@
-PG-0
-
-### Description
-<!--- Describe your changes in detail -->
-
-
-### Links
-<!--- Please provide links to any related PRs in this or other repositories --->
-


### PR DESCRIPTION
The current template does not seem useful either to us employees or to potential third party contributors.