### PR TITLE
Ensure decrypted internal keys never swapped

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -76,32 +76,31 @@ typedef struct RelKeyCacheRec
 } RelKeyCacheRec;
 
 /*
- * Relation keys cache.
+ * Memory locked into RAM (cannot be paged to the swap area).
  *
- * This is a slice backed by memory `*data`. Initially, we allocate one memory
- * page (usually 4Kb). We reallocate it by adding another page when we run out
- * of space. This memory is locked in the RAM so it won't be paged to the swap
- * (we don't want decrypted keys on disk). We do allocations in mem pages as
- * these are the units `mlock()` operations are performed in.
+ * This is a slice backed by memory `*data`. This memory is locked into RAM so
+ * it won't be paged to the swap (we don't want decrypted keys on disk). We do
+ * allocations in mem pages as these are the units `mlock()` operations are
+ * performed in.
  *
  * Currently, the cache can only grow (no eviction). The data is located in
  * TopMemoryContext hence being wiped when the process exits, as well as memory
  * is being unlocked by OS.
  */
-typedef struct RelKeyCache
+typedef struct LockedMemory
 {
-	RelKeyCacheRec *data;		/* must be a multiple of a memory page
+	unsigned char *data;		/* must be a multiple of a memory page
 								 * (usually 4Kb) */
-	int			len;			/* num of RelKeyCacheRecs currenty in cache */
-	int			cap;			/* max amount of RelKeyCacheRec data can fit */
-} RelKeyCache;
+	int			len;
+	int			cap;
+} LockedMemory;
 
-RelKeyCache tde_rel_key_cache = {
+
+LockedMemory tde_safe_cache = {
 	.data = NULL,
 	.len = 0,
 	.cap = 0,
 };
-
 
 /*
  * TODO: WAL should have its own RelKeyCache
@@ -109,9 +108,9 @@ RelKeyCache tde_rel_key_cache = {
 static WALKeyCacheRec *tde_wal_key_cache = NULL;
 static WALKeyCacheRec *tde_wal_key_last_rec = NULL;
 
-static InternalKey *pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type);
+static bool pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, InternalKey *out);
 static TDEMapEntry *pg_tde_find_map_entry(const RelFileLocator *rlocator, uint32 key_type, char *db_map_path);
-static InternalKey *tde_decrypt_rel_key(TDEPrincipalKey *principal_key, TDEMapEntry *map_entry);
+static void tde_decrypt_rel_key(TDEPrincipalKey *principal_key, TDEMapEntry *map_entry, InternalKey *out);
 static int	pg_tde_open_file_basic(const char *tde_filename, int fileFlags, bool ignore_missing);
 static void pg_tde_file_header_read(const char *tde_filename, int fd, TDEFileHeader *fheader, off_t *bytes_read);
 static bool pg_tde_read_one_map_entry(int fd, const RelFileLocator *rlocator, int flags, TDEMapEntry *map_entry, off_t *offset);
@@ -119,7 +118,10 @@ static void pg_tde_read_one_map_entry2(int keydata_fd, int32 key_index, TDEMapEn
 static int	pg_tde_open_file_read(const char *tde_filename, off_t *curr_pos);
 static InternalKey *pg_tde_get_key_from_cache(const RelFileLocator *rlocator, uint32 key_type);
 static WALKeyCacheRec *pg_tde_add_wal_key_to_cache(InternalKey *cached_key, XLogRecPtr start_lsn);
-static InternalKey *pg_tde_put_key_into_cache(const RelFileLocator *locator, InternalKey *key);
+static void *tde_alloc_safe_mem(size_t len);
+static void tde_release_safe_mem(void *ptr, size_t len);
+
+#define AllocRelCache(SIZE) (RelKeyCacheRec *) tde_alloc_safe_mem(sizeof(RelKeyCacheRec) * SIZE);
 
 #ifndef FRONTEND
 static InternalKey *pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type);
@@ -150,11 +152,11 @@ pg_tde_create_smgr_key(const RelFileLocatorBackend *newrlocator)
 static InternalKey *
 pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type)
 {
-	InternalKey rel_key_data;
 	TDEPrincipalKey *principal_key;
 	LWLock	   *lock_pk = tde_lwlock_enc_keys();
+	RelKeyCacheRec *rel_key = AllocRelCache(1);
 
-	pg_tde_generate_internal_key(&rel_key_data, entry_type);
+	pg_tde_generate_internal_key(&rel_key->key, entry_type);
 
 	LWLockAcquire(lock_pk, LW_EXCLUSIVE);
 	principal_key = GetPrincipalKey(newrlocator->dbOid, LW_EXCLUSIVE);
@@ -168,20 +170,23 @@ pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, uint32 entry_type
 	/*
 	 * Add the encrypted key to the key map data file structure.
 	 */
-	pg_tde_write_key_map_entry(newrlocator, &rel_key_data, principal_key, true);
+	pg_tde_write_key_map_entry(newrlocator, &rel_key->key, principal_key, true);
 	LWLockRelease(lock_pk);
 
-	return pg_tde_put_key_into_cache(newrlocator, &rel_key_data);
+	rel_key->locator = *newrlocator;
+
+	return &rel_key->key;
 }
 
 static InternalKey *
 pg_tde_create_local_key(const RelFileLocator *newrlocator, uint32 entry_type)
 {
-	InternalKey int_key;
+	RelKeyCacheRec *rel_key = AllocRelCache(1);
 
-	pg_tde_generate_internal_key(&int_key, entry_type);
+	pg_tde_generate_internal_key(&rel_key->key, entry_type);
+	rel_key->locator = *newrlocator;
 
-	return pg_tde_put_key_into_cache(newrlocator, &int_key);
+	return &rel_key->key;
 }
 
 static void
