### PR TITLE
PG-1512 Fix broken rotation of default keys

### DIFF
--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -1,4 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION IF NOT EXISTS pg_buffercache;
 SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_principal_key.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
@@ -44,6 +45,7 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 CREATE DATABASE regress_pg_tde_other;
 \c regress_pg_tde_other
 CREATE EXTENSION pg_tde;
+CREATE EXTENSION pg_buffercache;
 -- Should fail: no principal key for the database yet
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
@@ -65,6 +67,7 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 (1 row)
 
 \c regression_pg_tde
+CHECKPOINT;
 SELECT pg_tde_set_default_principal_key('new-default-principal-key', 'file-provider', false);
  pg_tde_set_default_principal_key 
 ----------------------------------
@@ -86,9 +89,38 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
               -3 | file-provider     | new-default-principal-key
 (1 row)
 
+SELECT pg_buffercache_evict(bufferid) FROM pg_buffercache WHERE relfilenode = (SELECT relfilenode FROM pg_class WHERE oid = 'test_enc'::regclass);
+ pg_buffercache_evict 
+----------------------
+ t
+(1 row)
+
+SELECT * FROM test_enc;
+ id | k 
+----+---
+  1 | 1
+  2 | 2
+  3 | 3
+(3 rows)
+
 DROP TABLE test_enc;
 DROP EXTENSION pg_tde CASCADE;
 \c regression_pg_tde
+SELECT pg_buffercache_evict(bufferid) FROM pg_buffercache WHERE relfilenode = (SELECT relfilenode FROM pg_class WHERE oid = 'test_enc'::regclass);
+ pg_buffercache_evict 
+----------------------
+ t
+(1 row)
+
+SELECT * FROM test_enc;
+ id | k 
+----+---
+  1 | 1
+  2 | 2
+  3 | 3
+(3 rows)
+
 DROP TABLE test_enc;
 DROP EXTENSION pg_tde CASCADE;
+DROP EXTENSION pg_buffercache;
 DROP DATABASE regress_pg_tde_other;

--- a/contrib/pg_tde/expected/default_principal_key_1.out
+++ b/contrib/pg_tde/expected/default_principal_key_1.out
@@ -1,17 +1,33 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 CREATE EXTENSION IF NOT EXISTS pg_buffercache;
-
 SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_principal_key.per');
+ pg_tde_add_global_key_provider_file 
+-------------------------------------
+                                  -4
+(1 row)
 
 SELECT pg_tde_set_default_principal_key('default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key 
+----------------------------------
+ t
+(1 row)
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-provider');
+ERROR:  Can't delete a provider which is currently in use
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
+ id |  provider_name  
+----+-----------------
+ -1 | reg_file-global
+ -3 | file-keyring2
+ -4 | file-provider
+(3 rows)
 
 -- Should fail: no principal key for the database yet
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
+ERROR:  Principal key does not exists for the database
+HINT:  Use set_principal_key interface to set the principal key
  
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
@@ -19,68 +35,96 @@ CREATE TABLE test_enc(
 	k INTEGER DEFAULT '0' NOT NULL,
 	PRIMARY KEY (id)
 ) USING tde_heap;
-
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
-
 -- Should succeed: create table localized the principal key
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
+ key_provider_id | key_provider_name |  principal_key_name   
+-----------------+-------------------+-----------------------
+              -4 | file-provider     | default-principal-key
+(1 row)
 
+SELECT current_database() AS regress_database
+\gset
 CREATE DATABASE regress_pg_tde_other;
-
 \c regress_pg_tde_other
-
 CREATE EXTENSION pg_tde;
 CREATE EXTENSION pg_buffercache;
-
 -- Should fail: no principal key for the database yet
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
-
+ERROR:  Principal key does not exists for the database
+HINT:  Use set_principal_key interface to set the principal key
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
 	id SERIAL,
 	k INTEGER DEFAULT '0' NOT NULL,
 	PRIMARY KEY (id)
 ) USING tde_heap;
-
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
-
 -- Should succeed: create table localized the principal key
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
+ key_provider_id | key_provider_name |  principal_key_name   
+-----------------+-------------------+-----------------------
+              -4 | file-provider     | default-principal-key
+(1 row)
 
-\c regression_pg_tde
-
+\c :regress_database
 CHECKPOINT;
-
 SELECT pg_tde_set_default_principal_key('new-default-principal-key', 'file-provider', false);
+ pg_tde_set_default_principal_key 
+----------------------------------
+ t
+(1 row)
 
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
+ key_provider_id | key_provider_name |    principal_key_name     
+-----------------+-------------------+---------------------------
+              -4 | file-provider     | new-default-principal-key
+(1 row)
 
 \c regress_pg_tde_other
-
 SELECT  key_provider_id, key_provider_name, principal_key_name
 		FROM pg_tde_principal_key_info();
+ key_provider_id | key_provider_name |    principal_key_name     
+-----------------+-------------------+---------------------------
+              -4 | file-provider     | new-default-principal-key
+(1 row)
 
 SELECT pg_buffercache_evict(bufferid) FROM pg_buffercache WHERE relfilenode = (SELECT relfilenode FROM pg_class WHERE oid = 'test_enc'::regclass);
+ pg_buffercache_evict 
+----------------------
+ t
+(1 row)
 
 SELECT * FROM test_enc;
+ id | k 
+----+---
+  1 | 1
+  2 | 2
+  3 | 3
+(3 rows)
 
 DROP TABLE test_enc;
-
 DROP EXTENSION pg_tde CASCADE;
-
-\c regression_pg_tde
-
+\c :regress_database
 SELECT pg_buffercache_evict(bufferid) FROM pg_buffercache WHERE relfilenode = (SELECT relfilenode FROM pg_class WHERE oid = 'test_enc'::regclass);
+ pg_buffercache_evict 
+----------------------
+ t
+(1 row)
 
 SELECT * FROM test_enc;
+ id | k 
+----+---
+  1 | 1
+  2 | 2
+  3 | 3
+(3 rows)
 
 DROP TABLE test_enc;
-
 DROP EXTENSION pg_tde CASCADE;
 DROP EXTENSION pg_buffercache;
-
 DROP DATABASE regress_pg_tde_other;


### PR DESCRIPTION
We had swapped the arguments when rotating default keys so the data, so this fixes that. And add a regression test which uses to pg_buffercache extension to simulate some of a server restart without having to write a TAP test.

This bug was found while implementing AES-128-GCM encryption of internal keys so that work is for sure worth it, if only to catch bugs.