### PR TITLE
Initialize the whole WAL record when creating internal keys

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -190,6 +190,7 @@ pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type
 	 */
 	xlrec.rlocator = *newrlocator;
 	xlrec.relKey = *enc_rel_key_data;
+	xlrec.pkInfo = principal_key->keyInfo;
 
 	XLogBeginInsert();
 	XLogRegisterData((char *) &xlrec, sizeof(xlrec));

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -55,14 +55,10 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 
 	if (info == XLOG_TDE_ADD_RELATION_KEY)
 	{
-		TDEPrincipalKeyInfo *pk = NULL;
 		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
 
-		if (xlrec->pkInfo.databaseId != 0)
-			pk = &xlrec->pkInfo;
-
 		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
-		pg_tde_write_key_map_entry(&xlrec->rlocator, &xlrec->relKey, pk);
+		pg_tde_write_key_map_entry(&xlrec->rlocator, &xlrec->relKey, &xlrec->pkInfo);
 		LWLockRelease(tde_lwlock_enc_keys());
 	}
 	else if (info == XLOG_TDE_ADD_PRINCIPAL_KEY || info == XLOG_TDE_UPDATE_PRINCIPAL_KEY)


### PR DESCRIPTION
The WAL record has a field for which principal key was used to encrypt the internal key but it was never initialized. The reaosn it worked is because if we were lucky enough to have the data on stack be zero we would treat it as no principal key info was passed and that code path worked well since the parameter is optional.

Alternatively we could drop the field from the WAL record and pass NULL instead pg_tde_write_map_entry() since that seems to so far have worked.