@@ -223,10 +228,11 @@ tde_sprint_key(InternalKey *k)
  * cache. The key is always created with start_lsn = InvalidXLogRecPtr. Which
  * will be updated with the actual lsn by the first WAL write.
  */
-void
-pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocator, uint32 entry_type)
+InternalKey *
+pg_tde_create_wal_key(const RelFileLocator *newrlocator, uint32 entry_type)
 {
 	TDEPrincipalKey *principal_key;
+	RelKeyCacheRec *rec;
 
 	LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
 
@@ -238,15 +244,18 @@ pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocat
 				 errhint("create one using pg_tde_set_server_principal_key before using encrypted WAL")));
 	}
 
+	rec = AllocRelCache(1);
+	rec->locator = *newrlocator;
 	/* TODO: no need in generating key if TDE_KEY_TYPE_WAL_UNENCRYPTED */
-	pg_tde_generate_internal_key(rel_key_data, TDE_KEY_TYPE_GLOBAL | entry_type);
+	pg_tde_generate_internal_key(&rec->key, TDE_KEY_TYPE_GLOBAL | entry_type);
 
 	/*
 	 * Add the encrypted key to the key map data file structure.
 	 */
-	pg_tde_write_key_map_entry(newrlocator, rel_key_data, principal_key, false);
-
+	pg_tde_write_key_map_entry(newrlocator, &rec->key, principal_key, false);
 	LWLockRelease(tde_lwlock_enc_keys());
+
+	return &rec->key;
 }
 
 /*
@@ -696,6 +705,7 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 	off_t		map_size;
 	XLogPrincipalKeyRotate *xlrec;
 	off_t		xlrec_size;
+	InternalKey *rel_key_data = (InternalKey *) tde_alloc_safe_mem(sizeof(InternalKey));
 
 	pg_tde_sign_principal_key_info(&new_signed_key_info, new_principal_key);
 
@@ -707,7 +717,6 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 	/* Read all entries until EOF */
 	while (1)
 	{
-		InternalKey *rel_key_data;
 		off_t		old_prev_pos,
 					new_prev_pos;
 		TDEMapEntry read_map_entry,
@@ -731,15 +740,15 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 		rloc.relNumber = read_map_entry.relNumber;
 
 		/* Decrypt and re-encrypt key */
-		rel_key_data = tde_decrypt_rel_key(principal_key, &read_map_entry);
+		tde_decrypt_rel_key(principal_key, &read_map_entry, rel_key_data);
 		pg_tde_initialize_map_entry(&write_map_entry, new_principal_key, &rloc, rel_key_data);
 
 		/* Write the given entry at the location pointed by prev_pos */
 		new_prev_pos = new_curr_pos;
 		new_curr_pos = pg_tde_write_one_map_entry(new_fd, &write_map_entry, &new_prev_pos, new_path);
-
-		pfree(rel_key_data);
 	}
+
+	tde_release_safe_mem(rel_key_data, sizeof(InternalKey));
 
 	close(old_fd);
 
@@ -921,14 +930,13 @@ pg_tde_open_file_write(const char *tde_filename, const TDESignedPrincipalKeyInfo
  * Reads the key of the required relation. It identifies its map entry and then simply
  * reads the key data from the keydata file.
  */
-static InternalKey *
-pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type)
+static bool
+pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type, InternalKey *out)
 {
 	TDEMapEntry *map_entry;
 	TDEPrincipalKey *principal_key;
 	LWLock	   *lock_pk = tde_lwlock_enc_keys();
 	char		db_map_path[MAXPGPATH] = {0};
-	InternalKey *rel_key;
 
 	Assert(rlocator);
 
@@ -936,7 +944,7 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type)
 	pg_tde_set_db_file_path(rlocator->dbOid, db_map_path);
 
 	if (access(db_map_path, F_OK) == -1)
