### PR TITLE
Don't Xlog new use of default keys

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -905,11 +905,6 @@ GetPrincipalKey(Oid dbOid, LWLockMode lockMode)
 
 	create_principal_key_info(&newPrincipalKey->keyInfo);
 
-	/* XLog the new use of the default key */
-	XLogBeginInsert();
-	XLogRegisterData((char *) &newPrincipalKey->keyInfo, sizeof(TDEPrincipalKeyInfo));
-	XLogInsert(RM_TDERMGR_ID, XLOG_TDE_ADD_PRINCIPAL_KEY);
-
 	push_principal_key_to_cache(newPrincipalKey);
 
 	pfree(newPrincipalKey);


### PR DESCRIPTION
We should not XLog a default key copy. It doesn’t make sense for reliability as we write results dirctly to the disk. And as for the replicas, they would just try to get a key, retrieve the default one and do copying on its own instead of reading that from the XLog.

XLogging a new use of default keys creates the next issue: On server start, the WAL init tries to get a current WAL key to decide what to do next - create a new encrypted or unencrypted key, or do nothing - and for that it needs a principal key. During the GetPrincipalKey call, if there is only a default principal key, the server will create a new principal key for WAL (in this case) by copying the default key with the WAL Oid. Hence, create a new principal key with XLogInserts generated.

Fixes PG-1476