### PR TITLE
Always raise error on failed key rotation, don't return bool

### DIFF
--- a/contrib/pg_tde/expected/access_control.out
+++ b/contrib/pg_tde/expected/access_control.out
@@ -36,7 +36,7 @@ SELECT pg_tde_add_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');
 SELECT pg_tde_set_principal_key('test-db-principal-key', 'file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 SELECT * FROM pg_tde_list_all_key_providers();

--- a/contrib/pg_tde/expected/alter_index.out
+++ b/contrib/pg_tde/expected/alter_index.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 SET default_table_access_method = "tde_heap";

--- a/contrib/pg_tde/expected/cache_alloc.out
+++ b/contrib/pg_tde/expected/cache_alloc.out
@@ -9,7 +9,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 do $$

--- a/contrib/pg_tde/expected/change_access_method.out
+++ b/contrib/pg_tde/expected/change_access_method.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 CREATE TABLE country_table (

--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regressi
 SELECT pg_tde_set_default_principal_key('default-principal-key', 'file-provider', false);
  pg_tde_set_default_principal_key 
 ----------------------------------
- t
+ 
 (1 row)
 
 -- fails
@@ -70,7 +70,7 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 SELECT pg_tde_set_default_principal_key('new-default-principal-key', 'file-provider', false);
  pg_tde_set_default_principal_key 
 ----------------------------------
- t
+ 
 (1 row)
 
 SELECT  key_provider_id, key_provider_name, principal_key_name

--- a/contrib/pg_tde/expected/default_principal_key_1.out
+++ b/contrib/pg_tde/expected/default_principal_key_1.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regressi
 SELECT pg_tde_set_default_principal_key('default-principal-key', 'file-provider', false);
  pg_tde_set_default_principal_key 
 ----------------------------------
- t
+ 
 (1 row)
 
 -- fails
@@ -71,7 +71,7 @@ SELECT  key_provider_id, key_provider_name, principal_key_name
 SELECT pg_tde_set_default_principal_key('new-default-principal-key', 'file-provider', false);
  pg_tde_set_default_principal_key 
 ----------------------------------
- t
+ 
 (1 row)
 
 SELECT  key_provider_id, key_provider_name, principal_key_name

--- a/contrib/pg_tde/expected/insert_update_delete.out
+++ b/contrib/pg_tde/expected/insert_update_delete.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 CREATE TABLE albums (

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -39,7 +39,7 @@ ERROR:  principal key not configured for current database
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 SELECT pg_tde_verify_principal_key();
@@ -135,7 +135,7 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 SELECT pg_tde_set_global_principal_key('test-db-principal-key', 'file-keyring', false);
  pg_tde_set_global_principal_key 
 ---------------------------------
- t
+ 
 (1 row)
 
 -- fails

--- a/contrib/pg_tde/expected/key_provider_1.out
+++ b/contrib/pg_tde/expected/key_provider_1.out
@@ -39,7 +39,7 @@ ERROR:  principal key not configured for current database
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-provider');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 SELECT pg_tde_verify_principal_key();
@@ -137,7 +137,7 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 SELECT pg_tde_set_global_principal_key('test-db-principal-key', 'file-keyring', false);
  pg_tde_set_global_principal_key 
 ---------------------------------
- t
+ 
 (1 row)
 
 -- fails

--- a/contrib/pg_tde/expected/keyprovider_dependency.out
+++ b/contrib/pg_tde/expected/keyprovider_dependency.out
@@ -28,7 +28,7 @@ SELECT * FROM pg_tde_list_all_key_providers();
 SELECT pg_tde_set_principal_key('test-db-principal-key','mk-file');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/kmip_test.out
+++ b/contrib/pg_tde/expected/kmip_test.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_kmip('kmip-prov','127.0.0.1', 5696, '/tmp/server_
 SELECT pg_tde_set_principal_key('kmip-principal-key','kmip-prov');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 CREATE TABLE test_enc(

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -11,7 +11,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 CREATE TABLE test_enc(

--- a/contrib/pg_tde/expected/recreate_storage.out
+++ b/contrib/pg_tde/expected/recreate_storage.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 SET default_table_access_method = "tde_heap";

--- a/contrib/pg_tde/expected/subtransaction.out
+++ b/contrib/pg_tde/expected/subtransaction.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 BEGIN;                      -- Nesting level 1

--- a/contrib/pg_tde/expected/tablespace.out
+++ b/contrib/pg_tde/expected/tablespace.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 CREATE TABLE test(num1 bigint, num2 double precision, t text) USING tde_heap;

--- a/contrib/pg_tde/expected/toast_decrypt.out
+++ b/contrib/pg_tde/expected/toast_decrypt.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 CREATE TABLE src (f1 TEXT STORAGE EXTERNAL) USING tde_heap;

--- a/contrib/pg_tde/expected/toast_decrypt_1.out
+++ b/contrib/pg_tde/expected/toast_decrypt_1.out
@@ -9,7 +9,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 CREATE TABLE src (f1 TEXT STORAGE EXTERNAL) USING tde_heap;

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -25,7 +25,7 @@ SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0
 SELECT pg_tde_set_principal_key('vault-v2-principal-key','vault-v2');
  pg_tde_set_principal_key 
 --------------------------
- t
+ 
 (1 row)
 
 CREATE TABLE test_enc(

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -102,7 +102,7 @@ BEGIN ATOMIC
 END;
 
 CREATE FUNCTION pg_tde_set_default_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
-RETURNS boolean
+RETURNS VOID
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
@@ -462,17 +462,17 @@ LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_set_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
-RETURNS boolean
+RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_set_global_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
-RETURNS boolean
+RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_set_server_principal_key(principal_key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
-RETURNS boolean
+RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -612,7 +612,7 @@ finalize_key_rotation(const char *path_old, const char *path_new)
 /*
  * Rotate keys and generates the WAL record for it.
  */
-bool
+void
 pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key)
 {
 #define OLD_PRINCIPAL_KEY	0
@@ -625,7 +625,6 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 	off_t		map_size;
 	XLogPrincipalKeyRotate *xlrec;
 	off_t		xlrec_size;
-	bool		success = true;
 
 	pg_tde_set_db_file_path(principal_key->keyInfo.databaseId, path[OLD_PRINCIPAL_KEY]);
 
@@ -682,9 +681,10 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 	xlrec->file_size = map_size;
 
 	/* TODO: pgstat_report_wait_start / pgstat_report_wait_end */
-	/* TODO: error handling */
 	if (pg_pread(fd[NEW_PRINCIPAL_KEY], xlrec->buff, xlrec->file_size, 0) == -1)
-		success = false;
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not write WAL for key rotation: %m")));
 
 	close(fd[NEW_PRINCIPAL_KEY]);
 
@@ -698,8 +698,6 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 
 	/* Free up the palloc'ed data */
 	pfree(xlrec);
-
-	return success;
 
 #undef OLD_PRINCIPAL_KEY
 #undef NEW_PRINCIPAL_KEY

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -97,7 +97,7 @@ static bool pg_tde_is_same_principal_key(TDEPrincipalKey *a, TDEPrincipalKey *b)
 static void pg_tde_update_global_principal_key_everywhere(TDEPrincipalKey *oldKey, TDEPrincipalKey *newKey);
 static void push_principal_key_to_cache(TDEPrincipalKey *principalKey);
 static Datum pg_tde_get_key_info(PG_FUNCTION_ARGS, Oid dbOid);
-static bool set_principal_key_with_keyring(const char *key_name,
+static void set_principal_key_with_keyring(const char *key_name,
 										   const char *provider_name,
 										   Oid providerOid,
 										   Oid dbOid,
@@ -127,10 +127,7 @@ enum global_status
 	GS_DEFAULT
 };
 
-static Datum
-			pg_tde_set_principal_key_internal(char *principal_key_name, enum global_status global, char *provider_name, bool ensure_new_key);
-
-
+static void pg_tde_set_principal_key_internal(char *principal_key_name, enum global_status global, char *provider_name, bool ensure_new_key);
 
 static const TDEShmemSetupRoutine principal_key_info_shmem_routine = {
 	.init_shared_state = initialize_shared_state,
@@ -253,7 +250,7 @@ shared_memory_shutdown(int code, Datum arg)
 	principalKeyLocalState.sharedPrincipalKeyState = NULL;
 }
 
-bool
+void
 set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 							   Oid providerOid, Oid dbOid, bool ensure_new_key)
 {
@@ -263,7 +260,6 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 	bool		already_has_key = false;
 	GenericKeyring *new_keyring;
 	const KeyInfo *keyInfo = NULL;
-	bool		success = true;
 
 	if (AllowInheritGlobalProviders == false && providerOid != dbOid)
 	{
@@ -352,22 +348,18 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 	else
 	{
 		/* key rotation */
-		bool		is_rotated = pg_tde_perform_rotate_key(curr_principal_key, new_principal_key);
+		pg_tde_perform_rotate_key(curr_principal_key, new_principal_key);
 
-		if (is_rotated && (!TDEisInGlobalSpace(curr_principal_key->keyInfo.databaseId)))
+		if (!TDEisInGlobalSpace(curr_principal_key->keyInfo.databaseId))
 		{
 			clear_principal_key_cache(curr_principal_key->keyInfo.databaseId);
 			push_principal_key_to_cache(new_principal_key);
 		}
-
-		success = is_rotated;
 	}
 
 	LWLockRelease(lock_files);
 
 	pfree(new_keyring);
-
-	return success;
 }
 
 /*
@@ -503,7 +495,9 @@ pg_tde_set_default_principal_key(PG_FUNCTION_ARGS)
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
 	bool		ensure_new_key = PG_GETARG_BOOL(2);
 
-	return pg_tde_set_principal_key_internal(principal_key_name, GS_DEFAULT, provider_name, ensure_new_key);
+	pg_tde_set_principal_key_internal(principal_key_name, GS_DEFAULT, provider_name, ensure_new_key);
+
+	PG_RETURN_VOID();
 }
 
 Datum
@@ -513,7 +507,9 @@ pg_tde_set_principal_key(PG_FUNCTION_ARGS)
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
 	bool		ensure_new_key = PG_GETARG_BOOL(2);
 
-	return pg_tde_set_principal_key_internal(principal_key_name, GS_LOCAL, provider_name, ensure_new_key);
+	pg_tde_set_principal_key_internal(principal_key_name, GS_LOCAL, provider_name, ensure_new_key);
+
+	PG_RETURN_VOID();
 }
 
 Datum
@@ -523,7 +519,9 @@ pg_tde_set_global_principal_key(PG_FUNCTION_ARGS)
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
 	bool		ensure_new_key = PG_GETARG_BOOL(2);
 
-	return pg_tde_set_principal_key_internal(principal_key_name, GS_GLOBAL, provider_name, ensure_new_key);
+	pg_tde_set_principal_key_internal(principal_key_name, GS_GLOBAL, provider_name, ensure_new_key);
+
+	PG_RETURN_VOID();
 }
 
 Datum
@@ -533,13 +531,14 @@ pg_tde_set_server_principal_key(PG_FUNCTION_ARGS)
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
 	bool		ensure_new_key = PG_GETARG_BOOL(2);
 
-	return pg_tde_set_principal_key_internal(principal_key_name, GS_SERVER, provider_name, ensure_new_key);
+	pg_tde_set_principal_key_internal(principal_key_name, GS_SERVER, provider_name, ensure_new_key);
+
+	PG_RETURN_VOID();
 }
 
-static Datum
+static void
 pg_tde_set_principal_key_internal(char *principal_key_name, enum global_status global, char *provider_name, bool ensure_new_key)
 {
-	bool		success;
 	Oid			providerOid = MyDatabaseId;
 	Oid			dbOid = MyDatabaseId;
 	TDEPrincipalKey *existingDefaultKey = NULL;
@@ -575,11 +574,11 @@ pg_tde_set_principal_key_internal(char *principal_key_name, enum global_status g
 		LWLockRelease(tde_lwlock_enc_keys());
 	}
 
-	success = set_principal_key_with_keyring(principal_key_name,
-											 provider_name,
-											 providerOid,
-											 dbOid,
-											 ensure_new_key);
+	set_principal_key_with_keyring(principal_key_name,
+								   provider_name,
+								   providerOid,
+								   dbOid,
+								   ensure_new_key);
 
 	if (global == GS_DEFAULT && existingDefaultKey != NULL)
 	{
@@ -603,8 +602,6 @@ pg_tde_set_principal_key_internal(char *principal_key_name, enum global_status g
 
 		LWLockRelease(tde_lwlock_enc_keys());
 	}
-
-	PG_RETURN_BOOL(success);
 }
 
 PG_FUNCTION_INFO_V1(pg_tde_principal_key_info);
@@ -950,17 +947,15 @@ pg_tde_is_same_principal_key(TDEPrincipalKey *a, TDEPrincipalKey *b)
 static void
 pg_tde_rotate_default_key_for_database(TDEPrincipalKey *oldKey, TDEPrincipalKey *newKeyTemplate)
 {
-	bool		is_rotated;
-
 	TDEPrincipalKey *newKey = palloc_object(TDEPrincipalKey);
 
 	*newKey = *newKeyTemplate;
 	newKey->keyInfo.databaseId = oldKey->keyInfo.databaseId;
 
 	/* key rotation */
-	is_rotated = pg_tde_perform_rotate_key(oldKey, newKey);
+	pg_tde_perform_rotate_key(oldKey, newKey);
 
-	if (is_rotated && (!TDEisInGlobalSpace(newKey->keyInfo.databaseId)))
+	if (!TDEisInGlobalSpace(newKey->keyInfo.databaseId))
 	{
 		clear_principal_key_cache(oldKey->keyInfo.databaseId);
 		push_principal_key_to_cache(newKey);

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -93,7 +93,7 @@ extern void pg_tde_delete_tde_files(Oid dbOid);
 
 extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
 extern void pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info);
-extern bool pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
+extern void pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern bool pg_tde_write_map_keydata_file(off_t size, char *file_data);
 
 const char *tde_sprint_key(InternalKey *k);

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -12,7 +12,7 @@ SELECT pg_tde_list_all_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring.per""}")
 (2,file-2,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring_2.per""}")
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
-t
+
 CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5),(6);
 SELECT * FROM test_enc ORDER BY id ASC;
@@ -32,7 +32,7 @@ SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
 SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');
-t
+
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
@@ -46,7 +46,7 @@ SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
 SELECT pg_tde_set_global_principal_key('rotated-principal-key', 'file-3', false);
-t
+
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
@@ -60,7 +60,7 @@ SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
 SELECT pg_tde_set_global_principal_key('rotated-principal-keyX', 'file-2', false);
-t
+
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
@@ -82,7 +82,7 @@ SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_principal_key interface to set the principal key
 SELECT pg_tde_set_principal_key('rotated-principal-key2','file-2');
-t
+
 SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_principal_key_info();
 2|file-2|rotated-principal-key2
 SELECT key_provider_id, key_provider_name, principal_key_name FROM pg_tde_global_principal_key_info();

--- a/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
+++ b/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 1
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
-t
+
 CREATE TABLE country_table (
      country_id        serial primary key,
      country_name    text unique not null,
@@ -20,7 +20,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 1
 SELECT pg_tde_set_principal_key('test-db-principal-key','file-vault');
-t
+
 CREATE TABLE country_table (
      country_id        serial primary key,
      country_name    text unique not null,

--- a/contrib/pg_tde/t/expected/009_wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/009_wal_encrypt.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');
 -1
 SELECT pg_tde_set_server_principal_key('global-db-principal-key', 'file-keyring-010');
-t
+
 -- server restart with wal encryption
 SHOW pg_tde.wal_encrypt;
 on

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -4,7 +4,7 @@ SELECT pg_tde_add_key_provider_file('file-vault', '/tmp/change_key_provider_1.pe
 SELECT pg_tde_list_all_key_providers();
 (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_1.per""}")
 SELECT pg_tde_set_principal_key('test-key', 'file-vault');
-t
+
 CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5), (6);
 SELECT pg_tde_verify_principal_key();


### PR DESCRIPTION
Since we only ever returned false in one odd internal error, i.e. when something is wrong with the file system, we may as well remove the returned boolean flag and jsut always raise an error when the rotation fails.