### PR TITLE
PG-1479,PG-1480: fix incorrect parameter order in default key rotation

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -1026,7 +1026,7 @@ pg_tde_rotate_default_key_for_database(TDEPrincipalKey *oldKey, TDEPrincipalKey 
 	newKey->keyInfo.databaseId = oldKey->keyInfo.databaseId;
 
 	/* key rotation */
-	is_rotated = pg_tde_perform_rotate_key(newKey, oldKey);
+	is_rotated = pg_tde_perform_rotate_key(oldKey, newKey);
 
 	if (is_rotated && (!TDEisInGlobalSpace(newKey->keyInfo.databaseId)))
 	{


### PR DESCRIPTION
The new and old principal keys were switched for the rotate function, and as we do not have principal key validation for tdemap data, the function doesn't notice this.

The problem also isn't visible until a server restart / new connection because of internal key caching, which means the SQL tests also missed to detect this.