-		return NULL;
+		return false;
 
 	LWLockAcquire(lock_pk, LW_SHARED);
 
@@ -946,7 +954,7 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type)
 	if (map_entry == NULL)
 	{
 		LWLockRelease(lock_pk);
-		return NULL;
+		return false;
 	}
 
 	/*
@@ -967,11 +975,11 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator, uint32 key_type)
 				(errmsg("principal key not configured"),
 				 errhint("create one using pg_tde_set_principal_key before using encrypted tables")));
 
-	rel_key = tde_decrypt_rel_key(principal_key, map_entry);
+	tde_decrypt_rel_key(principal_key, map_entry, out);
 
 	LWLockRelease(lock_pk);
 
-	return rel_key;
+	return true;
 }
 
 /*
@@ -1025,23 +1033,18 @@ pg_tde_verify_principal_key_info(TDESignedPrincipalKeyInfo *signed_key_info, con
 /*
  * Decrypts a given key and returns the decrypted one.
  */
-static InternalKey *
-tde_decrypt_rel_key(TDEPrincipalKey *principal_key, TDEMapEntry *map_entry)
+static void
+tde_decrypt_rel_key(TDEPrincipalKey *principal_key, TDEMapEntry *map_entry, InternalKey *out)
 {
-	InternalKey *rel_key_data = palloc_object(InternalKey);
-
 	/* Ensure we are getting a valid pointer here */
 	Assert(principal_key);
 
 	/* Fill in the structure */
-	*rel_key_data = map_entry->enc_key;
+	*out = map_entry->enc_key;
 
-	if (!AesGcmDecrypt(principal_key->keyData, map_entry->entry_iv, (unsigned char *) map_entry, offsetof(TDEMapEntry, enc_key), map_entry->enc_key.key, INTERNAL_KEY_LEN, rel_key_data->key, map_entry->aead_tag))
+	if (!AesGcmDecrypt(principal_key->keyData, map_entry->entry_iv, (unsigned char *) map_entry, offsetof(TDEMapEntry, enc_key), map_entry->enc_key.key, INTERNAL_KEY_LEN, out->key, map_entry->aead_tag))
 		ereport(ERROR,
 				(errmsg("Failed to decrypt key, incorrect principal key or corrupted key file")));
-
-
-	return rel_key_data;
 }
 
 /*
@@ -1233,37 +1236,34 @@ pg_tde_get_principal_key_info(Oid dbOid)
 InternalKey *
 GetSMGRRelationKey(RelFileLocatorBackend rel)
 {
+	InternalKey *key;
+	RelKeyCacheRec *rec;
+
 	Assert(rel.locator.relNumber != InvalidRelFileNumber);
 
-	if (RelFileLocatorBackendIsTemp(rel))
-		return pg_tde_get_key_from_cache(&rel.locator, TDE_KEY_TYPE_SMGR);
-	else
+	key = pg_tde_get_key_from_cache(&rel.locator, TDE_KEY_TYPE_SMGR);
+	if (key)
+		return key;
+
+	rec = AllocRelCache(1);
+
+	if (pg_tde_get_key_from_file(&rel.locator, TDE_KEY_TYPE_SMGR, &rec->key))
 	{
-		InternalKey *key;
-
-		key = pg_tde_get_key_from_cache(&rel.locator, TDE_KEY_TYPE_SMGR);
-		if (key)
-			return key;
-
-		key = pg_tde_get_key_from_file(&rel.locator, TDE_KEY_TYPE_SMGR);
-		if (key)
-		{
-			InternalKey *cached_key = pg_tde_put_key_into_cache(&rel.locator, key);
-
-			pfree(key);
-			return cached_key;
-		}
-
-		return NULL;
+		rec->locator = rel.locator;
+		return &rec->key;
 	}
+
+	tde_release_safe_mem(rec, sizeof(RelKeyCacheRec));
+
+	return NULL;
 }
 
 static InternalKey *
 pg_tde_get_key_from_cache(const RelFileLocator *rlocator, uint32 key_type)
 {
-	for (int i = 0; i < tde_rel_key_cache.len; i++)
+	for (int i = 0; i < tde_safe_cache.len; i += sizeof(RelKeyCacheRec))
 	{
-		RelKeyCacheRec *rec = tde_rel_key_cache.data + i;
+		RelKeyCacheRec *rec = (RelKeyCacheRec *) (tde_safe_cache.data + i);
 
 		if (RelFileLocatorEquals(rec->locator, *rlocator) && rec->key.rel_type & key_type)
 		{
@@ -1296,9 +1296,9 @@ update_wal_keys_cache(void)
 	WALKeyCacheRec *wal_rec = tde_wal_key_cache;
 	RelFileLocator rlocator = GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID);
 
-	for (int i = 0; i < tde_rel_key_cache.len && wal_rec; i++)
+	for (int i = 0; i < tde_safe_cache.len && wal_rec; i++)
 	{
-		RelKeyCacheRec *rec = tde_rel_key_cache.data + i;
+		RelKeyCacheRec *rec = ((RelKeyCacheRec *) tde_safe_cache.data) + i;
 
 		if (RelFileLocatorEquals(rec->locator, rlocator))
 		{
@@ -1319,8 +1319,8 @@ pg_tde_read_last_wal_key(void)
 	int			fd = -1;
 	int			file_idx = 0;
 	TDEMapEntry map_entry;
-	InternalKey *rel_key_data;
 	off_t		fsize;
+	RelKeyCacheRec *rec;
 
 	LWLockAcquire(lock_pk, LW_EXCLUSIVE);
 	principal_key = GetPrincipalKey(rlocator.dbOid, LW_EXCLUSIVE);
@@ -1344,11 +1344,14 @@ pg_tde_read_last_wal_key(void)
 	file_idx = ((fsize - TDE_FILE_HEADER_SIZE) / MAP_ENTRY_SIZE) - 1;
 	pg_tde_read_one_map_entry2(fd, file_idx, &map_entry, rlocator.dbOid);
 
-	rel_key_data = tde_decrypt_rel_key(principal_key, &map_entry);
+	rec = AllocRelCache(1);
+	rec->locator = rlocator;
+
+	tde_decrypt_rel_key(principal_key, &map_entry, &rec->key);
 	LWLockRelease(lock_pk);
 	close(fd);
 
-	return rel_key_data;
+	return &rec->key;
 }
 
 /* Fetches WAL keys from disk and adds them to the WAL cache */
