### PR TITLE
PG-1455 Add random base to IVs when encrypting WAL and relation data

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -194,6 +194,11 @@ pg_tde_generate_internal_key(InternalKey *int_key, uint32 entry_type)
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg("could not generate internal key: %s",
 						ERR_error_string(ERR_get_error(), NULL))));
+	if (!RAND_bytes(int_key->base_iv, INTERNAL_KEY_IV_LEN))
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not generate IV: %s",
+						ERR_error_string(ERR_get_error(), NULL))));
 }
 
 const char *

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -21,6 +21,9 @@
 #define TDE_KEY_TYPE_WAL_ENCRYPTED		0x10
 #define MAP_ENTRY_VALID (TDE_KEY_TYPE_SMGR | TDE_KEY_TYPE_GLOBAL)
 
+#define INTERNAL_KEY_LEN 16
+#define INTERNAL_KEY_IV_LEN 16
+
 typedef struct InternalKey
 {
 	/*
@@ -28,6 +31,7 @@ typedef struct InternalKey
 	 * pg_tde_read/write_one_keydata()
 	 */
 	uint8		key[INTERNAL_KEY_LEN];
+	uint8		base_iv[INTERNAL_KEY_IV_LEN];
 	uint32		rel_type;
 
 	XLogRecPtr	start_lsn;


### PR DESCRIPTION
It is unclear if this really adds much extra security since we still always use the same pair of key and IV, but since it is easy to do we might as well stop using fixed IVs and use a unique IV for each key. I add the base to the IV using XOR. An alternative would be to do a normal addition, either on a byte array or in a `uint128_t`, but xor was easy and I think just as good. Is my logic correct there?

I also for fun spent a bit of time writing the code in a way gcc could vectorize. I did not managed to get clang to vectorize, but the generated machine code looked good enough anyway. If it had been more performance critical I would have used 128 bit intrinsics but it is not.

I like how for the SMGR IVs one of the easiest ways to write it also ended up the fastest in GCC (with `-O2`), but for GCC to vectorize the WAL IV I needed to use temporary variables instead of just writing to `iv_prefix` directly.

The two final pieces of code I used in Godbolt.

```c
#include <stdint.h>
#include <string.h>
#include <stdio.h>

typedef uint32_t BlockNumber;

static void
CalcBlockIv(BlockNumber bn, const unsigned char *base_iv, unsigned char *iv)
{
	memset(iv, 0, 16);

	iv[12] = bn >> 24;
	iv[13] = bn >> 16;
	iv[14] = bn >> 8;
	iv[15] = bn;

	for (int i = 0; i < 16; i++)
		iv[i] ^= base_iv[i];
}

int f(BlockNumber bn, const unsigned char base[16]) {
    unsigned char iv[16];

    CalcBlockIv(bn, base, iv);

    printf("%s", iv);
}
```

```c
#include <stdint.h>
#include <string.h>
#include <stdio.h>

typedef uint32_t TimeLineID;
typedef uint64_t XLogRecPtr;

static void
CalcXLogPageIVPrefix(TimeLineID tli, XLogRecPtr lsn, const unsigned char *base_iv, char *iv_prefix)
{
	/* Temporary variables to make GCC optimize it */
	char 		a[16],
				b[16];

	memset(a, 0, 16);
	a[0] = tli >> 24;
	a[1] = tli >> 16;
	a[2] = tli >> 8;
	a[3] = tli;

	memset(b, 0, 16);
	b[4] = lsn >> 56;
	b[5] = lsn >> 48;
	b[6] = lsn >> 40;
	b[7] = lsn >> 32;
	b[8] = lsn >> 24;
	b[9] = lsn >> 16;
	b[10] = lsn >> 8;
	b[11] = lsn;

	for (int i = 0; i < 16; i++)
		iv_prefix[i] = (a[i] | b[i]) ^ base_iv[i]; 

	/* Zero lowest 4 bytes */
	for (int i = 12; i < 16; i++)
		iv_prefix[i] = 0;
}

int f(TimeLineID tli, XLogRecPtr lsn, const unsigned char base[16]) {
    unsigned char iv_prefix[16];

    CalcXLogPageIVPrefix(tli, lsn, base, iv_prefix);

    printf("%s", iv_prefix);
}
```