### PR TITLE
Do not have any code after `ereport(ERROR)` ore release locks before it

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -179,8 +179,6 @@ pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type
 	{
 		ereport(ERROR,
 				(errmsg("failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.")));
-
-		return NULL;
 	}
 
 	/* Encrypt the key */
@@ -262,8 +260,6 @@ pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocat
 	{
 		ereport(ERROR,
 				(errmsg("failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted WAL.")));
-
-		return;
 	}
 
 	/* TODO: no need in generating key if TDE_KEY_TYPE_WAL_UNENCRYPTED */
@@ -1071,7 +1067,6 @@ pg_tde_process_map_entry(const RelFileLocator *rlocator, uint32 key_type, char *
 					(errcode_for_file_access(),
 					 errmsg("could not seek in tde map file \"%s\": %m",
 							db_map_path)));
-			return curr_pos;
 		}
 	}
 	else

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -430,7 +430,6 @@ write_key_provider_info(KeyringProvideRecord *provider, Oid database_id,
 	fd = BasicOpenFile(kp_info_path, O_CREAT | O_RDWR | PG_BINARY);
 	if (fd < 0)
 	{
-		LWLockRelease(tde_provider_info_lock());
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not open tde file \"%s\": %m", kp_info_path)));
@@ -455,7 +454,6 @@ write_key_provider_info(KeyringProvideRecord *provider, Oid database_id,
 				if (error_if_exists)
 				{
 					close(fd);
-					LWLockRelease(tde_provider_info_lock());
 					ereport(ERROR,
 							(errcode(ERRCODE_DUPLICATE_OBJECT),
 							 errmsg("key provider \"%s\" already exists", provider->provider_name)));
@@ -527,7 +525,6 @@ write_key_provider_info(KeyringProvideRecord *provider, Oid database_id,
 	if (bytes_written != sizeof(KeyringProvideRecord))
 	{
 		close(fd);
-		LWLockRelease(tde_provider_info_lock());
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("key provider info file \"%s\" can't be written: %m",
@@ -536,7 +533,6 @@ write_key_provider_info(KeyringProvideRecord *provider, Oid database_id,
 	if (pg_fsync(fd) != 0)
 	{
 		close(fd);
-		LWLockRelease(tde_provider_info_lock());
 		ereport(ERROR,
 				(errcode_for_file_access(),
 				 errmsg("could not fsync file \"%s\": %m",

--- a/contrib/pg_tde/src/catalog/tde_keyring_parse_opts.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring_parse_opts.c
@@ -334,7 +334,6 @@ json_kring_object_field_start(void *state, char *fname, bool isnull)
 					{
 						*field = JK_FIELD_UNKNOWN;
 						elog(ERROR, "parse file keyring config: unexpected field %s", fname);
-						return JSON_INVALID_TOKEN;
 					}
 					break;
 
@@ -351,7 +350,6 @@ json_kring_object_field_start(void *state, char *fname, bool isnull)
 					{
 						*field = JK_FIELD_UNKNOWN;
 						elog(ERROR, "parse json keyring config: unexpected field %s", fname);
-						return JSON_INVALID_TOKEN;
 					}
 					break;
 
@@ -368,7 +366,6 @@ json_kring_object_field_start(void *state, char *fname, bool isnull)
 					{
 						*field = JK_FIELD_UNKNOWN;
 						elog(ERROR, "parse json keyring config: unexpected field %s", fname);
-						return JSON_INVALID_TOKEN;
 					}
 					break;
 
@@ -388,7 +385,6 @@ json_kring_object_field_start(void *state, char *fname, bool isnull)
 			{
 				*field = JK_FIELD_UNKNOWN;
 				elog(ERROR, "parse json keyring config: unexpected field %s", fname);
-				return JSON_INVALID_TOKEN;
 			}
 			break;
 	}
@@ -465,7 +461,6 @@ json_kring_assign_scalar(JsonKeyringState *parse, JsonKeyringField field, char *
 
 		default:
 			elog(ERROR, "json keyring: unexpected scalar field %d", field);
-			return JSON_INVALID_TOKEN;
 	}
 
 	return JSON_SUCCESS;
@@ -484,17 +479,14 @@ get_remote_kring_value(const char *url, const char *field_name)
 	if (!curlSetupSession(url, NULL, &outStr))
 	{
 		elog(ERROR, "CURL error for remote object %s", field_name);
-		return NULL;
 	}
 	if (curl_easy_perform(keyringCurl) != CURLE_OK)
 	{
 		elog(ERROR, "HTTP request error for remote object %s", field_name);
-		return NULL;
 	}
 	if (curl_easy_getinfo(keyringCurl, CURLINFO_RESPONSE_CODE, &httpCode) != CURLE_OK)
 	{
 		elog(ERROR, "HTTP error for remote object %s, HTTP code %li", field_name, httpCode);
-		return NULL;
 	}
 
 	/* remove trailing whitespace */
@@ -513,17 +505,15 @@ get_file_kring_value(const char *path, const char *field_name)
 	if (fd < 0)
 	{
 		elog(ERROR, "failed to open file %s for %s", path, field_name);
-		return NULL;
 	}
 
 	/* TODO: we never pfree it */
 	val = palloc0(MAX_CONFIG_FILE_DATA_LENGTH);
 	if (pg_pread(fd, val, MAX_CONFIG_FILE_DATA_LENGTH, 0) == -1)
 	{
-		elog(ERROR, "failed to read file %s for %s", path, field_name);
 		pfree(val);
 		close(fd);
-		return NULL;
+		elog(ERROR, "failed to read file %s for %s", path, field_name);
 	}
 	/* remove trailing whitespace */
 	val[strcspn(val, " \t\n\r")] = '\0';

--- a/contrib/pg_tde/src/catalog/tde_keyring_parse_opts.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring_parse_opts.c
@@ -511,7 +511,6 @@ get_file_kring_value(const char *path, const char *field_name)
 	val = palloc0(MAX_CONFIG_FILE_DATA_LENGTH);
 	if (pg_pread(fd, val, MAX_CONFIG_FILE_DATA_LENGTH, 0) == -1)
 	{
-		pfree(val);
 		close(fd);
 		elog(ERROR, "failed to read file %s for %s", path, field_name);
 	}

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -324,8 +324,6 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 
 	if (keyInfo != NULL && ensure_new_key)
 	{
-		pfree(new_keyring);
-
 		ereport(ERROR,
 				(errmsg("failed to create principal key: already exists")));
 	}
@@ -340,8 +338,6 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 
 	if (keyInfo == NULL)
 	{
-		pfree(new_keyring);
-
 		ereport(ERROR,
 				(errmsg("failed to retrieve/create principal key.")));
 	}

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -295,8 +295,6 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 
 	if (provider_name == NULL && !already_has_key)
 	{
-		LWLockRelease(lock_files);
-
 		ereport(ERROR,
 				(errmsg("provider_name is a required parameter when creating the first principal key for a database")));
 	}
@@ -327,8 +325,6 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 
 	if (keyInfo != NULL && ensure_new_key)
 	{
-		LWLockRelease(lock_files);
-
 		pfree(new_keyring);
 
 		ereport(ERROR,
@@ -347,8 +343,6 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 
 	if (keyInfo == NULL)
 	{
-		LWLockRelease(lock_files);
-
 		pfree(new_keyring);
 
 		ereport(ERROR,

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -319,7 +319,6 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 			ereport(ERROR,
 					(errmsg("failed to retrieve principal key from keyring provider :\"%s\"", new_keyring->provider_name),
 					 errdetail("Error code: %d", kr_ret)));
-			return false;
 		}
 	}
 
@@ -329,8 +328,6 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 
 		ereport(ERROR,
 				(errmsg("failed to create principal key: already exists")));
-
-		return false;
 	}
 
 	if (strlen(key_name) >= sizeof(keyInfo->name))
@@ -347,8 +344,6 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 
 		ereport(ERROR,
 				(errmsg("failed to retrieve/create principal key.")));
-
-		return false;
 	}
 
 	new_principal_key = palloc_object(TDEPrincipalKey);
@@ -682,7 +677,6 @@ pg_tde_get_key_info(PG_FUNCTION_ARGS, Oid dbOid)
 		ereport(ERROR,
 				(errmsg("Principal key does not exists for the database"),
 				 errhint("Use set_principal_key interface to set the principal key")));
-		PG_RETURN_NULL();
 	}
 
 	keyring = GetKeyProviderByID(principal_key->keyInfo.keyringId, principal_key->keyInfo.databaseId);

--- a/contrib/pg_tde/src/keyring/keyring_file.c
+++ b/contrib/pg_tde/src/keyring/keyring_file.c
@@ -110,7 +110,6 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 	existing_key = get_key_by_name(keyring, key->name, &return_code);
 	if (existing_key)
 	{
-		pfree(existing_key);
 		ereport(ERROR,
 				(errmsg("Key with name %s already exists in keyring", key->name)));
 	}

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -196,9 +196,6 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 
 	if (!curl_perform(vault_keyring, url, &str, &httpCode, jsonText))
 	{
-		if (str.ptr != NULL)
-			pfree(str.ptr);
-
 		ereport(ERROR,
 				(errmsg("HTTP(S) request to keyring provider \"%s\" failed",
 						vault_keyring->keyring.provider_name)));

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -101,7 +101,6 @@ _PG_init(void)
 	if (!process_shared_preload_libraries_in_progress)
 	{
 		elog(ERROR, "pg_tde can only be loaded at server startup. Restart required.");
-		return;
 	}
 
 	check_percona_api_version();


### PR DESCRIPTION
Since `ereport(ERROR)` does a longjump and then releases all LWLocks it is quite pointless to have code after  `ereport()` or to release locks. I also remove some unnecessary `pfree()` calls of stuff which is in the memory context which will be destroyed in a very short time.