### PR TITLE
Close file descriptor when header is invalid

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -1243,6 +1243,7 @@ pg_tde_file_header_read(char *tde_filename, int fd, TDEFileHeader *fheader, bool
 		|| fheader->file_version != PG_TDE_FILEMAGIC)
 	{
 		/* Corrupt file */
+		close(fd);
 		ereport(FATAL,
 				(errcode_for_file_access(),
 				 errmsg("TDE map file \"%s\" is corrupted: %m",


### PR DESCRIPTION
We forgot the close the file before raising an exception when we got
    the wrong magic number or length.

Plus removing an unused return value.