### PR TITLE
PG-1416, PG-829 Merge the map and keydata files

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -79,13 +79,6 @@ typedef struct TDEMapEntry
 	int32		key_index;
 } TDEMapEntry;
 
-typedef struct TDEMapFilePath
-{
-	char		map_path[MAXPGPATH];
-	char		keydata_path[MAXPGPATH];
-}			TDEMapFilePath;
-
-
 typedef struct RelKeyCacheRec
 {
 	RelFileLocator locator;

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -744,6 +744,10 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 
 		/* Increment the key index for the new principal key */
 		key_index[NEW_PRINCIPAL_KEY]++;
+
+		pfree(rel_key_data[OLD_PRINCIPAL_KEY]);
+		pfree(enc_rel_key_data[NEW_PRINCIPAL_KEY]);
+		pfree(enc_rel_key_data[OLD_PRINCIPAL_KEY]);
 	}
 
 	/* Close unrotated files */

--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -56,7 +56,7 @@ static ssize_t TDEXLogWriteEncryptedPages(int fd, const void *buf, size_t count,
 typedef struct EncryptionStateData
 {
 	char	   *segBuf;
-	char		db_keydata_path[MAXPGPATH];
+	char		db_map_path[MAXPGPATH];
 	pg_atomic_uint64 enc_key_lsn;	/* to sync with readers */
 } EncryptionStateData;
 
@@ -190,7 +190,7 @@ TDEXLogSmgrInit(void)
 		pg_atomic_write_u64(&EncryptionState->enc_key_lsn, EncryptionKey.start_lsn);
 	}
 
-	pg_tde_set_db_file_paths(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID).dbOid, NULL, EncryptionState->db_keydata_path);
+	pg_tde_set_db_file_path(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID).dbOid, EncryptionState->db_map_path);
 
 #endif
 	SetXLogSmgr(&tde_xlog_smgr);
@@ -214,7 +214,7 @@ tdeheap_xlog_seg_write(int fd, const void *buf, size_t count, off_t offset,
 
 		XLogSegNoOffsetToRecPtr(segno, offset, wal_segment_size, lsn);
 
-		pg_tde_wal_last_key_set_lsn(lsn, EncryptionState->db_keydata_path);
+		pg_tde_wal_last_key_set_lsn(lsn, EncryptionState->db_map_path);
 		EncryptionKey.start_lsn = lsn;
 		pg_atomic_write_u64(&EncryptionState->enc_key_lsn, lsn);
 	}

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -377,7 +377,7 @@ xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec)
 {
 	bool		ret;
 
-	ret = pg_tde_write_map_keydata_files(xlrec->map_size, xlrec->buff, xlrec->keydata_size, &xlrec->buff[xlrec->map_size]);
+	ret = pg_tde_write_map_keydata_file(xlrec->file_size, xlrec->buff);
 	clear_principal_key_cache(xlrec->databaseId);
 
 	return ret;

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -35,8 +35,6 @@ typedef struct InternalKey
 	void	   *ctx;
 } InternalKey;
 
-#define INTERNAL_KEY_DAT_LEN	offsetof(InternalKey, ctx)
-
 #define WALKeySetInvalid(key) \
 	((key)->rel_type &= ~(TDE_KEY_TYPE_WAL_ENCRYPTED | TDE_KEY_TYPE_WAL_UNENCRYPTED))
 #define WALKeyIsValid(key) \
@@ -83,15 +81,11 @@ extern void pg_tde_write_key_map_entry(const RelFileLocator *rlocator, InternalK
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, uint32 key_type, off_t offset);
 
 #define PG_TDE_MAP_FILENAME			"pg_tde_%d_map"
-#define PG_TDE_KEYDATA_FILENAME		"pg_tde_%d_dat"
 
 static inline void
-pg_tde_set_db_file_paths(Oid dbOid, char *map_path, char *keydata_path)
+pg_tde_set_db_file_path(Oid dbOid, char *path)
 {
-	if (map_path)
-		join_path_components(map_path, pg_tde_get_tde_data_dir(), psprintf(PG_TDE_MAP_FILENAME, dbOid));
-	if (keydata_path)
-		join_path_components(keydata_path, pg_tde_get_tde_data_dir(), psprintf(PG_TDE_KEYDATA_FILENAME, dbOid));
+	join_path_components(path, pg_tde_get_tde_data_dir(), psprintf(PG_TDE_MAP_FILENAME, dbOid));
 }
 
 extern InternalKey *GetSMGRRelationKey(RelFileLocatorBackend rel);
@@ -101,7 +95,7 @@ extern void pg_tde_delete_tde_files(Oid dbOid);
 extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
 extern void pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info);
 extern bool pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
-extern bool pg_tde_write_map_keydata_files(off_t map_size, char *m_file_data, off_t keydata_size, char *k_file_data);
+extern bool pg_tde_write_map_keydata_file(off_t size, char *file_data);
 
 const char *tde_sprint_key(InternalKey *k);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -80,7 +80,6 @@ extern void pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path
 extern InternalKey *pg_tde_create_smgr_key(const RelFileLocatorBackend *newrlocator);
 extern void pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocator, uint32 flags);
 extern void pg_tde_write_key_map_entry(const RelFileLocator *rlocator, InternalKey *enc_rel_key_data, TDEPrincipalKeyInfo *principal_key_info);
-extern void pg_tde_delete_key_map_entry(const RelFileLocator *rlocator, uint32 key_type);
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, uint32 key_type, off_t offset);
 
 #define PG_TDE_MAP_FILENAME			"pg_tde_%d_map"

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -38,8 +38,7 @@ typedef struct TDEPrincipalKey
 typedef struct XLogPrincipalKeyRotate
 {
 	Oid			databaseId;
-	off_t		map_size;
-	off_t		keydata_size;
+	off_t		file_size;
 	char		buff[FLEXIBLE_ARRAY_MEMBER];
 } XLogPrincipalKeyRotate;
 


### PR DESCRIPTION
 We never took advantage of that the relation keys were stored in two
    different files, one for the RelFileNumber and flags and one for the
    actual keys so this just complicated the code for almost no gain.
    
Bumps the version of the file format.

This will make it less painful to add new features to the file format like checksums.