### PR TITLE
Remove unnecessary cruft from header files

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -17,6 +17,7 @@
 #include "pg_tde_guc.h"
 #include "access/xlog.h"
 #include "access/xlog_internal.h"
+#include "access/xlog_smgr.h"
 #include "access/xloginsert.h"
 #include "storage/bufmgr.h"
 #include "storage/shmem.h"

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -50,6 +50,10 @@ typedef enum ProviderScanType
 
 #define PG_TDE_KEYRING_FILENAME "pg_tde_%d_keyring"
 
+#define FILE_KEYRING_TYPE "file"
+#define VAULTV2_KEYRING_TYPE "vault-v2"
+#define KMIP_KEYRING_TYPE "kmip"
+
 static FileKeyring *load_file_keyring_provider_options(char *keyring_options);
 static GenericKeyring *load_keyring_provider_options(ProviderType provider_type, char *keyring_options);
 static VaultV2Keyring *load_vaultV2_keyring_provider_options(char *keyring_options);

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -28,6 +28,7 @@
 #include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "catalog/pg_database.h"
+#include "keyring/keyring_api.h"
 
 #include "access/pg_tde_tdemap.h"
 #include "catalog/tde_global_space.h"
@@ -36,7 +37,9 @@
 #include "access/table.h"
 #include "common/pg_tde_shmem.h"
 #include "funcapi.h"
+#include "lib/dshash.h"
 #include "storage/lwlock.h"
+#include "storage/shmem.h"
 #else
 #include "pg_tde_fe.h"
 #endif

--- a/contrib/pg_tde/src/common/pg_tde_shmem.c
+++ b/contrib/pg_tde/src/common/pg_tde_shmem.c
@@ -12,8 +12,10 @@
 #include "postgres.h"
 #include "storage/ipc.h"
 #include "common/pg_tde_shmem.h"
+#include "lib/dshash.h"
 #include "nodes/pg_list.h"
 #include "storage/lwlock.h"
