### PR TITLE
PG-1457 Rename principal key on user API level to just a key

### DIFF
--- a/ci_scripts/backup/pg_basebackup_test.sh
+++ b/ci_scripts/backup/pg_basebackup_test.sh
@@ -105,7 +105,7 @@ setup_tde_heap(){
     sudo -u "$PG_USER" psql -p $PG_PORT -c "CREATE DATABASE $DB_NAME;"
     sudo -u "$PG_USER" psql -d "$DB_NAME" -p "$PG_PORT" -c "CREATE EXTENSION IF NOT EXISTS pg_tde;"
     sudo -u "$PG_USER" psql -d "$DB_NAME" -p "$PG_PORT" -c "SELECT pg_tde_add_database_key_provider_file('file-vault','$KEYLOCATION');"
-    sudo -u "$PG_USER" psql -d "$DB_NAME" -p "$PG_PORT" -c "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-master-key','file-vault');"
+    sudo -u "$PG_USER" psql -d "$DB_NAME" -p "$PG_PORT" -c "SELECT pg_tde_set_key_using_database_key_provider('test-db-master-key','file-vault');"
     sudo -u "$PG_USER" psql -p $PG_PORT -c "ALTER DATABASE $DB_NAME SET default_table_access_method='tde_heap';"
     sudo -u "$PG_USER" psql -p $PG_PORT -c "SELECT pg_reload_conf();"
 }

--- a/ci_scripts/tde_setup.sql
+++ b/ci_scripts/tde_setup.sql
@@ -1,4 +1,4 @@
 CREATE SCHEMA IF NOT EXISTS tde;
 CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
 SELECT tde.pg_tde_add_database_key_provider_file('reg_file-vault', '/tmp/pg_tde_test_keyring.per');
-SELECT tde.pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key', 'reg_file-vault');
+SELECT tde.pg_tde_set_key_using_database_key_provider('test-db-key', 'reg_file-vault');

--- a/ci_scripts/tde_setup_global.sql
+++ b/ci_scripts/tde_setup_global.sql
@@ -2,7 +2,7 @@ CREATE SCHEMA tde;
 CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
 
 SELECT tde.pg_tde_add_global_key_provider_file('reg_file-global', '/tmp/pg_tde_test_keyring.per');
-SELECT tde.pg_tde_set_server_principal_key_using_global_key_provider('server-principal-key', 'reg_file-global');
+SELECT tde.pg_tde_set_server_key_using_global_key_provider('server-key', 'reg_file-global');
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 ALTER SYSTEM SET default_table_access_method = 'tde_heap';
 ALTER SYSTEM SET search_path = "$user",public,tde;

