### PR TITLE
PG-1488: Only create keys for main/init forks

### DIFF
--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -242,20 +242,30 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 
 	mdcreate(relold, reln, forknum, isRedo);
 
-	/*
-	 * Later calls then decide to encrypt or not based on the existence of the
-	 * key
-	 */
-	key = tde_smgr_get_key(reln, event->alterAccessMethodMode ? NULL : &relold, true);
+	if (forknum == MAIN_FORKNUM || forknum == INIT_FORKNUM)
+	{
+		/*
+		 * Only create keys when creating the main/init fork. Other forks can
+		 * be created later, even during tde creation events. We definitely do
+		 * not want to create keys then, even later, when we encrypt all
+		 * forks!
+		 */
 
-	if (key)
-	{
-		tdereln->encrypted_relation = true;
-		tdereln->relKey = *key;
-	}
-	else
-	{
-		tdereln->encrypted_relation = false;
+		/*
+		 * Later calls then decide to encrypt or not based on the existence of
+		 * the key
+		 */
+		key = tde_smgr_get_key(reln, event->alterAccessMethodMode ? NULL : &relold, true);
+
+		if (key)
+		{
+			tdereln->encrypted_relation = true;
+			tdereln->relKey = *key;
+		}
+		else
+		{
+			tdereln->encrypted_relation = false;
+		}
 	}
 }
 


### PR DESCRIPTION
smgr_create is called for all forks. It is possible that additional forks for existing tables are created during a tde creation event. In practice this happens quite often with CREATE INDEX CONCURRENTLY.

Without this fix, pg_tde created encryption keys for these existing tables, and later writes and reads tried to use these keys with all these issues. In practice some of the file got encrypted, some didn't, and earlier records that weren't encrypted became unreadable.