@@ -1363,6 +1366,7 @@ pg_tde_fetch_wal_keys(XLogRecPtr start_lsn)
 	int			fd = -1;
 	int			keys_count;
 	WALKeyCacheRec *return_wal_rec = NULL;
+	RelKeyCacheRec *rec = NULL;
 
 	LWLockAcquire(lock_pk, LW_SHARED);
 	principal_key = GetPrincipalKey(rlocator.dbOid, LW_SHARED);
@@ -1386,19 +1390,23 @@ pg_tde_fetch_wal_keys(XLogRecPtr start_lsn)
 	 */
 	if (keys_count == 0)
 	{
-		InternalKey *cached_key;
 		WALKeyCacheRec *wal_rec;
 		InternalKey stub_key = {
 			.start_lsn = InvalidXLogRecPtr,
 		};
 
-		cached_key = pg_tde_put_key_into_cache(&rlocator, &stub_key);
-		wal_rec = pg_tde_add_wal_key_to_cache(cached_key, InvalidXLogRecPtr);
+		rec = AllocRelCache(1);
+		rec->locator = rlocator;
+		rec->key = stub_key;
+
+		wal_rec = pg_tde_add_wal_key_to_cache(&rec->key, InvalidXLogRecPtr);
 
 		LWLockRelease(lock_pk);
 		close(fd);
 		return wal_rec;
 	}
+
+	rec = AllocRelCache(keys_count);
 
 	for (int file_idx = 0; file_idx < keys_count; file_idx++)
 	{
@@ -1413,15 +1421,16 @@ pg_tde_fetch_wal_keys(XLogRecPtr start_lsn)
 			WALKeyIsValid(&map_entry.enc_key) &&
 			map_entry.enc_key.start_lsn >= start_lsn)
 		{
-			InternalKey *rel_key_data = tde_decrypt_rel_key(principal_key, &map_entry);
-			InternalKey *cached_key = pg_tde_put_key_into_cache(&rlocator, rel_key_data);
 			WALKeyCacheRec *wal_rec;
 
-			pfree(rel_key_data);
+			tde_decrypt_rel_key(principal_key, &map_entry, &rec->key);
+			rec->locator = rlocator;
 
-			wal_rec = pg_tde_add_wal_key_to_cache(cached_key, map_entry.enc_key.start_lsn);
+			wal_rec = pg_tde_add_wal_key_to_cache(&rec->key, map_entry.enc_key.start_lsn);
 			if (!return_wal_rec)
 				return_wal_rec = wal_rec;
+
+			rec++;
 		}
 	}
 	LWLockRelease(lock_pk);
@@ -1464,95 +1473,77 @@ pg_tde_add_wal_key_to_cache(InternalKey *cached_key, XLogRecPtr start_lsn)
 }
 
 /*
- * Add key to cache. See comments on `RelKeyCache`.
+ * Allocates `len` bytes in safe (locked into RAM) memory and returns a pointer
+ * to it. Memory allocated in pages in TopMemoryContext.
+ *
+ * TODO: add tests.
  */
