### PR TITLE
PG-1416 Throw error when no principal key for encrypted table

### DIFF
--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -34,6 +34,8 @@ SELECT * FROM pg_tde_list_all_key_providers();
   2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
+SELECT pg_tde_verify_principal_key();
+ERROR:  principal key not configured for current database
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');
  pg_tde_set_principal_key 
 --------------------------
@@ -70,7 +72,7 @@ SELECT * FROM pg_tde_list_all_key_providers();
 (2 rows)
 
 SELECT pg_tde_verify_principal_key();
-ERROR:  Failed to retrieve key from keyring
+ERROR:  failed to retrieve principal key test-db-principal-key from keyring with ID 1
 SELECT pg_tde_change_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
 SELECT * FROM pg_tde_list_all_key_providers();

--- a/contrib/pg_tde/expected/key_provider_1.out
+++ b/contrib/pg_tde/expected/key_provider_1.out
@@ -34,6 +34,8 @@ SELECT * FROM pg_tde_list_all_key_providers();
   2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
+SELECT pg_tde_verify_principal_key();
+ERROR:  principal key not configured for current database
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');
  pg_tde_set_principal_key 
 --------------------------
@@ -70,7 +72,7 @@ SELECT * FROM pg_tde_list_all_key_providers();
 (2 rows)
 
 SELECT pg_tde_verify_principal_key();
-ERROR:  Failed to retrieve key from keyring
+ERROR:  failed to retrieve principal key test-db-principal-key from keyring with ID 1
 SELECT pg_tde_change_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
 SELECT * FROM pg_tde_list_all_key_providers();

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -14,7 +14,8 @@ CREATE TABLE test_enc(
 	  k INTEGER DEFAULT '0' NOT NULL,
 	  PRIMARY KEY (id)
 	) USING tde_heap;
-ERROR:  failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.
+ERROR:  principal key not configured
+HINT:  create one using pg_tde_set_principal_key before using encrypted tables
 SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
  pg_tde_add_key_provider_vault_v2 
 ----------------------------------

--- a/contrib/pg_tde/meson.build
+++ b/contrib/pg_tde/meson.build
@@ -101,6 +101,7 @@ tap_tests = [
       't/007_tde_heap.pl',
       't/008_key_rotate_tablespace.pl',
       't/009_wal_encrypt.pl',
+      't/010_change_key_provider.pl',
 ]
 
 tests += {

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -11,6 +11,8 @@ SELECT * FROM pg_tde_list_all_key_providers();
 SELECT pg_tde_add_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
 SELECT * FROM pg_tde_list_all_key_providers();
 
+SELECT pg_tde_verify_principal_key();
+
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');
 SELECT pg_tde_verify_principal_key();
 

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -178,7 +178,8 @@ pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type
 	if (principal_key == NULL)
 	{
 		ereport(ERROR,
-				(errmsg("failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.")));
+				(errmsg("principal key not configured"),
+				 errhint("create one using pg_tde_set_principal_key before using encrypted tables")));
 	}
 
 	/* Encrypt the key */
@@ -259,7 +260,8 @@ pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocat
 	if (principal_key == NULL)
 	{
 		ereport(ERROR,
-				(errmsg("failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted WAL.")));
+				(errmsg("principal key not configured"),
+				 errhint("create one using pg_tde_set_principal_key before using encrypted WAL")));
 	}
 
 	/* TODO: no need in generating key if TDE_KEY_TYPE_WAL_UNENCRYPTED */
@@ -1009,7 +1011,8 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type)
 	principal_key = GetPrincipalKey(rlocator->dbOid, LW_SHARED);
 	if (principal_key == NULL)
 		ereport(ERROR,
-				(errmsg("failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.")));
+				(errmsg("principal key not configured"),
+				 errhint("create one using pg_tde_set_principal_key before using encrypted tables")));
 
 	enc_rel_key_data = pg_tde_read_keydata(db_keydata_path, key_index, principal_key);
 	LWLockRelease(lock_pk);

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -73,7 +73,8 @@ checkEncryptionClause(const char *accessMethod)
 		if (principal_key == NULL)
 		{
 			ereport(ERROR,
-					(errmsg("failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.")));
+					(errmsg("principal key not configured"),
+					 errhint("create one using pg_tde_set_principal_key before using encrypted tables")));
 
 		}
 	}

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -47,15 +47,14 @@ tde_smgr_get_key(SMgrRelation reln, RelFileLocator *old_locator, bool can_create
 		return NULL;
 	}
 
