### PR TITLE
Remove `key_type` argument which is the same for all callers

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -90,7 +90,7 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 	{
 		RelFileLocator *xlrec = (RelFileLocator *) XLogRecGetData(record);
 
-		pg_tde_free_key_map_entry(xlrec, MAP_ENTRY_VALID, 0);
+		pg_tde_free_key_map_entry(xlrec, 0);
 	}
 	else
 	{

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -90,7 +90,7 @@ extern void pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path
 
 extern InternalKey *pg_tde_create_smgr_key(const RelFileLocatorBackend *newrlocator);
 extern void pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocator, uint32 flags);
-extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, uint32 key_type, off_t offset);
+extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, off_t offset);
 extern void pg_tde_write_key_map_entry_redo(const TDEMapEntry *write_map_entry, TDEPrincipalKeyInfo *principal_key_info);
 
 #define PG_TDE_MAP_FILENAME			"pg_tde_%d_map"

--- a/contrib/pg_tde/src/transam/pg_tde_xact_handler.c
+++ b/contrib/pg_tde/src/transam/pg_tde_xact_handler.c
@@ -133,7 +133,7 @@ do_pending_deletes(bool isCommit)
 			ereport(LOG,
 					(errmsg("pg_tde_xact_callback: deleting entry at offset %d",
 							(int) (pending->map_entry_offset))));
-			pg_tde_free_key_map_entry(&pending->rlocator, MAP_ENTRY_VALID, pending->map_entry_offset);
+			pg_tde_free_key_map_entry(&pending->rlocator, pending->map_entry_offset);
 		}
 		pfree(pending);
 		/* prev does not change */


### PR DESCRIPTION
All callers call `pg_tde_free_key_map_entry()` with `MAP_ENTRY_VALID` so we can move it down to the place where it is used instead of passing it as an argument.