### PR TITLE
 PG-829 Remove `XLOG_TDE_UPDATE_PRINCIPAL_KEY` plus related code

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -317,7 +317,7 @@ pg_tde_delete_tde_files(Oid dbOid)
  *
  * The caller must have an EXCLUSIVE LOCK on the files before calling this function.
  */
-bool
+void
 pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info)
 {
 	int			map_fd = -1;
@@ -341,8 +341,6 @@ pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info)
 	/* Closing files. */
 	close(map_fd);
 	close(keydata_fd);
-
-	return (is_new_map && is_new_key_data);
 }
 
 /*

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -61,16 +61,12 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 		pg_tde_write_key_map_entry(&xlrec->rlocator, &xlrec->relKey, &xlrec->pkInfo);
 		LWLockRelease(tde_lwlock_enc_keys());
 	}
-	else if (info == XLOG_TDE_ADD_PRINCIPAL_KEY || info == XLOG_TDE_UPDATE_PRINCIPAL_KEY)
+	else if (info == XLOG_TDE_ADD_PRINCIPAL_KEY)
 	{
 		TDEPrincipalKeyInfo *mkey = (TDEPrincipalKeyInfo *) XLogRecGetData(record);
 
 		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
-		if (info == XLOG_TDE_ADD_PRINCIPAL_KEY)
-			create_principal_key_info(mkey);
-		else
-			update_principal_key_info(mkey);
-
+		create_principal_key_info(mkey);
 		LWLockRelease(tde_lwlock_enc_keys());
 	}
 	else if (info == XLOG_TDE_EXTENSION_INSTALL_KEY)
@@ -128,12 +124,6 @@ tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 
 		appendStringInfo(buf, "add tde principal key for db %u", xlrec->databaseId);
 	}
-	if (info == XLOG_TDE_UPDATE_PRINCIPAL_KEY)
-	{
-		TDEPrincipalKeyInfo *xlrec = (TDEPrincipalKeyInfo *) XLogRecGetData(record);
-
-		appendStringInfo(buf, "Alter key provider to:%d for tde principal key for db %u", xlrec->keyringId, xlrec->databaseId);
-	}
 	if (info == XLOG_TDE_EXTENSION_INSTALL_KEY)
 	{
 		XLogExtensionInstall *xlrec = (XLogExtensionInstall *) XLogRecGetData(record);
@@ -162,9 +152,6 @@ tdeheap_rmgr_identify(uint8 info)
 
 	if ((info & ~XLR_INFO_MASK) == XLOG_TDE_ADD_PRINCIPAL_KEY)
 		return "XLOG_TDE_ADD_PRINCIPAL_KEY";
-
-	if ((info & ~XLR_INFO_MASK) == XLOG_TDE_UPDATE_PRINCIPAL_KEY)
-		return "XLOG_TDE_UPDATE_PRINCIPAL_KEY";
 
 	if ((info & ~XLR_INFO_MASK) == XLOG_TDE_EXTENSION_INSTALL_KEY)
 		return "XLOG_TDE_EXTENSION_INSTALL_KEY";

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -66,7 +66,7 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 		TDEPrincipalKeyInfo *mkey = (TDEPrincipalKeyInfo *) XLogRecGetData(record);
 
 		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
-		create_principal_key_info(mkey);
+		pg_tde_save_principal_key(mkey);
 		LWLockRelease(tde_lwlock_enc_keys());
 	}
 	else if (info == XLOG_TDE_EXTENSION_INSTALL_KEY)

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -253,14 +253,6 @@ shared_memory_shutdown(int code, Datum arg)
 }
 
 bool
-create_principal_key_info(TDEPrincipalKeyInfo *principal_key_info)
-{
-	Assert(principal_key_info != NULL);
-
-	return pg_tde_save_principal_key(principal_key_info);
-}
-
-bool
 set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 							   Oid providerOid, Oid dbOid, bool ensure_new_key)
 {
@@ -347,7 +339,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 	if (!already_has_key)
 	{
 		/* First key created for the database */
