### PR TITLE
PG-1419 Make sure `pg_tde_is_encrypted()` returns NULL on paritioned tables

### DIFF
--- a/contrib/pg_tde/README.md
+++ b/contrib/pg_tde/README.md
@@ -162,4 +162,6 @@ The extension provides the following helper functions:
 
 ### pg_tde_is_encrypted(tablename)
 
-Returns `t` if the relation is encrypted, or `f` otherwise.
+Returns `t` if the relation is encrypted, if unencrypted `f` or `NULL` if the
+relation lacks storage, i.e. views, foreign tables, and partitioning tables and
+indexes.

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -264,7 +264,9 @@ The `ensure_new_key` parameter instructs the function how to handle a principal 
 
 ### pg_tde_is_encrypted
 
-Tells if a relation is encrypted using the `pg_tde` extension or not.
+Tells if a relation is encrypted using the `pg_tde` extension or not. Returns
+`NULL` if a relation lacks storage like views, foreign tables, and partitioned
+tables and indexes.
 
 To verify that a table is encrypted, run the following statement:
 

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -24,53 +24,42 @@ CREATE TABLE test_norm(
 	  k INTEGER DEFAULT '0' NOT NULL,
 	  PRIMARY KEY (id)
 	) USING heap;
-SELECT amname FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = 'test_enc';
-  amname  
-----------
- tde_heap
-(1 row)
+CREATE TABLE test_part(
+	  id SERIAL,
+	  k INTEGER DEFAULT '0' NOT NULL,
+	  PRIMARY KEY (id)
+	) PARTITION BY RANGE (id) USING tde_heap;
+SELECT relname, amname FROM pg_class JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname IN ('test_enc', 'test_norm', 'test_part') ORDER BY relname;
+  relname  |  amname  
+-----------+----------
+ test_enc  | tde_heap
+ test_norm | heap
+ test_part | tde_heap
+(3 rows)
 
-SELECT amname FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = 'test_norm';
- amname 
---------
- heap
-(1 row)
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc'), ('test_norm'), ('test_part')) AS r (relname) ORDER BY relname;
+  relname  | pg_tde_is_encrypted 
+-----------+---------------------
+ test_enc  | t
+ test_norm | f
+ test_part | 
+(3 rows)
 
-SELECT pg_tde_is_encrypted('test_enc');
- pg_tde_is_encrypted 
----------------------
- t
-(1 row)
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_id_seq'), ('test_norm_id_seq'), ('test_part_id_seq')) AS r (relname) ORDER BY relname;
+     relname      | pg_tde_is_encrypted 
+------------------+---------------------
+ test_enc_id_seq  | t
+ test_norm_id_seq | f
+ test_part_id_seq | t
+(3 rows)
 
-SELECT pg_tde_is_encrypted('test_norm');
- pg_tde_is_encrypted 
----------------------
- f
-(1 row)
-
-SELECT pg_tde_is_encrypted('test_enc_id_seq');
- pg_tde_is_encrypted 
----------------------
- t
-(1 row)
-
-SELECT pg_tde_is_encrypted('test_norm_id_seq');
- pg_tde_is_encrypted 
----------------------
- f
-(1 row)
-
-SELECT pg_tde_is_encrypted('test_enc_pkey');
- pg_tde_is_encrypted 
----------------------
- t
-(1 row)
-
-SELECT pg_tde_is_encrypted('test_norm_pkey');
- pg_tde_is_encrypted 
----------------------
- f
-(1 row)
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_pkey'), ('test_norm_pkey'), ('test_part_pkey')) AS r (relname) ORDER BY relname;
+    relname     | pg_tde_is_encrypted 
+----------------+---------------------
+ test_enc_pkey  | t
+ test_norm_pkey | f
+ test_part_pkey | 
+(3 rows)
 
 SELECT pg_tde_is_encrypted(NULL);
  pg_tde_is_encrypted 
@@ -85,6 +74,7 @@ SELECT key_provider_id, key_provider_name, principal_key_name
                1 | file-vault        | test-db-principal-key
 (1 row)
 
-DROP TABLE test_enc;
+DROP TABLE test_part;
 DROP TABLE test_norm;
+DROP TABLE test_enc;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
+++ b/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
@@ -17,24 +17,27 @@ CREATE TABLE test_norm(
 	  PRIMARY KEY (id)
 	) USING heap;
 
-SELECT amname FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = 'test_enc';
-SELECT amname FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = 'test_norm';
+CREATE TABLE test_part(
+	  id SERIAL,
+	  k INTEGER DEFAULT '0' NOT NULL,
+	  PRIMARY KEY (id)
+	) PARTITION BY RANGE (id) USING tde_heap;
 
-SELECT pg_tde_is_encrypted('test_enc');
-SELECT pg_tde_is_encrypted('test_norm');
+SELECT relname, amname FROM pg_class JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname IN ('test_enc', 'test_norm', 'test_part') ORDER BY relname;
 
-SELECT pg_tde_is_encrypted('test_enc_id_seq');
-SELECT pg_tde_is_encrypted('test_norm_id_seq');
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc'), ('test_norm'), ('test_part')) AS r (relname) ORDER BY relname;
 
-SELECT pg_tde_is_encrypted('test_enc_pkey');
-SELECT pg_tde_is_encrypted('test_norm_pkey');
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_id_seq'), ('test_norm_id_seq'), ('test_part_id_seq')) AS r (relname) ORDER BY relname;
+
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_pkey'), ('test_norm_pkey'), ('test_part_pkey')) AS r (relname) ORDER BY relname;
 
 SELECT pg_tde_is_encrypted(NULL);
 
 SELECT key_provider_id, key_provider_name, principal_key_name
     FROM pg_tde_principal_key_info();
 
-DROP TABLE test_enc;
+DROP TABLE test_part;
 DROP TABLE test_norm;
+DROP TABLE test_enc;
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -1179,6 +1179,8 @@ pg_tde_get_principal_key_info(Oid dbOid)
 InternalKey *
 GetSMGRRelationKey(RelFileLocatorBackend rel)
 {
+	Assert(rel.locator.relNumber != InvalidRelFileNumber);
+
 	if (RelFileLocatorBackendIsTemp(rel))
 		return pg_tde_get_key_from_cache(&rel.locator, TDE_KEY_TYPE_SMGR);
 	else

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -1211,9 +1211,7 @@ pg_tde_get_key_from_cache(const RelFileLocator *rlocator, uint32 key_type)
 	{
 		RelKeyCacheRec *rec = tde_rel_key_cache.data + i;
 
-		if ((rlocator->relNumber == InvalidRelFileNumber ||
-			 RelFileLocatorEquals(rec->locator, *rlocator)) &&
-			rec->key.rel_type & key_type)
+		if (RelFileLocatorEquals(rec->locator, *rlocator) && rec->key.rel_type & key_type)
 		{
 			return &rec->key;
 		}


### PR DESCRIPTION
Since partitioned tables, and indexes, lack storage the "is encrypted"
    property is not relevant to them because encryption is done at the SMGR
    level. Therefore we should either throw an error or return NULL, and
    here we choose to return NULL to make the function easier to work with.

Additionally I remove some code which was supposed to be dead but instead caused us to get flaky behavior between true and false.