### PR TITLE
Simplify counting of `tde_heap` tables

### DIFF
--- a/contrib/pg_tde/src/common/pg_tde_utils.c
+++ b/contrib/pg_tde/src/common/pg_tde_utils.c
@@ -52,15 +52,15 @@ pg_tde_is_encrypted(PG_FUNCTION_ARGS)
 }
 
 /*
- * Returns the list of OIDs for all TDE tables in a database
+ * Returns the number of TDE tables in a database
  */
-List *
-get_all_tde_tables(void)
+int
+get_tde_tables_count(void)
 {
 	Relation	pg_class;
 	SysScanDesc scan;
 	HeapTuple	tuple;
-	List	   *tde_tables = NIL;
+	int			count = 0;
 	Oid			am_oid = get_tde_table_am_oid();
 
 	/* Open the pg_class table */
@@ -77,11 +77,7 @@ get_all_tde_tables(void)
 
 		/* Check if the table uses the specified access method */
 		if (classForm->relam == am_oid)
-		{
-			/* Print the name of the table */
-			tde_tables = lappend_oid(tde_tables, classForm->oid);
-			elog(DEBUG2, "Table %s uses the TDE access method.", NameStr(classForm->relname));
-		}
+			count++;
 	}
 
 	/* End the scan */
@@ -89,16 +85,6 @@ get_all_tde_tables(void)
 
 	/* Close the pg_class table */
 	table_close(pg_class, AccessShareLock);
-	return tde_tables;
-}
-
-int
-get_tde_tables_count(void)
-{
-	List	   *tde_tables = get_all_tde_tables();
-	int			count = list_length(tde_tables);
-
-	list_free(tde_tables);
 	return count;
 }
 

--- a/contrib/pg_tde/src/include/common/pg_tde_utils.h
+++ b/contrib/pg_tde/src/include/common/pg_tde_utils.h
@@ -8,12 +8,7 @@
 #ifndef PG_TDE_UTILS_H
 #define PG_TDE_UTILS_H
 
-#include "postgres.h"
-
 #ifndef FRONTEND
-#include "nodes/pg_list.h"
-
-extern List *get_all_tde_tables(void);
 extern int	get_tde_tables_count(void);
 #endif							/* !FRONTEND */
 


### PR DESCRIPTION
It is likely that we should remove this check but for now simplify it so the code does not look like it does something it actually does not.