### PR TITLE
PG-1437 CLean up definition of special TDE oids

### DIFF
--- a/contrib/pg_tde/src/include/catalog/tde_global_space.h
+++ b/contrib/pg_tde/src/include/catalog/tde_global_space.h
@@ -15,21 +15,23 @@
 #include "catalog/pg_tablespace_d.h"
 
 /*
- * Needed for global data (WAL etc) keys identification in caches and storage.
- * We take Oids of the sql operators, so there is no overlap with the "real"
- * catalog objects possible.
+ * We pick magical database oids from the tablespace oid which avoids
+ * collissions with any real database oid.
  */
-#define GLOBAL_DATA_TDE_OID	607 // TODO: why not repeat GLOBALTABLESPACE_OID ?
-#define XLOG_TDE_OID        608
+#define GLOBAL_DATA_TDE_OID		GLOBALTABLESPACE_OID
+#define DEFAULT_DATA_TDE_OID	DEFAULTTABLESPACE_OID
+
+/*
+ * This oid can be anything since the database oid is gauranteed to not be a
+ * real database.
+ */
+#define XLOG_TDE_OID 1
 
 #define GLOBAL_SPACE_RLOCATOR(_obj_oid) (RelFileLocator) { \
 	GLOBALTABLESPACE_OID, \
 	GLOBAL_DATA_TDE_OID, \
 	_obj_oid \
 }
-
-/*  Needed for using the same default key for multiple databases */
-#define DEFAULT_DATA_TDE_OID	DEFAULTTABLESPACE_OID
 
 #define TDEisInGlobalSpace(dbOid) 	(dbOid == GLOBAL_DATA_TDE_OID)
 


### PR DESCRIPTION
The oids worked as-is, in general any reserved catalog oid which is frefers to an object of another type will work as a special magical oid. Here we decide to use tablespce oids for special database values and a database oid, 1, for the relation value. But in the latter case anything would have worked since we are guarnteed to have no collissions due to the database oid not being and actual database.

The old solution which use a mix worked too but this is more consistent.