+#include "storage/shmem.h"
 
 typedef struct TdeSharedState
 {

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -9,10 +9,7 @@
 #define PG_TDE_MAP_H
 
 #include "access/xlog_internal.h"
-#include "port.h"
 #include "storage/relfilelocator.h"
-
-#include "pg_tde.h"
 #include "catalog/tde_principal_key.h"
 #include "common/pg_tde_utils.h"
 

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
@@ -10,7 +10,6 @@
 #define PG_TDE_XLOGENCRYPT_H
 
 #include "postgres.h"
-#include "access/xlog_smgr.h"
 
 extern Size TDEXLogEncryptStateSize(void);
 extern void TDEXLogShmemInit(void);

--- a/contrib/pg_tde/src/include/catalog/keyring_min.h
+++ b/contrib/pg_tde/src/include/catalog/keyring_min.h
@@ -2,15 +2,12 @@
 #ifndef KEYRING_MIN_H_
 #define KEYRING_MIN_H_
 
-#include "pg_config_manual.h"
-
 /* This is a minimal header that doesn't depend on postgres headers to avoid a type conflict with libkmip */
-
-typedef unsigned int Oid;
 
 #define MAX_PROVIDER_NAME_LEN 128	/* pg_tde_key_provider's provider_name
 									 * size */
 #define MAX_KEYRING_OPTION_LEN 1024
+
 typedef enum ProviderType
 {
 	UNKNOWN_KEY_PROVIDER,
@@ -60,14 +57,6 @@ typedef struct TDEKeyringRoutine
 	KeyInfo    *(*keyring_get_key) (GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *returnCode);
 	void		(*keyring_store_key) (GenericKeyring *keyring, KeyInfo *key);
 } TDEKeyringRoutine;
-
-/*
- * Keyring type name must be in sync with catalog table
- * defination in pg_tde--1.0 SQL
- */
-#define FILE_KEYRING_TYPE "file"
-#define VAULTV2_KEYRING_TYPE "vault-v2"
-#define KMIP_KEYRING_TYPE "kmip"
 
 typedef struct FileKeyring
 {

--- a/contrib/pg_tde/src/include/catalog/tde_keyring.h
+++ b/contrib/pg_tde/src/include/catalog/tde_keyring.h
@@ -11,7 +11,6 @@
 #define TDE_KEYRING_H
 
 #include "postgres.h"
-#include "nodes/pg_list.h"
 #include "catalog/keyring_min.h"
 
 /* This record goes into key provider info file */
@@ -22,6 +21,7 @@ typedef struct KeyringProvideRecord
 	char		options[MAX_KEYRING_OPTION_LEN];
 	ProviderType provider_type;
 } KeyringProvideRecord;
+
 typedef struct KeyringProviderXLRecord
 {
 	Oid			database_id;
@@ -43,4 +43,5 @@ extern uint32 redo_key_provider_info(KeyringProviderXLRecord *xlrec);
 
 extern bool ParseKeyringJSONOptions(ProviderType provider_type, void *out_opts,
 									char *in_buf, int buf_len);
+
 #endif							/* TDE_KEYRING_H */

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -13,8 +13,6 @@
 
 #include "postgres.h"
 #include "catalog/tde_keyring.h"
-#include "keyring/keyring_api.h"
-#include "nodes/pg_list.h"
 #ifndef FRONTEND
 #include "storage/lwlock.h"
 #endif

--- a/contrib/pg_tde/src/include/common/pg_tde_shmem.h
+++ b/contrib/pg_tde/src/include/common/pg_tde_shmem.h
@@ -9,9 +9,6 @@
 #define PG_TDE_SHMEM_H
 
 #include "postgres.h"
-#include "storage/shmem.h"
-#include "storage/lwlock.h"
-#include "lib/dshash.h"
 #include "utils/dsa.h"
 
 #define TDE_TRANCHE_NAME "pg_tde_tranche"

--- a/contrib/pg_tde/src/include/common/pg_tde_utils.h
+++ b/contrib/pg_tde/src/include/common/pg_tde_utils.h
@@ -19,4 +19,5 @@ extern int	get_tde_tables_count(void);
 
 extern void pg_tde_set_data_dir(const char *dir);
 extern char *pg_tde_get_tde_data_dir(void);
+
 #endif							/* PG_TDE_UTILS_H */

--- a/contrib/pg_tde/src/include/encryption/enc_tde.h
+++ b/contrib/pg_tde/src/include/encryption/enc_tde.h
@@ -10,12 +10,7 @@
 #ifndef ENC_TDE_H
 #define ENC_TDE_H
 
-#include "utils/rel.h"
-#include "storage/bufpage.h"
-#include "executor/tuptable.h"
-#include "executor/tuptable.h"
 #include "access/pg_tde_tdemap.h"
-#include "keyring/keyring_api.h"
 
 extern void pg_tde_crypt(const char *iv_prefix, uint32 start_offset, const char *data, uint32 data_len, char *out, InternalKey *key, const char *context);
 

--- a/contrib/pg_tde/src/include/keyring/keyring_api.h
+++ b/contrib/pg_tde/src/include/keyring/keyring_api.h
@@ -9,7 +9,6 @@
 #ifndef KEYRING_API_H
 #define KEYRING_API_H
 
-#include "catalog/tde_keyring.h"
 #include "catalog/keyring_min.h"
 
 extern void RegisterKeyProvider(const TDEKeyringRoutine *routine, ProviderType type);

--- a/src/bin/pg_checksums/pg_checksums.c
+++ b/src/bin/pg_checksums/pg_checksums.c
@@ -34,6 +34,7 @@
 #include "storage/checksum_impl.h"
 
 #ifdef PERCONA_EXT
+#include "pg_tde.h"
 #include "access/pg_tde_fe_init.h"
 #include "access/pg_tde_tdemap.h"
 #endif

--- a/src/bin/pg_waldump/pg_waldump.c
+++ b/src/bin/pg_waldump/pg_waldump.c
@@ -35,6 +35,7 @@
 #ifdef PERCONA_EXT
 #include "access/pg_tde_fe_init.h"
 #include "access/pg_tde_xlog_encrypt.h"
+#include "access/xlog_smgr.h"
 #include "catalog/tde_global_space.h"
 #endif
 


### PR DESCRIPTION
Some includes should be in .c files while some were not nedded at all. On top of that we move some define into the right .c file and remove an unused typedef.