-	event = GetCurrentTdeCreateEvent();
-
 	/* see if we have a key for the relation, and return if yes */
 	key = GetSMGRRelationKey(reln->smgr_rlocator);
-
 	if (key != NULL)
 	{
 		return key;
 	}
+
+	event = GetCurrentTdeCreateEvent();
 
 	/*
 	 * Can be many things, such as: CREATE TABLE ALTER TABLE SET ACCESS METHOD
@@ -72,9 +71,9 @@ tde_smgr_get_key(SMgrRelation reln, RelFileLocator *old_locator, bool can_create
 	if (old_locator != NULL && can_create)
 	{
 		RelFileLocatorBackend rlocator = {.locator = *old_locator,.backend = reln->smgr_rlocator.backend};
-		InternalKey *key2 = GetSMGRRelationKey(rlocator);
+		InternalKey *oldkey = GetSMGRRelationKey(rlocator);
 
-		if (key2 != NULL)
+		if (oldkey != NULL)
 		{
 			/* create a new key for the new file */
 			return pg_tde_create_smgr_key(&reln->smgr_rlocator);

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -40,19 +40,10 @@ tde_smgr_get_key(SMgrRelation reln, RelFileLocator *old_locator, bool can_create
 {
 	TdeCreateEvent *event;
 	InternalKey *key;
-	TDEPrincipalKey *pk;
 
 	if (IsCatalogRelationOid(reln->smgr_rlocator.locator.relNumber))
 	{
 		/* do not try to encrypt/decrypt catalog tables */
-		return NULL;
-	}
-
-	LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
-	pk = GetPrincipalKey(reln->smgr_rlocator.locator.dbOid, LW_SHARED);
-	LWLockRelease(tde_lwlock_enc_keys());
-	if (pk == NULL)
-	{
 		return NULL;
 	}
 

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -1,0 +1,144 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use File::Basename;
+use File::Compare;
+use File::Copy;
+use Test::More;
+use lib 't';
+use pgtde;
+
+# Get file name and CREATE out file name and dirs WHERE requried
+PGTDE::setup_files_dir(basename($0));
+
+# CREATE new PostgreSQL node and do initdb
+my $node = PGTDE->pgtde_init_pg();
+my $pgdata = $node->data_dir;
+
+# UPDATE postgresql.conf to include/load pg_tde library
+open my $conf, '>>', "$pgdata/postgresql.conf";
+print $conf "shared_preload_libraries = 'pg_tde'\n";
+close $conf;
+
+unlink('/tmp/change_key_provider_1.per');
+unlink('/tmp/change_key_provider_2.per');
+unlink('/tmp/change_key_provider_3.per');
+
+# Start server
+my $rt_value = $node->start;
+ok($rt_value == 1, "Start Server");
+
+# CREATE EXTENSION IF NOT EXISTS and change out file permissions
+my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
+ok($cmdret == 0, "CREATE PGTDE EXTENSION");
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_key_providers();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key('test-key', 'file-vault');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc (k) VALUES (5), (6);', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# Change provider and move file
+PGTDE::append_to_file("-- mv /tmp/change_key_provider_1.per /tmp/change_key_provider_2.per");
+move('/tmp/change_key_provider_1.per', '/tmp/change_key_provider_2.per');
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_key_providers();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# Restart the server
+PGTDE::append_to_file("-- server restart");
+$rt_value = $node->stop();
+$rt_value = $node->start();
+
+# Verify
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# Change provider and do not move file
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_key_providers();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+PGTDE::append_to_file($stderr);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# Restart the server
+PGTDE::append_to_file("-- server restart");
+$rt_value = $node->stop();
+$rt_value = $node->start();
+
+# Verify
+(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+PGTDE::append_to_file($stderr);
+(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+PGTDE::append_to_file($stderr);
+(undef, $stdout, $stderr) = $node->psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+PGTDE::append_to_file($stderr);
+
+PGTDE::append_to_file("-- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_3.per");
+move('/tmp/change_key_provider_2.per', '/tmp/change_key_provider_3.per');
+
+# Restart the server
+PGTDE::append_to_file("-- server restart");
+$rt_value = $node->stop();
+$rt_value = $node->start();
+
+# Verify
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# DROP EXTENSION
+(undef, $stdout, $stderr) = $node->psql('postgres', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+PGTDE::append_to_file($stderr);
+# Stop the server
+$node->stop();
+
+# compare the expected and out file
+my $compare = PGTDE->compare_results();
+
+# Test/check if expected and result/out file match. If Yes, test passes.
+is($compare, 0, "Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
+
+# Done testing for this testcase file.
+done_testing();

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -1,0 +1,65 @@
+CREATE EXTENSION IF NOT EXISTS pg_tde;
+SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');
+1
+SELECT pg_tde_list_all_key_providers();
+(1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_1.per""}")
+SELECT pg_tde_set_principal_key('test-key', 'file-vault');
+t
+CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc (k) VALUES (5), (6);
+SELECT pg_tde_verify_principal_key();
+
+SELECT pg_tde_is_encrypted('test_enc');
+t
+SELECT * FROM test_enc ORDER BY id;
+1|5
+2|6
+-- mv /tmp/change_key_provider_1.per /tmp/change_key_provider_2.per
+SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');
+1
+SELECT pg_tde_list_all_key_providers();
+(1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_2.per""}")
+SELECT pg_tde_verify_principal_key();
+
+SELECT pg_tde_is_encrypted('test_enc');
+t
+SELECT * FROM test_enc ORDER BY id;
+1|5
+2|6
+-- server restart
+SELECT pg_tde_verify_principal_key();
+
+SELECT pg_tde_is_encrypted('test_enc');
+t
+SELECT * FROM test_enc ORDER BY id;
+1|5
+2|6
+SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');
+1
+SELECT pg_tde_list_all_key_providers();
+(1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_3.per""}")
+SELECT pg_tde_verify_principal_key();
+psql:<stdin>:1: ERROR:  Failed to retrieve key from keyring
+SELECT pg_tde_is_encrypted('test_enc');
+t
+SELECT * FROM test_enc ORDER BY id;
+1|5
+2|6
+-- server restart
+SELECT pg_tde_verify_principal_key();
+psql:<stdin>:1: ERROR:  Failed to retrieve key from keyring
+SELECT pg_tde_is_encrypted('test_enc');
+psql:<stdin>:1: ERROR:  failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.
+SELECT * FROM test_enc ORDER BY id;
+psql:<stdin>:1: ERROR:  failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.
+-- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_3.per
+-- server restart
+SELECT pg_tde_verify_principal_key();
+
+SELECT pg_tde_is_encrypted('test_enc');
+t
+SELECT * FROM test_enc ORDER BY id;
+1|5
+2|6
+DROP EXTENSION pg_tde CASCADE;
+psql:<stdin>:1: NOTICE:  drop cascades to table test_enc

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -39,7 +39,7 @@ SELECT pg_tde_change_key_provider_file('file-vault', '/tmp/change_key_provider_3
 SELECT pg_tde_list_all_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_3.per""}")
 SELECT pg_tde_verify_principal_key();
-psql:<stdin>:1: ERROR:  Failed to retrieve key from keyring
+psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
 SELECT pg_tde_is_encrypted('test_enc');
 t
 SELECT * FROM test_enc ORDER BY id;
@@ -47,11 +47,11 @@ SELECT * FROM test_enc ORDER BY id;
 2|6
 -- server restart
 SELECT pg_tde_verify_principal_key();
-psql:<stdin>:1: ERROR:  Failed to retrieve key from keyring
+psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
 SELECT pg_tde_is_encrypted('test_enc');
-psql:<stdin>:1: ERROR:  failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.
+psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
 SELECT * FROM test_enc ORDER BY id;
-psql:<stdin>:1: ERROR:  failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.
+psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
 -- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_3.per
 -- server restart
 SELECT pg_tde_verify_principal_key();


### PR DESCRIPTION
By first looking up the principal key and then the relation key we hid
    errors when we have lost the principal key but some relations are still
    encrypted. Which could for example lead to trying to read an encrypted
    table as it was unecnrypted causing errors like the following:
    
    ERROR:  invalid page in block 0 of relation base/5/16448
    
This does not solve the much scarier issue when we get another principal
    key back from the key server but we at least get better error messages
    for this common case.