-static InternalKey *
-pg_tde_put_key_into_cache(const RelFileLocator *rlocator, InternalKey *key)
+static void *
+tde_alloc_safe_mem(size_t len)
 {
 	static long pageSize = 0;
-	RelKeyCacheRec *rec;
 	MemoryContext oldCtx;
+	int			needPages;
+	unsigned char *newPages;
+	unsigned char *ret = NULL;
 
 	if (pageSize == 0)
 	{
-#ifndef _SC_PAGESIZE
-		pageSize = getpagesize();
-#else
 		pageSize = sysconf(_SC_PAGESIZE);
-#endif
 	}
 
-	if (tde_rel_key_cache.data == NULL)
+	/* An already palloc'ed space might be enough. */
+	if (tde_safe_cache.data != NULL && tde_safe_cache.cap - tde_safe_cache.len >= len)
 	{
-#ifndef FRONTEND
-		oldCtx = MemoryContextSwitchTo(TopMemoryContext);
-		tde_rel_key_cache.data = palloc_aligned(pageSize, pageSize, MCXT_ALLOC_ZERO);
-		MemoryContextSwitchTo(oldCtx);
-#else
-		tde_rel_key_cache.data = aligned_alloc(pageSize, pageSize);
-		memset(tde_rel_key_cache.data, 0, pageSize);
-#endif
-
-		if (mlock(tde_rel_key_cache.data, pageSize) == -1)
-			elog(ERROR, "could not mlock internal key initial cache page: %m");
-
-		tde_rel_key_cache.len = 0;
-		tde_rel_key_cache.cap = (pageSize - 1) / sizeof(RelKeyCacheRec);
+		goto done;
 	}
 
-	/*
-	 * Add another mem page if there is no more room left for another key. We
-	 * allocate `current_memory_size` + 1 page and copy data there.
-	 */
-	if (tde_rel_key_cache.len == tde_rel_key_cache.cap)
-	{
-		size_t		size;
-		size_t		old_size;
-		RelKeyCacheRec *cachePage;
-
-		old_size = TYPEALIGN(pageSize, tde_rel_key_cache.cap * sizeof(RelKeyCacheRec));
-
-		/*
-		 * TODO: consider some formula for less allocations when  caching a
-		 * lot of objects. But on the other, hand it'll use more memory...
-		 * E.g.: if (old_size < 0x8000) size = old_size * 2; else size =
-		 * TYPEALIGN(pageSize, old_size + ((old_size + 3*256) >> 2));
-		 *
-		 */
-		size = old_size + pageSize;
+	needPages = TYPEALIGN(pageSize, len - (tde_safe_cache.cap - tde_safe_cache.len)) / pageSize;
+	if (tde_safe_cache.data != NULL)
+		needPages += tde_safe_cache.cap / pageSize;
 
 #ifndef FRONTEND
-		oldCtx = MemoryContextSwitchTo(TopMemoryContext);
-		cachePage = palloc_aligned(size, pageSize, MCXT_ALLOC_ZERO);
-		MemoryContextSwitchTo(oldCtx);
+	oldCtx = MemoryContextSwitchTo(TopMemoryContext);
+	newPages = palloc_aligned(pageSize * needPages, pageSize, MCXT_ALLOC_ZERO);
+	MemoryContextSwitchTo(oldCtx);
 #else
-		cachePage = aligned_alloc(pageSize, size);
-		memset(cachePage, 0, size);
+	newPages = aligned_alloc(pageSize, pageSize * needPages);
+	memset(newPages, 0, pageSize * needPages);
 #endif
 
-		memcpy(cachePage, tde_rel_key_cache.data, old_size);
+	if (mlock(newPages, pageSize * needPages) == -1)
+		elog(ERROR, "could not mlock internal key cache: %m");
 
-		explicit_bzero(tde_rel_key_cache.data, old_size);
-		if (munlock(tde_rel_key_cache.data, old_size) == -1)
+	if (tde_safe_cache.data != NULL)
+	{
+		memcpy(newPages, tde_safe_cache.data, tde_safe_cache.len);
+
+		explicit_bzero(tde_safe_cache.data, tde_safe_cache.len);
+		if (munlock(tde_safe_cache.data, tde_safe_cache.len) == -1)
 			elog(WARNING, "could not munlock internal key cache pages: %m");
-		pfree(tde_rel_key_cache.data);
-
-		tde_rel_key_cache.data = cachePage;
-
-		if (mlock(tde_rel_key_cache.data, size) == -1)
-			elog(WARNING, "could not mlock internal key cache pages: %m");
-
-		tde_rel_key_cache.cap = (size - 1) / sizeof(RelKeyCacheRec);
-
-		/* update wal key pointers after moving the cache */
-		update_wal_keys_cache();
+		pfree(tde_safe_cache.data);
 	}
 
-	rec = tde_rel_key_cache.data + tde_rel_key_cache.len;
+	tde_safe_cache.data = newPages;
+	update_wal_keys_cache();
+	tde_safe_cache.cap = pageSize * needPages;
 
-	rec->locator = *rlocator;
-	rec->key = *key;
-	tde_rel_key_cache.len++;
+done:
+	ret = tde_safe_cache.data + tde_safe_cache.len;
+	tde_safe_cache.len += len;
 
-	return &rec->key;
+	return (void *) ret;
+}
+
+/* Make the last `len` bytes pointed by `ptr` available for use. `prt` here is
+ * for the cross-check that the caller is trying to free what they mean.
+*/
+static void
+tde_release_safe_mem(void *ptr, size_t len)
+{
+	Assert(tde_safe_cache.len >= len);
+	Assert(tde_safe_cache.data + tde_safe_cache.len - len == ptr);
+
+	explicit_bzero(tde_safe_cache.data + tde_safe_cache.len - len, len);
+	tde_safe_cache.len -= len;
 }

--- a/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_encrypt.c
@@ -70,12 +70,7 @@ typedef struct EncryptionStateData
 
 static EncryptionStateData *EncryptionState = NULL;
 
-/* TODO: can be swapped out to the disk */
-static InternalKey EncryptionKey =
-{
-	.rel_type = MAP_ENTRY_EMPTY,
-	.start_lsn = InvalidXLogRecPtr,
-};
+static InternalKey *EncryptionKey = NULL;
 static void *EncryptionCryptCtx = NULL;
 
 static int	XLOGChooseNumBuffers(void);
@@ -165,31 +160,26 @@ TDEXLogWriteEncryptedPages(int fd, const void *buf, size_t count, off_t offset,
 						   TimeLineID tli, XLogSegNo segno)
 {
 	char		iv_prefix[16];
-	InternalKey *key = &EncryptionKey;
 	char	   *enc_buff = EncryptionState->segBuf;
 
 	Assert(count <= TDEXLogEncryptBuffSize());
 
 #ifdef TDE_XLOG_DEBUG
 	elog(DEBUG1, "write encrypted WAL, size: %lu, offset: %ld [%lX], seg: %X/%X, key_start_lsn: %X/%X",
-		 count, offset, offset, LSN_FORMAT_ARGS(segno), LSN_FORMAT_ARGS(key->start_lsn));
+		 count, offset, offset, LSN_FORMAT_ARGS(segno), LSN_FORMAT_ARGS(EncryptionKey->start_lsn));
 #endif
 
-	CalcXLogPageIVPrefix(tli, segno, key->base_iv, iv_prefix);
+	CalcXLogPageIVPrefix(tli, segno, EncryptionKey->base_iv, iv_prefix);
 	PG_TDE_ENCRYPT_DATA(iv_prefix, offset,
 						(char *) buf, count,
-						enc_buff, key, &EncryptionCryptCtx);
+						enc_buff, EncryptionKey, &EncryptionCryptCtx);
 
 	return pg_pwrite(fd, enc_buff, count, offset);
 }
 
