### PR TITLE
Create pg_tde dir on replicas

### DIFF
--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -171,6 +171,7 @@ pg_tde_extension_initialize(PG_FUNCTION_ARGS)
 void
 extension_install_redo(XLogExtensionInstall *xlrec)
 {
+	pg_tde_init_data_dir();
 	run_extension_install_callbacks(xlrec, true);
 }
 


### PR DESCRIPTION
Otherwise `pg_tde_add_key_provider...` fill fail if a replica was created before primary run `CREATE EXTENSION pg_tde`

Fixes PG-1489