### PR TITLE
PG-1532 Rewrite seqeunces using lower level functions

### DIFF
--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -418,43 +418,6 @@ BEGIN ATOMIC
                             'certPath' VALUE kmip_cert_path));
 END;
 
-
-CREATE FUNCTION pg_tde_internal_refresh_sequences(table_oid OID)
-RETURNS VOID
-AS
-$BODY$
-DECLARE
-    rec RECORD;
-BEGIN
-    FOR rec IN
-            SELECT s.relname AS sequence_name,
-                ns.nspname AS sequence_namespace,
-                se.seqstart AS sequence_start
-            FROM pg_class AS t
-            JOIN pg_attribute AS a
-                ON a.attrelid = t.oid
-            JOIN pg_depend AS d
-                ON d.refobjid = t.oid
-                AND d.refobjsubid = a.attnum
-            JOIN pg_class AS s
-                ON s.oid = d.objid
-            JOIN pg_sequence AS se
-                ON se.seqrelid = d.objid
-            JOIN pg_namespace AS ns
-                ON ns.oid = s.relnamespace
-            WHERE d.classid = 'pg_catalog.pg_class'::regclass
-            AND d.refclassid = 'pg_catalog.pg_class'::regclass
-            AND d.deptype IN ('i', 'a')
-            AND t.relkind IN ('r', 'P')
-            AND s.relkind = 'S'
-            AND t.oid = table_oid
-    LOOP
-        EXECUTE format('ALTER SEQUENCE %s.%s START %s', rec.sequence_namespace, rec.sequence_name, rec.sequence_start);
-    END LOOP;
-END
-$BODY$
-LANGUAGE plpgsql;
-
 CREATE FUNCTION pg_tde_is_encrypted(relation regclass)
 RETURNS boolean
 STRICT


### PR DESCRIPTION
By using SPI and a SQL language function to force the rewrite of sequences we made life unnecessarily hard for ourselves and also intoduced a bug where ALTER TABLE could break if the pg_tde extension's functions were not in the search path.

Instead we re-use the code for updating sequence persistance whe table persistance is changed. And we only need to look at the table's presistance since it is always the same as the one of the sequences.