-#endif							/* !FRONTEND */
-
-void
-TDEXLogSmgrInit(void)
+static void
+tde_init_wal_encryption_key(void)
 {
-#ifndef FRONTEND
-	/* TODO: move to the separate func, it's not an SMGR init */
 	InternalKey *key = pg_tde_read_last_wal_key();
 
 	/* TDOO: clean-up this mess */
@@ -197,16 +187,40 @@ TDEXLogSmgrInit(void)
 								  ((key->rel_type & TDE_KEY_TYPE_WAL_ENCRYPTED && !EncryptXLog) ||
 								   (key->rel_type & TDE_KEY_TYPE_WAL_UNENCRYPTED && EncryptXLog))))
 	{
-		pg_tde_create_wal_key(&EncryptionKey, &GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID),
-							  (EncryptXLog ? TDE_KEY_TYPE_WAL_ENCRYPTED : TDE_KEY_TYPE_WAL_UNENCRYPTED));
+		key = pg_tde_create_wal_key(&GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID),
+									(EncryptXLog ? TDE_KEY_TYPE_WAL_ENCRYPTED : TDE_KEY_TYPE_WAL_UNENCRYPTED));
 	}
 	else if (key)
 	{
-		EncryptionKey = *key;
-		pfree(key);
-		pg_atomic_write_u64(&EncryptionState->enc_key_lsn, EncryptionKey.start_lsn);
+		pg_atomic_write_u64(&EncryptionState->enc_key_lsn, key->start_lsn);
 	}
 
