### PR TITLE
Make tde_setup.sql friendlier to run manually

### DIFF
--- a/ci_scripts/tde_setup.sql
+++ b/ci_scripts/tde_setup.sql
@@ -1,4 +1,4 @@
 CREATE SCHEMA IF NOT EXISTS tde;
 CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
-SELECT pg_tde_add_key_provider_file('reg_file-vault', '/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key('test-db-principal-key', 'reg_file-vault');
+SELECT tde.pg_tde_add_key_provider_file('reg_file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT tde.pg_tde_set_principal_key('test-db-principal-key', 'reg_file-vault');


### PR DESCRIPTION
If we schema qualify the functions we call users do not always need to set the search path.