--- a/contrib/pg_tde/README.md
+++ b/contrib/pg_tde/README.md
@@ -126,11 +126,11 @@ _See [Make Builds for Developers](https://github.com/percona/pg_tde/wiki/Make-bu
 
         **Note: The `File` provided is intended for development and stores the keys unencrypted in the specified data file.**
 
-   5. Set the principal key for the database using the `pg_tde_set_principal_key` function.
+   5. Set the principal key for the database using the `pg_tde_set_key` function.
 
         ```sql
-        -- pg_tde_set_principal_key_using_database_key_provider(principal_key_name, provider_name);
-        SELECT pg_tde_set_principal_key_using_database_key_provider('my-principal-key','file');
+        -- pg_tde_set_key_using_database_key_provider(key_name, provider_name);
+        SELECT pg_tde_set_key_using_database_key_provider('my-key','file');
         ```
    
    6. Specify `tde_heap` access method during table creation

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -61,7 +61,7 @@ You can add a new key provider using the provided functions, which are implement
 
 There are two functions to add a key provider: one function adds it for the current database and another one - for the global scope. 
 
-* `pg_tde_add_key_provider_<type>('provider-name', <provider specific parameters>)`
+* `pg_tde_add_database_key_provider_<type>('provider-name', <provider specific parameters>)`
 * `pg_tde_add_global_key_provider_<type>('provider-name', <provider specific parameters>)`
 
 When you add a new provider, the provider name must be unqiue in the scope. But a local database provider and a global provider can have the same name.
@@ -201,12 +201,12 @@ Use these functions to create a new principal key for a specific scope such as a
 
 Princial keys are stored on key providers by the name specified in this function - for example, when using the Vault provider, after creating a key named "foo", a key named "foo" will be visible on the Vault server at the specified mount point.
 
-### pg_tde_set_principal_key_using_database_key_provider
+### pg_tde_set_key_using_database_key_provider
 
 Creates or rotates the principal key for the current database using the specified database key provider and key name.
 
 ```
-SELECT pg_tde_set_principal_key_using_database_key_provider('name-of-the-principal-key','provider-name','ensure_new_key');
+SELECT pg_tde_set_key_using_database_key_provider('name-of-the-key','provider-name','ensure_new_key');
 ```
 
  The `ensure_new_key` parameter instructs the function how to handle a principal key during key rotation:
@@ -215,12 +215,12 @@ SELECT pg_tde_set_principal_key_using_database_key_provider('name-of-the-princip
   If the provider already stores a key by that name, the function returns an error.
 * If set to `false`, an existing principal key may be reused.
 
-### pg_tde_set_principal_key_using_global_key_provider
+### pg_tde_set_key_using_global_key_provider
 
 Creates or rotates the global principal key using the specified global key provider and the key name. This key is used for global settings like WAL encryption.
 
 ```
-SELECT pg_tde_set_principal_key_using_global_key_provider('name-of-the-principal-key','provider-name','ensure_new_key');
+SELECT pg_tde_set_key_using_global_key_provider('name-of-the-key','provider-name','ensure_new_key');
 ```
 
  The `ensure_new_key` parameter instructs the function how to handle a principal key during key rotation:
@@ -229,12 +229,12 @@ SELECT pg_tde_set_principal_key_using_global_key_provider('name-of-the-principal
   If the provider already stores a key by that name, the function returns an error.
 * If set to `false`, an existing principal key may be reused.
 
-### pg_tde_set_server_principal_key_using_global_key_provider
+### pg_tde_set_server_key_using_global_key_provider
 
 Creates or rotates the server principal key using the specified global key provider. Use this function to set a principal key for WAL encryption.
 
 ```
-SELECT pg_tde_set_server_principal_key_using_global_key_provider('name-of-the-principal-key','provider-name','ensure_new_key');
+SELECT pg_tde_set_server_key_using_global_key_provider('name-of-the-key','provider-name','ensure_new_key');
 ```
 
 The `ensure_new_key` parameter instructs the function how to handle a principal key during key rotation:
@@ -244,14 +244,14 @@ The `ensure_new_key` parameter instructs the function how to handle a principal 
 * If set to `false`, an existing principal key may be reused.
 
 
-### pg_tde_set_default_principal_key_using_global_key_provider
+### pg_tde_set_default_key_using_global_key_provider
 
 Creates or rotates the default principal key for the server using the specified global key provider.
 
 The default key is automatically used as a principal key  by any database that doesn't have an individual key provider and key configuration.
 
 ```
-SELECT pg_tde_set_default_principal_key_using_global_key_provider('name-of-the-principal-key','provider-name','ensure_new_key');
+SELECT pg_tde_set_default_key_using_global_key_provider('name-of-the-key','provider-name','ensure_new_key');
 ```
 
 The `ensure_new_key` parameter instructs the function how to handle a principal key during key rotation:
@@ -282,23 +282,23 @@ SELECT pg_tde_is_encrypted('schema.table_name');
 
 This can additionally be used to verify that indexes and sequences are encrypted.
 
-### pg_tde_principal_key_info
+### pg_tde_key_info
 
 Displays information about the principal key for the current database, if it exists.
 
 ```
-SELECT pg_tde_principal_key_info()
+SELECT pg_tde_key_info()
 ```
 
-### pg_tde_server_principal_key_info
+### pg_tde_server_key_info
 
 Displays information about the principal key for the server scope, if exists.
 
 ```
-SELECT pg_tde_server_principal_key_info()
+SELECT pg_tde_server_key_info()
 ```
 
-### pg_tde_verify_principal_key
+### pg_tde_verify_key
 
 This function checks that the current database has a properly functional encryption setup, which means:
 
@@ -311,10 +311,10 @@ This function checks that the current database has a properly functional encrypt
 If any of the above checks fail, the function reports an error.
 
 ```
-SELECT pg_tde_verify_principal_key()
+SELECT pg_tde_verify_key()
 ```
 
-### pg_tde_verify_server_principal_key
+### pg_tde_verify_server_key
 
 This function checks that the server scope has a properly functional encryption setup, which means:
 
@@ -327,5 +327,5 @@ This function checks that the server scope has a properly functional encryption 
 If any of the above checks fail, the function reports an error.
 
 ```
-SELECT pg_tde_verify_server_principal_key()
+SELECT pg_tde_verify_server_key()
 ```

--- a/contrib/pg_tde/documentation/docs/multi-tenant-setup.md
+++ b/contrib/pg_tde/documentation/docs/multi-tenant-setup.md
@@ -117,19 +117,19 @@ You must do these steps for every database where you have created the extension.
 2. Add a principal key
 
     ```sql
-    SELECT pg_tde_set_principal_key_using_database_key_provider('name-of-the-principal-key', 'provider-name','ensure_new_key');
+    SELECT pg_tde_set_key_using_database_key_provider('name-of-the-key', 'provider-name','ensure_new_key');
     ```
 
     where:
 
-    * `name-of-the-principal-key` is the name of the principal key. You will use this name to identify the key.
+    * `name-of-the-key` is the name of the principal key. You will use this name to identify the key.
     * `provider-name` is the name of the key provider you added before. The principal key will be associated with this provider.
     * `ensure_new_key` defines if a principal key must be unique. The default value `true` means that you must speficy a unique key during key rotation. The `false` value allows reusing an existing principal key.
 
     <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
     ```sql
-    SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-master-key','file-vault','ensure_new_key');
+    SELECT pg_tde_set_key_using_database_key_provider('test-db-master-key','file-vault','ensure_new_key');
     ```
 
     The key is auto-generated.

--- a/contrib/pg_tde/documentation/docs/setup.md
+++ b/contrib/pg_tde/documentation/docs/setup.md
@@ -112,19 +112,19 @@ Load the `pg_tde` at startup time. The extension requires additional shared memo
 2. Add a default principal key
 
     ```sql
-    SELECT pg_tde_set_default_principal_key_using_global_key_provider('name-of-the-principal-key','provider-name','ensure_new_key');
+    SELECT pg_tde_set_default_key_using_global_key_provider('name-of-the-key','provider-name','ensure_new_key');
     ```
 
     where:
 
-    * `name-of-the-principal-key` is the name of the principal key. You will use this name to identify the key.
+    * `name-of-the-key` is the name of the principal key. You will use this name to identify the key.
     * `provider-name` is the name of the key provider you added before. The principal key will be associated with this provider.
     * `ensure_new_key` defines if a principal key must be unique. The default value `true` means that you must speficy a unique key during key rotation. The `false` value allows reusing an existing principal key.
 
     <i warning>:material-information: Warning:</i> This example is for testing purposes only. Replace the key name and provider name with your values:
 
     ```sql
-    SELECT pg_tde_set_principal_key_using_global_key_provider('test-db-master-key','file-vault','ensure_new_key');
+    SELECT pg_tde_set_key_using_global_key_provider('test-db-master-key','file-vault','ensure_new_key');
     ```
 
     The key is auto-generated.

--- a/contrib/pg_tde/documentation/docs/test.md
+++ b/contrib/pg_tde/documentation/docs/test.md
@@ -33,15 +33,7 @@ Here's how to do it:
 
     The function returns `t` if the table is encrypted and `f` - if not.
 
-3. Rotate the principal key when needed:
-
-    ```
-    SELECT pg_tde_rotate_key(); -- uses automatic key versionin
-    -- or
-    SELECT pg_tde_rotate_key('new-key', NULL); -- specify new key name
-    -- or
-    SELECT pg_tde_rotate_key('new-key', 'new-provider'); -- changeprovider
-    ```
+3. Rotate the principal key when needed, see [Principal key management](functions.md#principal-key-management))
 
 ## Encrypt existing table
 

--- a/contrib/pg_tde/documentation/docs/test.md
+++ b/contrib/pg_tde/documentation/docs/test.md
@@ -36,11 +36,11 @@ Here's how to do it:
 3. Rotate the principal key when needed:
 
     ```
-    SELECT pg_tde_rotate_principal_key(); -- uses automatic key versionin
+    SELECT pg_tde_rotate_key(); -- uses automatic key versionin
     -- or
-    SELECT pg_tde_rotate_principal_key('new-principal-key', NULL); -- specify new key name
+    SELECT pg_tde_rotate_key('new-key', NULL); -- specify new key name
     -- or
-    SELECT pg_tde_rotate_principal_key('new-principal-key', 'new-provider'); -- changeprovider
+    SELECT pg_tde_rotate_key('new-key', 'new-provider'); -- changeprovider
     ```
 
 ## Encrypt existing table

--- a/contrib/pg_tde/documentation/docs/wal-encryption.md
+++ b/contrib/pg_tde/documentation/docs/wal-encryption.md
@@ -61,7 +61,7 @@ Here's what to do:
 3. Create principal key
     
     ```sql
-    SELECT pg_tde_set_server_principal_key_using_global_key_provider('principal-key', 'provider-name');
+    SELECT pg_tde_set_server_key_using_global_key_provider('key', 'provider-name');
     ```
 
 4. Enable WAL level encryption using the `ALTER SYSTEM` command. You need the privileges of the superuser to run this command:

--- a/contrib/pg_tde/expected/access_control.out
+++ b/contrib/pg_tde/expected/access_control.out
@@ -4,8 +4,8 @@ SET ROLE regress_pg_tde_access_control;
 -- should throw access denied
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
 ERROR:  permission denied for function pg_tde_add_database_key_provider_file
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key', 'file-vault');
-ERROR:  permission denied for function pg_tde_set_principal_key_using_database_key_provider
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
+ERROR:  permission denied for function pg_tde_set_key_using_database_key_provider
 RESET ROLE;
 SELECT pg_tde_grant_database_key_management_to_role('regress_pg_tde_access_control');
  pg_tde_grant_database_key_management_to_role 
@@ -33,9 +33,9 @@ SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/pg_tde_test_keyring
                                      2
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key', 'file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 
@@ -46,10 +46,10 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
   2 | file-2        | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring_2.per"}
 (2 rows)
 
-SELECT principal_key_name, key_provider_name, key_provider_id FROM pg_tde_principal_key_info();
-  principal_key_name   | key_provider_name | key_provider_id 
------------------------+-------------------+-----------------
- test-db-principal-key | file-vault        |               1
+SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_key_info();
+  key_name   | key_provider_name | key_provider_id 
+-------------+-------------------+-----------------
+ test-db-key | file-vault        |               1
 (1 row)
 
 RESET ROLE;
@@ -63,7 +63,7 @@ SET ROLE regress_pg_tde_access_control;
 -- verify the view access is revoked
 SELECT * FROM pg_tde_list_all_database_key_providers();
 ERROR:  permission denied for function pg_tde_list_all_database_key_providers
-SELECT principal_key_name, key_provider_name, key_provider_id FROM pg_tde_principal_key_info();
-ERROR:  permission denied for function pg_tde_principal_key_info
+SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_key_info();
+ERROR:  permission denied for function pg_tde_key_info
 RESET ROLE;
 DROP EXTENSION pg_tde CASCADE;

--- a/contrib/pg_tde/expected/alter_index.out
+++ b/contrib/pg_tde/expected/alter_index.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyr
                                      1
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/cache_alloc.out
+++ b/contrib/pg_tde/expected/cache_alloc.out
@@ -6,9 +6,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyr
                                      1
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/change_access_method.out
+++ b/contrib/pg_tde/expected/change_access_method.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyr
                                      1
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_principal_key.per');
+SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_key.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
                                   -3
 (1 row)
 
-SELECT pg_tde_set_default_principal_key_using_global_key_provider('default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key_using_global_key_provider 
-------------------------------------------------------------
+SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'file-provider', false);
+ pg_tde_set_default_key_using_global_key_provider 
+--------------------------------------------------
  
 (1 row)
 
@@ -21,10 +21,10 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 (1 row)
 
 -- Should fail: no principal key for the database yet
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
 ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
  
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
@@ -34,11 +34,11 @@ CREATE TABLE test_enc(
 ) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
 -- Should succeed: create table localized the principal key
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
- key_provider_id | key_provider_name |  principal_key_name   
------------------+-------------------+-----------------------
-              -3 | file-provider     | default-principal-key
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
+ key_provider_id | key_provider_name |  key_name   
+-----------------+-------------------+-------------
+              -3 | file-provider     | default-key
 (1 row)
 
 SELECT current_database() AS regress_database
@@ -47,10 +47,10 @@ CREATE DATABASE regress_pg_tde_other;
 \c regress_pg_tde_other
 CREATE EXTENSION pg_tde;
 -- Should fail: no principal key for the database yet
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
 ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
 	id SERIAL,
@@ -59,33 +59,33 @@ CREATE TABLE test_enc(
 ) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
 -- Should succeed: create table localized the principal key
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
- key_provider_id | key_provider_name |  principal_key_name   
------------------+-------------------+-----------------------
-              -3 | file-provider     | default-principal-key
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
+ key_provider_id | key_provider_name |  key_name   
+-----------------+-------------------+-------------
+              -3 | file-provider     | default-key
 (1 row)
 
 \c :regress_database
-SELECT pg_tde_set_default_principal_key_using_global_key_provider('new-default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key_using_global_key_provider 
-------------------------------------------------------------
+SELECT pg_tde_set_default_key_using_global_key_provider('new-default-key', 'file-provider', false);
+ pg_tde_set_default_key_using_global_key_provider 
+--------------------------------------------------
  
 (1 row)
 
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
- key_provider_id | key_provider_name |    principal_key_name     
------------------+-------------------+---------------------------
-              -3 | file-provider     | new-default-principal-key
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
+ key_provider_id | key_provider_name |    key_name     
+-----------------+-------------------+-----------------
+              -3 | file-provider     | new-default-key
 (1 row)
 
 \c regress_pg_tde_other
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
- key_provider_id | key_provider_name |    principal_key_name     
------------------+-------------------+---------------------------
-              -3 | file-provider     | new-default-principal-key
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
+ key_provider_id | key_provider_name |    key_name     
+-----------------+-------------------+-----------------
+              -3 | file-provider     | new-default-key
 (1 row)
 
 DROP TABLE test_enc;

--- a/contrib/pg_tde/expected/default_principal_key_1.out
+++ b/contrib/pg_tde/expected/default_principal_key_1.out
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_principal_key.per');
+SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_key.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
                                   -4
 (1 row)
 
-SELECT pg_tde_set_default_principal_key_using_global_key_provider('default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key_using_global_key_provider 
-------------------------------------------------------------
+SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'file-provider', false);
+ pg_tde_set_default_key_using_global_key_provider 
+--------------------------------------------------
  
 (1 row)
 
@@ -22,10 +22,10 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 (2 rows)
 
 -- Should fail: no principal key for the database yet
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
 ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
  
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
@@ -35,11 +35,11 @@ CREATE TABLE test_enc(
 ) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
 -- Should succeed: create table localized the principal key
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
- key_provider_id | key_provider_name |  principal_key_name   
------------------+-------------------+-----------------------
-              -4 | file-provider     | default-principal-key
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
+ key_provider_id | key_provider_name |  key_name   
+-----------------+-------------------+-------------
+              -4 | file-provider     | default-key
 (1 row)
 
 SELECT current_database() AS regress_database
@@ -48,10 +48,10 @@ CREATE DATABASE regress_pg_tde_other;
 \c regress_pg_tde_other
 CREATE EXTENSION pg_tde;
 -- Should fail: no principal key for the database yet
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
 ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
 	id SERIAL,
@@ -60,33 +60,33 @@ CREATE TABLE test_enc(
 ) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
 -- Should succeed: create table localized the principal key
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
- key_provider_id | key_provider_name |  principal_key_name   
------------------+-------------------+-----------------------
-              -4 | file-provider     | default-principal-key
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
+ key_provider_id | key_provider_name |  key_name   
+-----------------+-------------------+-------------
+              -4 | file-provider     | default-key
 (1 row)
 
 \c :regress_database
-SELECT pg_tde_set_default_principal_key_using_global_key_provider('new-default-principal-key', 'file-provider', false);
- pg_tde_set_default_principal_key_using_global_key_provider 
-------------------------------------------------------------
+SELECT pg_tde_set_default_key_using_global_key_provider('new-default-key', 'file-provider', false);
+ pg_tde_set_default_key_using_global_key_provider 
+--------------------------------------------------
  
 (1 row)
 
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
- key_provider_id | key_provider_name |    principal_key_name     
------------------+-------------------+---------------------------
-              -4 | file-provider     | new-default-principal-key
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
+ key_provider_id | key_provider_name |    key_name     
+-----------------+-------------------+-----------------
+              -4 | file-provider     | new-default-key
 (1 row)
 
 \c regress_pg_tde_other
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
- key_provider_id | key_provider_name |    principal_key_name     
------------------+-------------------+---------------------------
-              -4 | file-provider     | new-default-principal-key
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
+ key_provider_id | key_provider_name |    key_name     
+-----------------+-------------------+-----------------
+              -4 | file-provider     | new-default-key
 (1 row)
 
 DROP TABLE test_enc;

--- a/contrib/pg_tde/expected/delete_key_provider.out
+++ b/contrib/pg_tde/expected/delete_key_provider.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT  * FROM pg_tde_principal_key_info();
+SELECT  * FROM pg_tde_key_info();
 ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/expected/insert_update_delete.out
+++ b/contrib/pg_tde/expected/insert_update_delete.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyr
                                      1
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT  * FROM pg_tde_principal_key_info();
+SELECT  * FROM pg_tde_key_info();
 ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 SELECT pg_tde_add_database_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
 SELECT * FROM pg_tde_list_all_database_key_providers();
@@ -34,17 +34,17 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
   2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 ERROR:  principal key not configured for current database
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 
-SELECT pg_tde_verify_principal_key();
- pg_tde_verify_principal_key 
------------------------------
+SELECT pg_tde_verify_key();
+ pg_tde_verify_key 
+-------------------
  
 (1 row)
 
@@ -71,8 +71,8 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
   2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
-SELECT pg_tde_verify_principal_key();
-ERROR:  failed to retrieve principal key test-db-principal-key from keyring with ID 1
+SELECT pg_tde_verify_key();
+ERROR:  failed to retrieve principal key test-db-key from keyring with ID 1
 SELECT pg_tde_change_database_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
 SELECT * FROM pg_tde_list_all_database_key_providers();
@@ -132,9 +132,9 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  -2 | file-keyring2
 (2 rows)
 
-SELECT pg_tde_set_principal_key_using_global_key_provider('test-db-principal-key', 'file-keyring', false);
- pg_tde_set_principal_key_using_global_key_provider 
-----------------------------------------------------
+SELECT pg_tde_set_key_using_global_key_provider('test-db-key', 'file-keyring', false);
+ pg_tde_set_key_using_global_key_provider 
+------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/key_provider_1.out
+++ b/contrib/pg_tde/expected/key_provider_1.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT  * FROM pg_tde_principal_key_info();
+SELECT  * FROM pg_tde_key_info();
 ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 SELECT pg_tde_add_database_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
 SELECT * FROM pg_tde_list_all_database_key_providers();
@@ -34,17 +34,17 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
   2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 ERROR:  principal key not configured for current database
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 
-SELECT pg_tde_verify_principal_key();
- pg_tde_verify_principal_key 
------------------------------
+SELECT pg_tde_verify_key();
+ pg_tde_verify_key 
+-------------------
  
 (1 row)
 
@@ -71,8 +71,8 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
   2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
-SELECT pg_tde_verify_principal_key();
-ERROR:  failed to retrieve principal key test-db-principal-key from keyring with ID 1
+SELECT pg_tde_verify_key();
+ERROR:  failed to retrieve principal key test-db-key from keyring with ID 1
 SELECT pg_tde_change_database_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
 SELECT * FROM pg_tde_list_all_database_key_providers();
@@ -134,9 +134,9 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  -3 | file-keyring2
 (3 rows)
 
-SELECT pg_tde_set_principal_key_using_global_key_provider('test-db-principal-key', 'file-keyring', false);
- pg_tde_set_principal_key_using_global_key_provider 
-----------------------------------------------------
+SELECT pg_tde_set_key_using_global_key_provider('test-db-key', 'file-keyring', false);
+ pg_tde_set_key_using_global_key_provider 
+------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/keyprovider_dependency.out
+++ b/contrib/pg_tde/expected/keyprovider_dependency.out
@@ -25,9 +25,9 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
   3 | V2-vault      | vault-v2      | {"type" : "vault-v2", "url" : "percona.com/vault-v2/percona", "token" : "vault-token", "mountPath" : "/mount/dev", "caPath" : "ca-cert-auth"}
 (3 rows)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','mk-file');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','mk-file');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/kmip_test.out
+++ b/contrib/pg_tde/expected/kmip_test.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_database_key_provider_kmip('kmip-prov','127.0.0.1', 5696, '/tm
                                      1
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('kmip-principal-key','kmip-prov');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('kmip-key','kmip-prov');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/no_provider_error.out
+++ b/contrib/pg_tde/expected/no_provider_error.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION pg_tde;
 -- should fail
 CREATE TABLE t1 (n INT) USING tde_heap;
-ERROR:  failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.
+ERROR:  failed to retrieve principal key. Create one using pg_tde_set_key before using encrypted tables.
 -- should work
 CREATE TABLE t2 (n INT) USING heap;
 DROP TABLE t2;

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -1,16 +1,16 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT * FROM pg_tde_principal_key_info();
+SELECT * FROM pg_tde_key_info();
 ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
                                      1
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 
@@ -67,11 +67,11 @@ SELECT pg_tde_is_encrypted(NULL);
  
 (1 row)
 
-SELECT key_provider_id, key_provider_name, principal_key_name
-    FROM pg_tde_principal_key_info();
- key_provider_id | key_provider_name |  principal_key_name   
------------------+-------------------+-----------------------
-               1 | file-vault        | test-db-principal-key
+SELECT key_provider_id, key_provider_name, key_name
+    FROM pg_tde_key_info();
+ key_provider_id | key_provider_name |  key_name   
+-----------------+-------------------+-------------
+               1 | file-vault        | test-db-key
 (1 row)
 
 DROP TABLE test_part;

--- a/contrib/pg_tde/expected/recreate_storage.out
+++ b/contrib/pg_tde/expected/recreate_storage.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyr
                                      1
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/subtransaction.out
+++ b/contrib/pg_tde/expected/subtransaction.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyr
                                      1
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/tablespace.out
+++ b/contrib/pg_tde/expected/tablespace.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyr
                                      1
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/toast_decrypt.out
+++ b/contrib/pg_tde/expected/toast_decrypt.out
@@ -5,9 +5,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyr
                                      1
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/toast_decrypt_1.out
+++ b/contrib/pg_tde/expected/toast_decrypt_1.out
@@ -6,9 +6,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyr
                                      2
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -7,7 +7,7 @@ SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token'
 (1 row)
 
 -- FAILS
-SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-incorrect');
+SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-incorrect');
 ERROR:  Invalid HTTP response from keyring provider "vault-incorrect": 404
 CREATE TABLE test_enc(
 	  id SERIAL,
@@ -15,16 +15,16 @@ CREATE TABLE test_enc(
 	  PRIMARY KEY (id)
 	) USING tde_heap;
 ERROR:  principal key not configured
-HINT:  create one using pg_tde_set_principal_key before using encrypted tables
+HINT:  create one using pg_tde_set_key before using encrypted tables
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
                                          2
 (1 row)
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-v2');
- pg_tde_set_principal_key_using_database_key_provider 
-------------------------------------------------------
+SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-v2');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
  
 (1 row)
 

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -420,22 +420,22 @@ STRICT
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_principal_key_using_database_key_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_key_using_database_key_provider(key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_principal_key_using_global_key_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_key_using_global_key_provider(key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_server_principal_key_using_global_key_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_server_key_using_global_key_provider(key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_default_principal_key_using_global_key_provider(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_default_key_using_global_key_provider(key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
@@ -445,26 +445,26 @@ RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_verify_principal_key()
+CREATE FUNCTION pg_tde_verify_key()
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_verify_server_principal_key()
+CREATE FUNCTION pg_tde_verify_server_key()
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_principal_key_info()
-RETURNS TABLE ( principal_key_name text,
+CREATE FUNCTION pg_tde_key_info()
+RETURNS TABLE ( key_name text,
                 key_provider_name text,
                 key_provider_id integer,
                 key_createion_time timestamp with time zone)
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_server_principal_key_info()
-RETURNS TABLE ( principal_key_name text,
+CREATE FUNCTION pg_tde_server_key_info()
+RETURNS TABLE ( key_name text,
                 key_provider_name text,     
                 key_provider_id integer,
                 key_createion_time timestamp with time zone)
@@ -542,9 +542,9 @@ BEGIN
 
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_delete_global_key_provider(text) TO %I', target_role);
 
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_principal_key_using_global_key_provider(text, text, BOOLEAN) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_server_principal_key_using_global_key_provider(text, text, BOOLEAN) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_default_principal_key_using_global_key_provider(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_key_using_global_key_provider(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_server_key_using_global_key_provider(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_default_key_using_global_key_provider(text, text, BOOLEAN) TO %I', target_role);
 END;
 $$;
 
@@ -575,7 +575,7 @@ BEGIN
 
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_delete_database_key_provider(text) TO %I', target_role);
 
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_principal_key_using_database_key_provider(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_key_using_database_key_provider(text, text, BOOLEAN) TO %I', target_role);
 END;
 $$;
 
@@ -589,10 +589,10 @@ BEGIN
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_list_all_database_key_providers() TO %I', target_role);
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_list_all_global_key_providers() TO %I', target_role);
 
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_principal_key_info() TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_server_principal_key_info() TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_verify_principal_key() TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_verify_server_principal_key() TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_key_info() TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_server_key_info() TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_verify_key() TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_verify_server_key() TO %I', target_role);
 END;
 $$;
 
@@ -623,9 +623,9 @@ BEGIN
 
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_delete_global_key_provider(text) FROM %I', target_role);
 
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_principal_key_using_global_key_provider(text, text, BOOLEAN) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_server_principal_key_using_global_key_provider(text, text, BOOLEAN) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_default_principal_key_using_global_key_provider(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_key_using_global_key_provider(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_server_key_using_global_key_provider(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_default_key_using_global_key_provider(text, text, BOOLEAN) FROM %I', target_role);
 END;
 $$;
 
@@ -656,7 +656,7 @@ BEGIN
 
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_delete_database_key_provider(text) FROM %I', target_role);
 
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_principal_key_using_database_key_provider(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_key_using_database_key_provider(text, text, BOOLEAN) FROM %I', target_role);
 END;
 $$;
 
@@ -670,10 +670,10 @@ BEGIN
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_list_all_database_key_providers() FROM %I', target_role);
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_list_all_global_key_providers() FROM %I', target_role);
 
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_principal_key_info() FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_server_principal_key_info() FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_verify_principal_key() FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_verify_server_principal_key() FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_key_info() FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_server_key_info() FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_verify_key() FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_verify_server_key() FROM %I', target_role);
 END;
 $$;
 

--- a/contrib/pg_tde/sql/access_control.sql
+++ b/contrib/pg_tde/sql/access_control.sql
@@ -6,7 +6,7 @@ SET ROLE regress_pg_tde_access_control;
 
 -- should throw access denied
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key', 'file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
 
 RESET ROLE;
 
@@ -18,9 +18,9 @@ SET ROLE regress_pg_tde_access_control;
 -- should now be allowed
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key', 'file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
 SELECT * FROM pg_tde_list_all_database_key_providers();
-SELECT principal_key_name, key_provider_name, key_provider_id FROM pg_tde_principal_key_info();
+SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_key_info();
 
 RESET ROLE;
 
@@ -30,7 +30,7 @@ SET ROLE regress_pg_tde_access_control;
 
 -- verify the view access is revoked
 SELECT * FROM pg_tde_list_all_database_key_providers();
-SELECT principal_key_name, key_provider_name, key_provider_id FROM pg_tde_principal_key_info();
+SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_key_info();
 
 RESET ROLE;
 

--- a/contrib/pg_tde/sql/alter_index.sql
+++ b/contrib/pg_tde/sql/alter_index.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 SET default_table_access_method = "tde_heap";
 

--- a/contrib/pg_tde/sql/cache_alloc.sql
+++ b/contrib/pg_tde/sql/cache_alloc.sql
@@ -3,7 +3,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 do $$
     DECLARE idx integer;

--- a/contrib/pg_tde/sql/change_access_method.sql
+++ b/contrib/pg_tde/sql/change_access_method.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,

--- a/contrib/pg_tde/sql/default_principal_key.sql
+++ b/contrib/pg_tde/sql/default_principal_key.sql
@@ -1,16 +1,16 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_principal_key.per');
+SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_key.per');
 
-SELECT pg_tde_set_default_principal_key_using_global_key_provider('default-principal-key', 'file-provider', false);
+SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'file-provider', false);
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-provider');
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 
 -- Should fail: no principal key for the database yet
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
  
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
@@ -22,8 +22,8 @@ CREATE TABLE test_enc(
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
 
 -- Should succeed: create table localized the principal key
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
 
 SELECT current_database() AS regress_database
 \gset
@@ -35,8 +35,8 @@ CREATE DATABASE regress_pg_tde_other;
 CREATE EXTENSION pg_tde;
 
 -- Should fail: no principal key for the database yet
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
 
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
@@ -48,20 +48,20 @@ CREATE TABLE test_enc(
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
 
 -- Should succeed: create table localized the principal key
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
 
 \c :regress_database
 
-SELECT pg_tde_set_default_principal_key_using_global_key_provider('new-default-principal-key', 'file-provider', false);
+SELECT pg_tde_set_default_key_using_global_key_provider('new-default-key', 'file-provider', false);
 
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
 
 \c regress_pg_tde_other
 
-SELECT  key_provider_id, key_provider_name, principal_key_name
-		FROM pg_tde_principal_key_info();
+SELECT  key_provider_id, key_provider_name, key_name
+		FROM pg_tde_key_info();
 
 DROP TABLE test_enc;
 

--- a/contrib/pg_tde/sql/delete_key_provider.sql
+++ b/contrib/pg_tde/sql/delete_key_provider.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT  * FROM pg_tde_principal_key_info();
+SELECT  * FROM pg_tde_key_info();
 
 SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
 SELECT * FROM pg_tde_list_all_database_key_providers();

--- a/contrib/pg_tde/sql/insert_update_delete.sql
+++ b/contrib/pg_tde/sql/insert_update_delete.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 CREATE TABLE albums (
     id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT  * FROM pg_tde_principal_key_info();
+SELECT  * FROM pg_tde_key_info();
 
 SELECT pg_tde_add_database_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 SELECT * FROM pg_tde_list_all_database_key_providers();
@@ -11,17 +11,17 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
 SELECT pg_tde_add_database_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
 SELECT * FROM pg_tde_list_all_database_key_providers();
 
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');
+SELECT pg_tde_verify_key();
 
 SELECT pg_tde_change_database_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
 SELECT * FROM pg_tde_list_all_database_key_providers();
 
 SELECT pg_tde_change_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_other.per');
 SELECT * FROM pg_tde_list_all_database_key_providers();
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 
 SELECT pg_tde_change_database_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 SELECT * FROM pg_tde_list_all_database_key_providers();
@@ -44,7 +44,7 @@ SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
 
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 
-SELECT pg_tde_set_principal_key_using_global_key_provider('test-db-principal-key', 'file-keyring', false);
+SELECT pg_tde_set_key_using_global_key_provider('test-db-key', 'file-keyring', false);
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-keyring');

--- a/contrib/pg_tde/sql/keyprovider_dependency.sql
+++ b/contrib/pg_tde/sql/keyprovider_dependency.sql
@@ -6,6 +6,6 @@ SELECT pg_tde_add_database_key_provider_vault_v2('V2-vault','vault-token','perco
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
 
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','mk-file');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','mk-file');
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/kmip_test.sql
+++ b/contrib/pg_tde/sql/kmip_test.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_database_key_provider_kmip('kmip-prov','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_key_jane_doe.pem');
-SELECT pg_tde_set_principal_key_using_database_key_provider('kmip-principal-key','kmip-prov');
+SELECT pg_tde_set_key_using_database_key_provider('kmip-key','kmip-prov');
 
 CREATE TABLE test_enc(
 	  id SERIAL,

--- a/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
+++ b/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
@@ -1,9 +1,9 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT * FROM pg_tde_principal_key_info();
+SELECT * FROM pg_tde_key_info();
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 CREATE TABLE test_enc(
 	  id SERIAL,
@@ -33,8 +33,8 @@ SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_pkey'), ('t
 
 SELECT pg_tde_is_encrypted(NULL);
 
-SELECT key_provider_id, key_provider_name, principal_key_name
-    FROM pg_tde_principal_key_info();
+SELECT key_provider_id, key_provider_name, key_name
+    FROM pg_tde_key_info();
 
 DROP TABLE test_part;
 DROP TABLE test_norm;

--- a/contrib/pg_tde/sql/recreate_storage.sql
+++ b/contrib/pg_tde/sql/recreate_storage.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 SET default_table_access_method = "tde_heap";
 

--- a/contrib/pg_tde/sql/subtransaction.sql
+++ b/contrib/pg_tde/sql/subtransaction.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 
 BEGIN;                      -- Nesting level 1

--- a/contrib/pg_tde/sql/tablespace.sql
+++ b/contrib/pg_tde/sql/tablespace.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 CREATE TABLE test(num1 bigint, num2 double precision, t text) USING tde_heap;
 INSERT INTO test(num1, num2, t)

--- a/contrib/pg_tde/sql/toast_decrypt.sql
+++ b/contrib/pg_tde/sql/toast_decrypt.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 CREATE TABLE src (f1 TEXT STORAGE EXTERNAL) USING tde_heap;
 INSERT INTO src VALUES(repeat('abcdeF',1000));

--- a/contrib/pg_tde/sql/vault_v2_test.sql
+++ b/contrib/pg_tde/sql/vault_v2_test.sql
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
 -- FAILS
-SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-incorrect');
+SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-incorrect');
 
 CREATE TABLE test_enc(
 	  id SERIAL,
@@ -13,7 +13,7 @@ CREATE TABLE test_enc(
 	) USING tde_heap;
 
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
-SELECT pg_tde_set_principal_key_using_database_key_provider('vault-v2-principal-key','vault-v2');
+SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-v2');
 
 CREATE TABLE test_enc(
 	  id SERIAL,

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -162,7 +162,7 @@ pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type
 	{
 		ereport(ERROR,
 				(errmsg("principal key not configured"),
-				 errhint("create one using pg_tde_set_principal_key before using encrypted tables")));
+				 errhint("create one using pg_tde_set_key before using encrypted tables")));
 	}
 
 	/*
@@ -235,7 +235,7 @@ pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocat
 	{
 		ereport(ERROR,
 				(errmsg("principal key not configured"),
-				 errhint("create one using pg_tde_set_server_principal_key before using encrypted WAL")));
+				 errhint("create one using pg_tde_set_server_key before using encrypted WAL")));
 	}
 
 	/* TODO: no need in generating key if TDE_KEY_TYPE_WAL_UNENCRYPTED */
@@ -960,7 +960,7 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type)
 	if (principal_key == NULL)
 		ereport(ERROR,
 				(errmsg("principal key not configured"),
-				 errhint("create one using pg_tde_set_principal_key before using encrypted tables")));
+				 errhint("create one using pg_tde_set_key before using encrypted tables")));
 
 	rel_key = tde_decrypt_rel_key(principal_key, map_entry);
 

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -64,8 +64,7 @@ checkEncryptionClause(const char *accessMethod)
 		{
 			ereport(ERROR,
 					(errmsg("principal key not configured"),
-					 errhint("create one using pg_tde_set_principal_key before using encrypted tables")));
-
+					 errhint("create one using pg_tde_set_key before using encrypted tables")));
 		}
 	}
 

--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -46,7 +46,7 @@ $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 $rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -54,7 +54,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
@@ -67,7 +67,7 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;'
 PGTDE::append_to_file($stdout);
 
 #rotate key
-$stdout = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('rotated-principal-key1');", extra_params => ['-a']);
+$stdout = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -77,9 +77,9 @@ PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
 
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
@@ -87,7 +87,7 @@ PGTDE::append_to_file($stdout);
 
 
 #Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('rotated-principal-key2','file-2');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -97,16 +97,16 @@ PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
 
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 #Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_global_key_provider('rotated-principal-key', 'file-3', false);", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-key', 'file-3', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -116,9 +116,9 @@ PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
 
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
@@ -128,7 +128,7 @@ PGTDE::append_to_file($stdout);
 # And maybe debug tools to show what's in a file keyring?
 
 #Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_global_key_provider('rotated-principal-keyX', 'file-2', false);", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX', 'file-2', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -138,9 +138,9 @@ PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
 
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
@@ -156,19 +156,19 @@ $rt_value = $node->stop();
 $rt_value = $node->start();
 
 # But now can't be changed to another global provider
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_global_key_provider('rotated-principal-keyX2', 'file-2', false);", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX2', 'file-2', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stderr);
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('rotated-principal-key2','file-2');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();", extra_params => ['-a']);
+($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -71,7 +71,7 @@ ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
 $rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello' ));", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/004_file_config.pl
+++ b/contrib/pg_tde/t/004_file_config.pl
@@ -35,7 +35,7 @@ ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
 $rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/005_multiple_extensions.pl
+++ b/contrib/pg_tde/t/005_multiple_extensions.pl
@@ -87,7 +87,7 @@ ok($cmdret == 0, "CREATE postgis_tiger_geocoder EXTENSION");
 PGTDE::append_to_debug_file($stdout);
 
 $rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-provider');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -79,7 +79,7 @@ ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
 $rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url' ), to_json('secret'::text), NULL);", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','vault-provider');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','vault-provider');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -50,7 +50,7 @@ $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 $rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');", extra_params => ['-a']);
 
 
 

--- a/contrib/pg_tde/t/008_key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/008_key_rotate_tablespace.pl
@@ -38,7 +38,7 @@ $stdout = $node->safe_psql('tbc',
 	q{
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,
@@ -57,7 +57,7 @@ SELECT * FROM country_table;
 PGTDE::append_to_file($stdout);
 
 
-$cmdret = $node->psql('tbc', "SELECT pg_tde_set_principal_key_using_database_key_provider('new-k', 'file-vault');", extra_params => ['-a']);
+$cmdret = $node->psql('tbc', "SELECT pg_tde_set_key_using_database_key_provider('new-k', 'file-vault');", extra_params => ['-a']);
 ok($cmdret == 0, "ROTATE KEY");
 PGTDE::append_to_file($stdout);
 

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -33,7 +33,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_using_global_key_provider('server-principal-key', 'file-keyring-010');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-010');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;', extra_params => ['-a']);

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -39,7 +39,7 @@ $stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-key', 'file-vault');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
@@ -47,7 +47,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc (k) VALUES (5), (6);', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -62,7 +62,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -75,7 +75,7 @@ $rt_value = $node->stop();
 $rt_value = $node->start();
 
 # Verify
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -88,7 +88,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
@@ -102,7 +102,7 @@ $rt_value = $node->stop();
 $rt_value = $node->start();
 
 # Verify
-(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 (undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
@@ -121,7 +121,7 @@ $rt_value = $node->stop();
 $rt_value = $node->start();
 
 # Verify
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -141,7 +141,7 @@ PGTDE::append_to_file($stdout);
 # Change provider and generate a new principal key
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-$stdout = $node->psql('postgres', "SELECT pg_tde_set_principal_key_using_database_key_provider('test-key', 'file-vault');", extra_params => ['-a']);
+$stdout = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
@@ -149,7 +149,7 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc (k) VALUES (5), (6);', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -165,7 +165,7 @@ $rt_value = $node->stop();
 $rt_value = $node->start();
 
 # Verify
-(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 (undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
@@ -182,7 +182,7 @@ $stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provid
 PGTDE::append_to_file($stdout);
 
 # Verify
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_principal_key();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -11,7 +11,7 @@ SELECT pg_tde_add_global_key_provider_file('file-3','/tmp/pg_tde_test_keyring_3.
 SELECT pg_tde_list_all_database_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring.per""}")
 (2,file-2,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring_2.per""}")
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5),(6);
@@ -23,71 +23,71 @@ SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
 -- server restart
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
-1|file-vault|rotated-principal-key1
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
+1|file-vault|rotated-key1
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
-SELECT pg_tde_set_principal_key_using_database_key_provider('rotated-principal-key2','file-2');
+SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');
 
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
 -- server restart
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
-2|file-2|rotated-principal-key2
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
+2|file-2|rotated-key2
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
-SELECT pg_tde_set_principal_key_using_global_key_provider('rotated-principal-key', 'file-3', false);
+SELECT pg_tde_set_key_using_global_key_provider('rotated-key', 'file-3', false);
 
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
 -- server restart
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
--2|file-3|rotated-principal-key
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
+-2|file-3|rotated-key
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
-SELECT pg_tde_set_principal_key_using_global_key_provider('rotated-principal-keyX', 'file-2', false);
+SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX', 'file-2', false);
 
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
 -- server restart
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
--1|file-2|rotated-principal-keyX
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
+-1|file-2|rotated-keyX
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
 ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;
 -- server restart
 psql:<stdin>:1: ERROR:  Usage of global key providers is disabled. Enable it with pg_tde.inherit_global_providers = ON
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
--1|file-2|rotated-principal-keyX
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
+-1|file-2|rotated-keyX
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
-SELECT pg_tde_set_principal_key_using_database_key_provider('rotated-principal-key2','file-2');
+HINT:  Use set_key interface to set the principal key
+SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');
 
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
-2|file-2|rotated-principal-key2
-SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_server_principal_key_info();
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
+2|file-2|rotated-key2
+SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_principal_key interface to set the principal key
+HINT:  Use set_key interface to set the principal key
 DROP TABLE test_enc;
 ALTER SYSTEM RESET pg_tde.inherit_global_providers;
 DROP EXTENSION pg_tde CASCADE;

--- a/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
+++ b/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 1
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,
@@ -19,7 +19,7 @@ SELECT * FROM country_table;
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 1
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-db-principal-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
 CREATE TABLE country_table (
      country_id        serial primary key,

--- a/contrib/pg_tde/t/expected/009_wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/009_wal_encrypt.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');
 -1
-SELECT pg_tde_set_server_principal_key_using_global_key_provider('server-principal-key', 'file-keyring-010');
+SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-010');
 
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 -- server restart with wal encryption

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -3,11 +3,11 @@ SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_prov
 1
 SELECT pg_tde_list_all_database_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_1.per""}")
-SELECT pg_tde_set_principal_key_using_database_key_provider('test-key', 'file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');
 
 CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5), (6);
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 
 SELECT pg_tde_is_encrypted('test_enc');
 t
@@ -19,7 +19,7 @@ SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_p
 1
 SELECT pg_tde_list_all_database_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_2.per""}")
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 
 SELECT pg_tde_is_encrypted('test_enc');
 t
@@ -27,7 +27,7 @@ SELECT * FROM test_enc ORDER BY id;
 1|5
 2|6
 -- server restart
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 
 SELECT pg_tde_is_encrypted('test_enc');
 t
@@ -38,7 +38,7 @@ SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_p
 1
 SELECT pg_tde_list_all_database_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_3.per""}")
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
 SELECT pg_tde_is_encrypted('test_enc');
 t
@@ -46,7 +46,7 @@ SELECT * FROM test_enc ORDER BY id;
 1|5
 2|6
 -- server restart
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
 SELECT pg_tde_is_encrypted('test_enc');
 psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
@@ -54,7 +54,7 @@ SELECT * FROM test_enc ORDER BY id;
 psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
 -- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_3.per
 -- server restart
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 
 SELECT pg_tde_is_encrypted('test_enc');
 t
@@ -69,7 +69,7 @@ SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_prov
 0
 CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5), (6);
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 
 SELECT pg_tde_is_encrypted('test_enc');
 t
@@ -79,7 +79,7 @@ SELECT * FROM test_enc ORDER BY id;
 SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');
 1
 -- server restart
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, incorrect principal key or corrupted key file
 SELECT pg_tde_is_encrypted('test_enc');
 psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, incorrect principal key or corrupted key file
@@ -89,7 +89,7 @@ CREATE TABLE test_enc2 (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
 psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, incorrect principal key or corrupted key file
 SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');
 1
-SELECT pg_tde_verify_principal_key();
+SELECT pg_tde_verify_key();
 
 SELECT pg_tde_is_encrypted('test_enc');
 t

--- a/src/bin/pg_waldump/t/003_basic_encrypted.pl
+++ b/src/bin/pg_waldump/t/003_basic_encrypted.pl
@@ -28,7 +28,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');");;
-$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_using_global_key_provider('server-principal-key', 'file-keyring-wal');");
+$node->safe_psql('postgres', "SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-wal');");
 
 $node->append_conf(
 	'postgresql.conf', q{

--- a/src/bin/pg_waldump/t/004_save_fullpage_encrypted.pl
+++ b/src/bin/pg_waldump/t/004_save_fullpage_encrypted.pl
@@ -42,7 +42,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');");;
-$node->safe_psql('postgres', "SELECT pg_tde_set_server_principal_key_using_global_key_provider('server-principal-key', 'file-keyring-wal');");
+$node->safe_psql('postgres', "SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-wal');");
 
 $node->append_conf(
 	'postgresql.conf', q{


### PR DESCRIPTION
PG-1457

This PR replaces `principal key` with just a `key` on user API level, as it's the only key that user can directly interact with.