+
+	/*
+	 * The relation cache might be moved to the new address space when growing
+	 * later on. It happens when there are a lot of tde_heap relations during
+	 * the recovery. So copy the key to the own locked mem. We could rewrite
+	 * the EncryptionKey pointer after the grow, but it'd be more complicated
+	 * and error-prone. We can sacrifice a couple of Kb.
+	 *
+	 * TODO: genralize and use `tde_alloc_safe_mem` instead?
+	 */
+	if (key)
+	{
+		long		pageSize = sysconf(_SC_PAGESIZE);
+
+		EncryptionKey = (InternalKey *) MemoryContextAllocAligned(TopMemoryContext, pageSize, pageSize, MCXT_ALLOC_ZERO);
+		memcpy(EncryptionKey, key, sizeof(InternalKey));
+	}
+}
+
+#endif							/* !FRONTEND */
+
+void
+TDEXLogInit(void)
+{
+#ifndef FRONTEND
+	tde_init_wal_encryption_key();
 	pg_tde_set_db_file_path(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID).dbOid, EncryptionState->db_map_path);
 
 #endif
@@ -224,15 +238,14 @@ tdeheap_xlog_seg_write(int fd, const void *buf, size_t count, off_t offset,
 	 *
 	 * This func called with WALWriteLock held, so no need in any extra sync.
 	 */
-	if (EncryptionKey.rel_type & TDE_KEY_TYPE_GLOBAL &&
-		pg_atomic_read_u64(&EncryptionState->enc_key_lsn) == 0)
+	if (EncryptionKey && pg_atomic_read_u64(&EncryptionState->enc_key_lsn) == 0)
 	{
 		XLogRecPtr	lsn;
 
 		XLogSegNoOffsetToRecPtr(segno, offset, wal_segment_size, lsn);
 
 		pg_tde_wal_last_key_set_lsn(lsn, EncryptionState->db_map_path);
-		EncryptionKey.start_lsn = lsn;
+		EncryptionKey->start_lsn = lsn;
 		pg_atomic_write_u64(&EncryptionState->enc_key_lsn, lsn);
 	}
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -100,7 +100,7 @@ extern WALKeyCacheRec *pg_tde_get_wal_cache_keys(void);
 extern void pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path);
 
 extern InternalKey *pg_tde_create_smgr_key(const RelFileLocatorBackend *newrlocator);
-extern void pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocator, uint32 flags);
+extern InternalKey *pg_tde_create_wal_key(const RelFileLocator *newrlocator, uint32 flags);
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, off_t offset);
 extern void pg_tde_write_key_map_entry_redo(const TDEMapEntry *write_map_entry, TDESignedPrincipalKeyInfo *signed_key_info);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_encrypt.h
@@ -13,6 +13,6 @@
 
 extern Size TDEXLogEncryptStateSize(void);
 extern void TDEXLogShmemInit(void);
-extern void TDEXLogSmgrInit(void);
+extern void TDEXLogInit(void);
 
 #endif							/* PG_TDE_XLOGENCRYPT_H */

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -92,7 +92,7 @@ tde_shmem_startup(void)
 	AesInit();
 
 	TDEXLogShmemInit();
-	TDEXLogSmgrInit();
+	TDEXLogInit();
 }
 
 void

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -21,7 +21,6 @@ typedef struct TDESMgrRelationData
 	struct _MdfdVec *md_seg_fds[MAX_FORKNUM + 1];
 
 	bool		encrypted_relation;
-	InternalKey *relKey;
 } TDESMgrRelationData;
 
 typedef TDESMgrRelationData *TDESMgrRelation;
@@ -81,7 +80,7 @@ tde_mdwritev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 			 const void **buffers, BlockNumber nblocks, bool skipFsync)
 {
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
-	InternalKey *int_key = tdereln->relKey;
+	InternalKey *int_key = GetSMGRRelationKey(tdereln->reln.smgr_rlocator);
 
 	if (!tdereln->encrypted_relation)
 	{
@@ -120,7 +119,7 @@ tde_mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 			 const void *buffer, bool skipFsync)
 {
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
-	InternalKey *int_key = tdereln->relKey;
+	InternalKey *int_key = GetSMGRRelationKey(tdereln->reln.smgr_rlocator);
 
 	if (!tdereln->encrypted_relation)
 	{
@@ -149,7 +148,7 @@ tde_mdreadv(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 			void **buffers, BlockNumber nblocks)
 {
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
-	InternalKey *int_key = tdereln->relKey;
+	InternalKey *int_key = GetSMGRRelationKey(tdereln->reln.smgr_rlocator);
 
 	mdreadv(reln, forknum, blocknum, buffers, nblocks);
 
@@ -233,15 +232,7 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 		 */
 		key = tde_smgr_get_key(reln, event->alterAccessMethodMode ? NULL : &relold, true);
 
-		if (key)
-		{
-			tdereln->encrypted_relation = true;
-			tdereln->relKey = key;
-		}
-		else
-		{
-			tdereln->encrypted_relation = false;
-		}
+		tdereln->encrypted_relation = key ? true : false;
 	}
 }
 
@@ -254,15 +245,8 @@ tde_mdopen(SMgrRelation reln)
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
 	InternalKey *key = tde_smgr_get_key(reln, NULL, false);
 
-	if (key)
-	{
-		tdereln->encrypted_relation = true;
-		tdereln->relKey = key;
-	}
-	else
-	{
-		tdereln->encrypted_relation = false;
-	}
+	tdereln->encrypted_relation = key ? true : false;
+
 	mdopen(reln);
 }
 

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -21,7 +21,7 @@ typedef struct TDESMgrRelationData
 	struct _MdfdVec *md_seg_fds[MAX_FORKNUM + 1];
 
 	bool		encrypted_relation;
-	InternalKey relKey;
+	InternalKey *relKey;
 } TDESMgrRelationData;
 
 typedef TDESMgrRelationData *TDESMgrRelation;
