### PR TITLE
Fix typo in KeyringProvideRecord typedef name

### DIFF
--- a/contrib/pg_tde/src/include/catalog/tde_keyring.h
+++ b/contrib/pg_tde/src/include/catalog/tde_keyring.h
@@ -14,28 +14,28 @@
 #include "keyring/keyring_api.h"
 
 /* This record goes into key provider info file */
-typedef struct KeyringProvideRecord
+typedef struct KeyringProviderRecord
 {
 	int			provider_id;
 	char		provider_name[MAX_PROVIDER_NAME_LEN];
 	char		options[MAX_KEYRING_OPTION_LEN];
 	ProviderType provider_type;
-} KeyringProvideRecord;
+} KeyringProviderRecord;
 
 typedef struct KeyringProviderXLRecord
 {
 	Oid			database_id;
 	off_t		offset_in_file;
-	KeyringProvideRecord provider;
+	KeyringProviderRecord provider;
 } KeyringProviderXLRecord;
 
 extern GenericKeyring *GetKeyProviderByName(const char *provider_name, Oid dbOid);
 extern GenericKeyring *GetKeyProviderByID(int provider_id, Oid dbOid);
 extern ProviderType get_keyring_provider_from_typename(char *provider_type);
 extern void InitializeKeyProviderInfo(void);
-extern uint32 save_new_key_provider_info(KeyringProvideRecord *provider,
+extern uint32 save_new_key_provider_info(KeyringProviderRecord *provider,
 										 Oid databaseId, bool write_xlog);
-extern uint32 modify_key_provider_info(KeyringProvideRecord *provider,
+extern uint32 modify_key_provider_info(KeyringProviderRecord *provider,
 									   Oid databaseId, bool write_xlog);
 extern uint32 delete_key_provider_info(int provider_id,
 									   Oid databaseId, bool write_xlog);

--- a/contrib/pg_tde/src/pg_tde_change_key_provider.c
+++ b/contrib/pg_tde/src/pg_tde_change_key_provider.c
@@ -116,7 +116,7 @@ main(int argc, char *argv[])
 	char	   *cptr = tdedir;
 	bool		provider_found = false;
 	GenericKeyring *keyring = NULL;
-	KeyringProvideRecord provider;
+	KeyringProviderRecord provider;
 
 	Oid			db_oid;
 


### PR DESCRIPTION
The R was pulling double duty in the old name.