### PR TITLE
Unlock pages in the key cache after clearing them

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -1459,7 +1459,12 @@ pg_tde_put_key_into_cache(const RelFileLocator *rlocator, InternalKey *key)
 #endif
 
 		memcpy(cachePage, tde_rel_key_cache.data, old_size);
+
+		explicit_bzero(tde_rel_key_cache.data, old_size);
+		if (munlock(tde_rel_key_cache.data, old_size) == -1)
+			elog(WARNING, "could not munlock internal key cache pages: %m");
 		pfree(tde_rel_key_cache.data);
+
 		tde_rel_key_cache.data = cachePage;
 
 		if (mlock(tde_rel_key_cache.data, size) == -1)


### PR DESCRIPTION
While it is not necessarily much memory it is bad manners to lock more pages in memory than we need to.