### PR TITLE
Make sure we abort on failed read of previous WAL key

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -940,7 +940,7 @@ pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path)
 		if (pg_pread(fd, &prev_key, INTERNAL_KEY_DAT_LEN, prev_key_pos) != INTERNAL_KEY_DAT_LEN)
 		{
 			LWLockRelease(lock_pk);
-			ereport(WARNING,
+			ereport(ERROR,
 					(errcode_for_file_access(),
 					 errmsg("could not read previous WAL key: %m")));
 		}


### PR DESCRIPTION
It makes no sense to continue after we failed to read from the file, especially since prev_key is used despite it containing junk now.

@dAdAbird Did I miss something? This seems like a bug.