### PR TITLE
Remove cached OpenSSL context from internal keys

### DIFF
--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -31,8 +31,6 @@ typedef struct InternalKey
 	uint32		rel_type;
 
 	XLogRecPtr	start_lsn;
-
-	void	   *ctx;
 } InternalKey;
 
 #define WALKeySetInvalid(key) \
@@ -63,6 +61,7 @@ typedef struct WALKeyCacheRec
 	XLogRecPtr	end_lsn;
 
 	InternalKey *key;
+	void	   *crypt_ctx;
 
 	struct WALKeyCacheRec *next;
 } WALKeyCacheRec;

--- a/contrib/pg_tde/src/include/encryption/enc_tde.h
+++ b/contrib/pg_tde/src/include/encryption/enc_tde.h
@@ -12,15 +12,15 @@
 
 #include "access/pg_tde_tdemap.h"
 
-extern void pg_tde_crypt(const char *iv_prefix, uint32 start_offset, const char *data, uint32 data_len, char *out, InternalKey *key, const char *context);
+extern void pg_tde_crypt(const char *iv_prefix, uint32 start_offset, const char *data, uint32 data_len, char *out, InternalKey *key, void **ctxPtr, const char *context);
 
 /* Function Macros over crypt */
 
-#define PG_TDE_ENCRYPT_DATA(_iv_prefix, _start_offset, _data, _data_len, _out, _key) \
-	pg_tde_crypt(_iv_prefix, _start_offset, _data, _data_len, _out, _key, "ENCRYPT")
+#define PG_TDE_ENCRYPT_DATA(_iv_prefix, _start_offset, _data, _data_len, _out, _key, _ctxptr) \
+	pg_tde_crypt(_iv_prefix, _start_offset, _data, _data_len, _out, _key, _ctxptr, "ENCRYPT")
 
-#define PG_TDE_DECRYPT_DATA(_iv_prefix, _start_offset, _data, _data_len, _out, _key) \
-	pg_tde_crypt(_iv_prefix, _start_offset, _data, _data_len, _out, _key, "DECRYPT")
+#define PG_TDE_DECRYPT_DATA(_iv_prefix, _start_offset, _data, _data_len, _out, _key, _ctxptr) \
+	pg_tde_crypt(_iv_prefix, _start_offset, _data, _data_len, _out, _key, _ctxptr, "DECRYPT")
 
 extern void AesEncryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, InternalKey *rel_key_data, InternalKey **p_enc_rel_key_data, size_t *enc_key_bytes);
 extern void AesDecryptKey(const TDEPrincipalKey *principal_key, Oid dbOid, InternalKey **p_rel_key_data, InternalKey *enc_rel_key_data, size_t *key_bytes);


### PR DESCRIPTION
Since only WAL encryption use the cached context it should not be part of every internal key. Instead store it in the WAL decryption key cache and the backend global state for WAL encryption.