### PR TITLE
Clarify some namings in keyring code

### DIFF
--- a/contrib/pg_tde/src/include/keyring/keyring_api.h
+++ b/contrib/pg_tde/src/include/keyring/keyring_api.h
@@ -87,7 +87,7 @@ typedef struct KmipKeyring
 	char	   *kmip_cert_path;
 } KmipKeyring;
 
-extern void RegisterKeyProvider(const TDEKeyringRoutine *routine, ProviderType type);
+extern void RegisterKeyProviderType(const TDEKeyringRoutine *routine, ProviderType type);
 
 extern KeyInfo *KeyringGetKey(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *returnCode);
 extern KeyInfo *KeyringGenerateNewKeyAndStore(GenericKeyring *keyring, const char *key_name, unsigned key_len);

--- a/contrib/pg_tde/src/keyring/keyring_file.c
+++ b/contrib/pg_tde/src/keyring/keyring_file.c
@@ -37,7 +37,7 @@ const TDEKeyringRoutine keyringFileRoutine = {
 void
 InstallFileKeyring(void)
 {
-	RegisterKeyProvider(&keyringFileRoutine, FILE_KEY_PROVIDER);
+	RegisterKeyProviderType(&keyringFileRoutine, FILE_KEY_PROVIDER);
 }
 
 static KeyInfo *

--- a/contrib/pg_tde/src/keyring/keyring_kmip.c
+++ b/contrib/pg_tde/src/keyring/keyring_kmip.c
@@ -35,7 +35,7 @@ const TDEKeyringRoutine keyringKmipRoutine = {
 void
 InstallKmipKeyring(void)
 {
-	RegisterKeyProvider(&keyringKmipRoutine, KMIP_KEY_PROVIDER);
+	RegisterKeyProviderType(&keyringKmipRoutine, KMIP_KEY_PROVIDER);
 }
 
 typedef struct KmipCtx

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -79,7 +79,7 @@ const TDEKeyringRoutine keyringVaultV2Routine = {
 void
 InstallVaultV2Keyring(void)
 {
-	RegisterKeyProvider(&keyringVaultV2Routine, VAULT_V2_KEY_PROVIDER);
+	RegisterKeyProviderType(&keyringVaultV2Routine, VAULT_V2_KEY_PROVIDER);
 }
 
 static bool


### PR DESCRIPTION
It's not clear to someone new to the code that "key provider" in these files refers to what's called "key provider type" elsewhere.

Rename these to make it easier for the next person.