### PR TITLE
Refactor `GetPrincipalKeyNoDefault()`

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -258,7 +258,7 @@ pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocat
 	InternalKey *enc_rel_key_data;
 	TDEPrincipalKey *principal_key;
 
-	principal_key = get_principal_key_from_keyring(newrlocator->dbOid, false);
+	principal_key = get_principal_key_from_keyring(newrlocator->dbOid);
 	if (principal_key == NULL)
 	{
 		ereport(ERROR,

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -63,6 +63,6 @@ extern bool update_principal_key_info(TDEPrincipalKeyInfo *principal_key_info);
 
 extern bool xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec);
 
-extern TDEPrincipalKey *get_principal_key_from_keyring(Oid dbOid, bool pushToCache);
+extern TDEPrincipalKey *get_principal_key_from_keyring(Oid dbOid);
 
 #endif							/* PG_TDE_PRINCIPAL_KEY_H */


### PR DESCRIPTION
By moving all caching logic into one place we simplify the code. This way `get_principal_key_from_keyring()` is the uncached version and `GetPrincipalKeyNoDefault()` the cached version of the same function.

We might want to improve naming in the future but this is good enough for now.