### PR TITLE
PG-1474: Properly set the key name in vault/kmip getters

### DIFF
--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -29,6 +29,25 @@ SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');
  t
 (1 row)
 
+SELECT pg_tde_set_principal_key('vault-v2-principal-key-2','vault-v2');
+ pg_tde_set_principal_key 
+--------------------------
+ t
+(1 row)
+
+SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');
+ pg_tde_set_principal_key 
+--------------------------
+ t
+(1 row)
+
+SELECT  key_provider_id, key_provider_name, principal_key_name
+		FROM pg_tde_principal_key_info();
+ key_provider_id | key_provider_name |   principal_key_name   
+-----------------+-------------------+------------------------
+               2 | vault-v2          | vault-v2-principal-key
+(1 row)
+
 CREATE TABLE test_enc(
 	  id SERIAL,
 	  k INTEGER DEFAULT '0' NOT NULL,

--- a/contrib/pg_tde/expected/vault_v2_test_basic.out
+++ b/contrib/pg_tde/expected/vault_v2_test_basic.out
@@ -30,21 +30,40 @@ SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');
  t
 (1 row)
 
+SELECT pg_tde_set_principal_key('vault-v2-principal-key-2','vault-v2');
+ pg_tde_set_principal_key 
+--------------------------
+ t
+(1 row)
+
+SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');
+ pg_tde_set_principal_key 
+--------------------------
+ t
+(1 row)
+
+SELECT  key_provider_id, key_provider_name, principal_key_name
+		FROM pg_tde_principal_key_info();
+ key_provider_id | key_provider_name |   principal_key_name   
+-----------------+-------------------+------------------------
+               2 | vault-v2          | vault-v2-principal-key
+(1 row)
+
 CREATE TABLE test_enc(
 	  id SERIAL,
 	  k INTEGER DEFAULT '0' NOT NULL,
 	  PRIMARY KEY (id)
 	) USING :tde_am;
-psql:sql/vault_v2_test.inc:22: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
-psql:sql/vault_v2_test.inc:22: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/vault_v2_test.inc:29: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/vault_v2_test.inc:29: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 INSERT INTO test_enc (k) VALUES (1);
-psql:sql/vault_v2_test.inc:24: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/vault_v2_test.inc:31: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 INSERT INTO test_enc (k) VALUES (2);
-psql:sql/vault_v2_test.inc:25: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/vault_v2_test.inc:32: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 INSERT INTO test_enc (k) VALUES (3);
-psql:sql/vault_v2_test.inc:26: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/vault_v2_test.inc:33: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
 SELECT * from test_enc;
-psql:sql/vault_v2_test.inc:28: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
+psql:sql/vault_v2_test.inc:35: WARNING:  tde_heap_basic is deprecated, and will be removed in the next release. Please migrate tables to tde_heap.
  id | k 
 ----+---
   1 | 1

--- a/contrib/pg_tde/sql/vault_v2_test.inc
+++ b/contrib/pg_tde/sql/vault_v2_test.inc
@@ -15,6 +15,13 @@ CREATE TABLE test_enc(
 SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
 SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');
 
+SELECT pg_tde_set_principal_key('vault-v2-principal-key-2','vault-v2');
+
+SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');
+
+SELECT  key_provider_id, key_provider_name, principal_key_name
+		FROM pg_tde_principal_key_info();
+
 CREATE TABLE test_enc(
 	  id SERIAL,
 	  k INTEGER DEFAULT '0' NOT NULL,

--- a/contrib/pg_tde/src/keyring/keyring_kmip.c
+++ b/contrib/pg_tde/src/keyring/keyring_kmip.c
@@ -264,6 +264,8 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, bool throw_error,
 			return NULL;
 		}
 
+		memset(key->name, 0, sizeof(key->name));
+		memcpy(key->name, key_name, strnlen(key_name, sizeof(key->name) - 1));
 		memcpy(key->data.data, keyp, key->data.len);
 		free(keyp);
 	}

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -283,6 +283,8 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, bool throw_error,
 #endif
 
 	key = palloc(sizeof(KeyInfo));
+	memset(key->name, 0, sizeof(key->name));
+	memcpy(key->name, key_name, strnlen(key_name, sizeof(key->name) - 1));
 	key->data.len = pg_b64_decode(responseKey, strlen(responseKey), (char *) key->data.data, MAX_KEY_DATA_SIZE);
 
 	if (key->data.len > MAX_KEY_DATA_SIZE)


### PR DESCRIPTION
Vault and KMIP providers forgot to set principal key name in the getter which returned the key from the server, resulting in a corrupted key reference when the key already existed on the remote server.