### PR TITLE
Initial clean up of locking

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -897,6 +897,7 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type)
 	TDEPrincipalKey *principal_key;
 	LWLock	   *lock_pk = tde_lwlock_enc_keys();
 	char		db_map_path[MAXPGPATH] = {0};
+	InternalKey *rel_key;
 
 	Assert(rlocator);
 
@@ -934,9 +935,12 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type)
 		ereport(ERROR,
 				(errmsg("principal key not configured"),
 				 errhint("create one using pg_tde_set_principal_key before using encrypted tables")));
+
+	rel_key = tde_decrypt_rel_key(principal_key, map_entry);
+
 	LWLockRelease(lock_pk);
 
-	return tde_decrypt_rel_key(principal_key, map_entry);
+	return rel_key;
 }
 
 /*

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -732,7 +732,7 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 /*
  * Rotate keys on a standby.
  */
-bool
+void
 pg_tde_write_map_keydata_file(off_t file_size, char *file_data)
 {
 	TDEFileHeader *fheader;
@@ -774,8 +774,6 @@ FINALIZE:
 
 	if (!is_err)
 		finalize_key_rotation(db_map_path, path_new);
-
-	return !is_err;
 }
 
 /* It's called by seg_write inside crit section so no pallocs, hence

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -94,11 +94,10 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 
 	else if (info == XLOG_TDE_FREE_MAP_ENTRY)
 	{
-		off_t		offset = 0;
 		RelFileLocator *xlrec = (RelFileLocator *) XLogRecGetData(record);
 
 		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
-		pg_tde_free_key_map_entry(xlrec, MAP_ENTRY_VALID, offset);
+		pg_tde_free_key_map_entry(xlrec, MAP_ENTRY_VALID, 0);
 		LWLockRelease(tde_lwlock_enc_keys());
 	}
 	else

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -57,17 +57,13 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 	{
 		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
 
-		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
 		pg_tde_write_key_map_entry_redo(&xlrec->mapEntry, &xlrec->pkInfo);
-		LWLockRelease(tde_lwlock_enc_keys());
 	}
 	else if (info == XLOG_TDE_ADD_PRINCIPAL_KEY)
 	{
 		TDEPrincipalKeyInfo *mkey = (TDEPrincipalKeyInfo *) XLogRecGetData(record);
 
-		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
-		pg_tde_save_principal_key(mkey);
-		LWLockRelease(tde_lwlock_enc_keys());
+		pg_tde_save_principal_key_redo(mkey);
 	}
 	else if (info == XLOG_TDE_EXTENSION_INSTALL_KEY)
 	{
@@ -87,18 +83,14 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 	{
 		XLogPrincipalKeyRotate *xlrec = (XLogPrincipalKeyRotate *) XLogRecGetData(record);
 
-		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
 		xl_tde_perform_rotate_key(xlrec);
-		LWLockRelease(tde_lwlock_enc_keys());
 	}
 
 	else if (info == XLOG_TDE_FREE_MAP_ENTRY)
 	{
 		RelFileLocator *xlrec = (RelFileLocator *) XLogRecGetData(record);
 
-		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
 		pg_tde_free_key_map_entry(xlrec, MAP_ENTRY_VALID, 0);
-		LWLockRelease(tde_lwlock_enc_keys());
 	}
 	else
 	{

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -371,8 +371,12 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 void
 xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec)
 {
+	LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
+
 	pg_tde_write_map_keydata_file(xlrec->file_size, xlrec->buff);
 	clear_principal_key_cache(xlrec->databaseId);
+
+	LWLockRelease(tde_lwlock_enc_keys());
 }
 
 /*

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -368,15 +368,11 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 /*
  * Rotate keys on a standby.
  */
-bool
+void
 xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec)
 {
-	bool		ret;
-
-	ret = pg_tde_write_map_keydata_file(xlrec->file_size, xlrec->buff);
+	pg_tde_write_map_keydata_file(xlrec->file_size, xlrec->buff);
 	clear_principal_key_cache(xlrec->databaseId);
-
-	return ret;
 }
 
 /*

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -100,6 +100,7 @@ static bool pg_tde_is_same_principal_key(TDEPrincipalKey *a, TDEPrincipalKey *b)
 static void pg_tde_update_global_principal_key_everywhere(TDEPrincipalKey *oldKey, TDEPrincipalKey *newKey);
 static void push_principal_key_to_cache(TDEPrincipalKey *principalKey);
 static Datum pg_tde_get_key_info(PG_FUNCTION_ARGS, Oid dbOid);
+static TDEPrincipalKey *get_principal_key_from_keyring(Oid dbOid);
 static TDEPrincipalKey *GetPrincipalKeyNoDefault(Oid dbOid, LWLockMode lockMode);
 static void set_principal_key_with_keyring(const char *key_name,
 										   const char *provider_name,
@@ -708,7 +709,7 @@ pg_tde_get_key_info(PG_FUNCTION_ARGS, Oid dbOid)
  *
  * Caller should hold an exclusive tde_lwlock_enc_keys lock
  */