@@ -81,7 +81,7 @@ tde_mdwritev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 			 const void **buffers, BlockNumber nblocks, bool skipFsync)
 {
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
-	InternalKey *int_key = &tdereln->relKey;
+	InternalKey *int_key = tdereln->relKey;
 
 	if (!tdereln->encrypted_relation)
 	{
@@ -120,7 +120,7 @@ tde_mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 			 const void *buffer, bool skipFsync)
 {
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
-	InternalKey *int_key = &tdereln->relKey;
+	InternalKey *int_key = tdereln->relKey;
 
 	if (!tdereln->encrypted_relation)
 	{
@@ -149,7 +149,7 @@ tde_mdreadv(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 			void **buffers, BlockNumber nblocks)
 {
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
-	InternalKey *int_key = &tdereln->relKey;
+	InternalKey *int_key = tdereln->relKey;
 
 	mdreadv(reln, forknum, blocknum, buffers, nblocks);
 
@@ -236,7 +236,7 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 		if (key)
 		{
 			tdereln->encrypted_relation = true;
-			tdereln->relKey = *key;
+			tdereln->relKey = key;
 		}
 		else
 		{
@@ -257,7 +257,7 @@ tde_mdopen(SMgrRelation reln)
 	if (key)
 	{
 		tdereln->encrypted_relation = true;
-		tdereln->relKey = *key;
+		tdereln->relKey = key;
 	}
 	else
 	{

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -91,9 +91,28 @@ PGTDE::append_to_file($stdout);
 
 $stdout = $node->safe_psql('postgres', "SELECT pg_drop_replication_slot('tde_slot');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
+PGTDE::append_to_file("-- server restart with wal encryption and recovery with a lot of tde_heap relations");
+$node->safe_psql('postgres',
+	q{
+SELECT pg_tde_add_key_provider_file('file-keyring-010-2','/tmp/pg_tde_test_keyring010_2.per');
+SELECT pg_tde_set_principal_key('test-db-principal-key','file-keyring-010-2');
+
+do $$
+    DECLARE idx integer;
+begin
+    for idx in 0..700 loop
+        EXECUTE format('CREATE TABLE t%s (c1 int) USING tde_heap', idx);
+    end loop;
+end; $$;
+});
+
+$rt_value = $node->restart();
+ok($rt_value == 1, "Restart Server");
+
+# TODO: add WAL content testing after the wal rework
 
 # DROP EXTENSION
-$stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 # Stop the server
 $node->stop();

--- a/contrib/pg_tde/t/expected/009_wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/009_wal_encrypt.out
@@ -38,4 +38,5 @@ table public.test_wal: INSERT: id[integer]:6 k[integer]:6
 COMMIT 742
 SELECT pg_drop_replication_slot('tde_slot');
 
-DROP EXTENSION pg_tde;
+-- server restart with wal encryption and recovery with a lot of tde_heap relations
+DROP EXTENSION pg_tde CASCADE;

--- a/src/bin/pg_waldump/pg_waldump.c
+++ b/src/bin/pg_waldump/pg_waldump.c
@@ -1156,7 +1156,7 @@ main(int argc, char **argv)
 	if (kringdir != NULL)
 	{
 		pg_tde_fe_init(kringdir);
-		TDEXLogSmgrInit();
+		TDEXLogInit();
 	}
 #endif
 


### PR DESCRIPTION
We have already had a locked memory for internal keys. But we read and created keys into usually palloced memory before copying them to the locked memory.

This commit changes the approach. Now, the user must allocate (acquire) a locked memory first and use it as a buffer for decryption/creating the key. This locked memory is kinda generic, so the user requests an amount of bytes (rather than objects). Although currently, during the key search, we assume that everything the memory contains only `RelKeyCacheRec` objects. With two exceptions: 1) server creates its own locked page to store the WAL write key;
2) `pg_tde_perform_rotate_key` cheekily allocates a space there for the keys re-encryption but releases this memory when it's done.

In future, if we switch to the full _map files encryption, we can gulp (mmap) the whole file into that memory.

Fixes PG-1445