-		create_principal_key_info(&new_principal_key->keyInfo);
+		pg_tde_save_principal_key(&new_principal_key->keyInfo);
 
 		/* XLog the new key */
 		XLogBeginInsert();
@@ -847,7 +839,7 @@ GetPrincipalKey(Oid dbOid, LWLockMode lockMode)
 	*newPrincipalKey = *principalKey;
 	newPrincipalKey->keyInfo.databaseId = dbOid;
 
-	create_principal_key_info(&newPrincipalKey->keyInfo);
+	pg_tde_save_principal_key(&newPrincipalKey->keyInfo);
 
 	/* XLog the new use of the default key */
 	XLogBeginInsert();

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -257,14 +257,7 @@ create_principal_key_info(TDEPrincipalKeyInfo *principal_key_info)
 {
 	Assert(principal_key_info != NULL);
 
-	return pg_tde_save_principal_key(principal_key_info, true, true);
-}
-
-bool
-update_principal_key_info(TDEPrincipalKeyInfo *principal_key_info)
-{
-	Assert(principal_key_info != NULL);
-	return pg_tde_save_principal_key(principal_key_info, false, true);
+	return pg_tde_save_principal_key(principal_key_info);
 }
 
 bool

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -100,7 +100,7 @@ extern InternalKey *GetSMGRRelationKey(RelFileLocatorBackend rel);
 extern void pg_tde_delete_tde_files(Oid dbOid);
 
 extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
-extern bool pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info, bool truncate_existing, bool update_header);
+extern bool pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info);
 extern bool pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern bool pg_tde_write_map_keydata_files(off_t map_size, char *m_file_data, off_t keydata_size, char *k_file_data);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -100,7 +100,7 @@ extern InternalKey *GetSMGRRelationKey(RelFileLocatorBackend rel);
 extern void pg_tde_delete_tde_files(Oid dbOid);
 
 extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
-extern bool pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info);
+extern void pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info);
 extern bool pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern bool pg_tde_write_map_keydata_files(off_t map_size, char *m_file_data, off_t keydata_size, char *k_file_data);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog.h
@@ -20,7 +20,6 @@
 #define XLOG_TDE_ROTATE_KEY				0x30
 #define XLOG_TDE_ADD_KEY_PROVIDER_KEY 	0x40
 #define XLOG_TDE_FREE_MAP_ENTRY		 	0x50
-#define XLOG_TDE_UPDATE_PRINCIPAL_KEY	0x60
 
 /* ID 140 is registered for Percona TDE extension: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
 #define RM_TDERMGR_ID	140

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -57,10 +57,7 @@ extern TDEPrincipalKey *GetPrincipalKeyNoDefault(Oid dbOid, void *lockMode);
 #endif
 
 extern bool create_principal_key_info(TDEPrincipalKeyInfo *principalKeyInfo);
-extern bool update_principal_key_info(TDEPrincipalKeyInfo *principal_key_info);
-
 extern bool xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec);
-
 extern TDEPrincipalKey *get_principal_key_from_keyring(Oid dbOid);
 
 #endif							/* PG_TDE_PRINCIPAL_KEY_H */

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -56,7 +56,6 @@ extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, void *lockMode);
 extern TDEPrincipalKey *GetPrincipalKeyNoDefault(Oid dbOid, void *lockMode);
 #endif
 
-extern bool create_principal_key_info(TDEPrincipalKeyInfo *principalKeyInfo);
 extern bool xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec);
 extern TDEPrincipalKey *get_principal_key_from_keyring(Oid dbOid);
 


### PR DESCRIPTION
Updating of principal keys has not been used since commit
    06885e3559f56ded3e83548992695bd351fb5fc0 and the code is broken anyway
    due to the byte offset being wrong after writing a header to the map
    file.

We also remove this broken code plus other code which was used to try to implement updating of principal keys. Updating a principal key does not make sense since we must reencrypt the keys anyway which we properly do in the rotation code.