-TDEPrincipalKey *
+static TDEPrincipalKey *
 get_principal_key_from_keyring(Oid dbOid)
 {
 	TDEPrincipalKeyInfo *principalKeyInfo;
@@ -717,7 +718,7 @@ get_principal_key_from_keyring(Oid dbOid)
 	KeyringReturnCodes keyring_ret;
 	TDEPrincipalKey *principalKey;
 
-	/* Assert(LWLockHeldByMeInMode(tde_lwlock_enc_keys(), LW_EXCLUSIVE)); */
+	Assert(LWLockHeldByMeInMode(tde_lwlock_enc_keys(), LW_EXCLUSIVE));
 
 	principalKeyInfo = pg_tde_get_principal_key_info(dbOid);
 	if (principalKeyInfo == NULL)

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -107,6 +107,7 @@ extern void pg_tde_delete_tde_files(Oid dbOid);
 
 extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
 extern void pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info);
+extern void pg_tde_save_principal_key_redo(TDEPrincipalKeyInfo *principal_key_info);
 extern void pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern void pg_tde_write_map_keydata_file(off_t size, char *file_data);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -108,7 +108,7 @@ extern void pg_tde_delete_tde_files(Oid dbOid);
 extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
 extern void pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info);
 extern void pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
-extern bool pg_tde_write_map_keydata_file(off_t size, char *file_data);
+extern void pg_tde_write_map_keydata_file(off_t size, char *file_data);
 
 const char *tde_sprint_key(InternalKey *k);
 

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -54,7 +54,7 @@ extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, void *lockMode);
 extern TDEPrincipalKey *GetPrincipalKeyNoDefault(Oid dbOid, void *lockMode);
 #endif
 
-extern bool xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec);
+extern void xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec);
 extern TDEPrincipalKey *get_principal_key_from_keyring(Oid dbOid);
 
 #endif							/* PG_TDE_PRINCIPAL_KEY_H */

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -54,6 +54,5 @@ extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, void *lockMode);
 #endif
 
 extern void xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec);
-extern TDEPrincipalKey *get_principal_key_from_keyring(Oid dbOid);
 
 #endif							/* PG_TDE_PRINCIPAL_KEY_H */

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -47,11 +47,10 @@ extern void InitializePrincipalKeyInfo(void);
 
 #ifndef FRONTEND
 extern LWLock *tde_lwlock_enc_keys(void);
+extern bool pg_tde_principal_key_configured(Oid databaseId);
 extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, LWLockMode lockMode);
-extern TDEPrincipalKey *GetPrincipalKeyNoDefault(Oid dbOid, LWLockMode lockMode);
 #else
 extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, void *lockMode);
-extern TDEPrincipalKey *GetPrincipalKeyNoDefault(Oid dbOid, void *lockMode);
 #endif
 
 extern void xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec);

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -49,8 +49,6 @@ GetCurrentTdeCreateEvent(void)
 static void
 checkEncryptionClause(const char *accessMethod)
 {
-	TDEPrincipalKey *principal_key;
-
 	if (accessMethod && strcmp(accessMethod, "tde_heap") == 0)
 	{
 		tdeCurrentCreateEvent.encryptMode = true;
@@ -62,14 +60,7 @@ checkEncryptionClause(const char *accessMethod)
 
 	if (tdeCurrentCreateEvent.encryptMode)
 	{
-		LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
-		principal_key = GetPrincipalKeyNoDefault(MyDatabaseId, LW_SHARED);
-		if (principal_key == NULL)
-		{
-			principal_key = GetPrincipalKeyNoDefault(DEFAULT_DATA_TDE_OID, LW_EXCLUSIVE);
-		}
-		LWLockRelease(tde_lwlock_enc_keys());
-		if (principal_key == NULL)
+		if (!pg_tde_principal_key_configured(MyDatabaseId))
 		{
 			ereport(ERROR,
 					(errmsg("principal key not configured"),

--- a/contrib/pg_tde/src/transam/pg_tde_xact_handler.c
+++ b/contrib/pg_tde/src/transam/pg_tde_xact_handler.c
@@ -111,8 +111,6 @@ do_pending_deletes(bool isCommit)
 	PendingMapEntryDelete *prev;
 	PendingMapEntryDelete *next;
 
-	LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
-
 	prev = NULL;
 	for (pending = pendingDeletes; pending != NULL; pending = next)
 	{
@@ -141,8 +139,6 @@ do_pending_deletes(bool isCommit)
 		/* prev does not change */
 
 	}
-
-	LWLockRelease(tde_lwlock_enc_keys());
 }
 
 


### PR DESCRIPTION
This PR makes sure we always open the key map file with the same helper functions so we can easily assert that we hold the right lock level. Additionally we refactor the code to make sure locking is done in fewer different source files.

This also fixes an issue where we did not hold onto some locks long enough so data could be deleted under us during key rotation plus we also make sure to hold the right lock when we write a WAL key. The latter should not have caused any issue in practice but was discovered due to the assert.

I am thinking long term we may want to do more to improve locking but this could potentially be good enough for GA.