### PR TITLE
Remove unused field from the TDE file header

### DIFF
--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -22,7 +22,6 @@
 typedef struct TDEPrincipalKeyInfo
 {
 	Oid			databaseId;
-	Oid			userId;
 	Oid			keyringId;
 	struct timeval creationTime;
 	char		name[PRINCIPAL_KEY_NAME_LEN];


### PR DESCRIPTION
The `userId` field of the principal key info has never been used since it was introduced in commit 210c95cf00cacc3304321950279201406708d09d so we can safely remove it.