### PR TITLE
Modernize our way to call `ereport()`

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -149,7 +149,7 @@ tde_provider_info_lock(void)
 void
 InitializeKeyProviderInfo(void)
 {
-	ereport(LOG, (errmsg("initializing TDE key provider info")));
+	ereport(LOG, errmsg("initializing TDE key provider info"));
 	RegisterShmemRequest(&key_provider_info_shmem_routine);
 	on_ext_install(key_provider_startup_cleanup, NULL);
 }
@@ -160,7 +160,7 @@ key_provider_startup_cleanup(int tde_tbl_count, XLogExtensionInstall *ext_info, 
 	if (tde_tbl_count > 0)
 	{
 		ereport(WARNING,
-				(errmsg("failed to perform initialization. database already has %d TDE tables", tde_tbl_count)));
+				errmsg("failed to perform initialization. database already has %d TDE tables", tde_tbl_count));
 		return;
 	}
 	cleanup_key_provider_info(ext_info->database_id);
@@ -235,14 +235,14 @@ pg_tde_change_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 	nlen = strlen(provider_name);
 	if (nlen >= sizeof(provider.provider_name))
 		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("too long provider name, maximum lenght is %ld bytes", sizeof(provider.provider_name) - 1)));
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("too long provider name, maximum lenght is %ld bytes", sizeof(provider.provider_name) - 1));
 
 	olen = strlen(options);
 	if (olen >= sizeof(provider.options))
 		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("too large provider options, maximum size is %ld bytes", sizeof(provider.options) - 1)));
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("too large provider options, maximum size is %ld bytes", sizeof(provider.options) - 1));
 
 	/* Struct will be saved to disk so keep clean */
 	memset(&provider, 0, sizeof(provider));
@@ -280,14 +280,14 @@ pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 	nlen = strlen(provider_name);
 	if (nlen >= sizeof(provider.provider_name) - 1)
 		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("too long provider name, maximum lenght is %ld bytes", sizeof(provider.provider_name) - 1)));
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("too long provider name, maximum lenght is %ld bytes", sizeof(provider.provider_name) - 1));
 
 	olen = strlen(options);
 	if (olen >= sizeof(provider.options))
 		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("too large provider options, maximum size is %ld bytes", sizeof(provider.options) - 1)));
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("too large provider options, maximum size is %ld bytes", sizeof(provider.options) - 1));
 
 	/* Struct will be saved to disk so keep clean */
 	memset(&provider, 0, sizeof(provider));
@@ -327,12 +327,12 @@ pg_tde_list_all_key_providers_internal(const char *fname, bool global, PG_FUNCTI
 	/* check to see if caller supports us returning a tuplestore */
 	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo))
 		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("%s: set-valued function called in context that cannot accept a set", fname)));
+				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("%s: set-valued function called in context that cannot accept a set", fname));
 	if (!(rsinfo->allowedModes & SFRM_Materialize))
 		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("%s: materialize mode required, but it is not allowed in this context", fname)));
+				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("%s: materialize mode required, but it is not allowed in this context", fname));
 
 	/* Switch into long-lived context to construct returned data structures */
 	per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
@@ -405,7 +405,7 @@ write_key_provider_info(KeyringProviderRecord *provider, Oid database_id,
 	if (error_if_exists && provider->provider_id != 0)
 	{
 		ereport(ERROR,
-				(errcode(ERRCODE_DATA_EXCEPTION), errmsg("Invalid write provider call")));
+				errcode(ERRCODE_DATA_EXCEPTION), errmsg("Invalid write provider call"));
 	}
 
 	/* Try to parse the JSON data first: if it doesn't work, don't save it! */
@@ -415,7 +415,7 @@ write_key_provider_info(KeyringProviderRecord *provider, Oid database_id,
 		if (record == NULL)
 		{
 			ereport(ERROR,
-					(errcode(ERRCODE_DATA_EXCEPTION), errmsg("Invalid provider options")));
+					errcode(ERRCODE_DATA_EXCEPTION), errmsg("Invalid provider options"));
 		}
 		else
 		{
@@ -431,8 +431,8 @@ write_key_provider_info(KeyringProviderRecord *provider, Oid database_id,
 	if (fd < 0)
 	{
 		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not open tde file \"%s\": %m", kp_info_path)));
+				errcode_for_file_access(),
+				errmsg("could not open tde file \"%s\": %m", kp_info_path));
 	}
 	if (position == -1)
 	{
@@ -455,8 +455,8 @@ write_key_provider_info(KeyringProviderRecord *provider, Oid database_id,
 				{
 					close(fd);
 					ereport(ERROR,
-							(errcode(ERRCODE_DUPLICATE_OBJECT),
-							 errmsg("key provider \"%s\" already exists", provider->provider_name)));
+							errcode(ERRCODE_DUPLICATE_OBJECT),
+							errmsg("key provider \"%s\" already exists", provider->provider_name));
 				}
 				else
 				{
@@ -526,17 +526,16 @@ write_key_provider_info(KeyringProviderRecord *provider, Oid database_id,
 	{
 		close(fd);
 		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("key provider info file \"%s\" can't be written: %m",
-						kp_info_path)));
+				errcode_for_file_access(),
+				errmsg("key provider info file \"%s\" can't be written: %m",
+					   kp_info_path));
 	}
 	if (pg_fsync(fd) != 0)
 	{
 		close(fd);
 		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not fsync file \"%s\": %m",
-						kp_info_path)));
+				errcode_for_file_access(),
+				errmsg("could not fsync file \"%s\": %m", kp_info_path));
 	}
 	close(fd);
 	LWLockRelease(tde_provider_info_lock());
@@ -635,8 +634,8 @@ scan_key_provider_file(ProviderScanType scanType, void *scanKey, Oid dbOid)
 	{
 		LWLockRelease(tde_provider_info_lock());
 		ereport(DEBUG2,
-				(errcode_for_file_access(),
-				 errmsg("could not open tde file \"%s\": %m", kp_info_path)));
+				errcode_for_file_access(),
+				errmsg("could not open tde file \"%s\": %m", kp_info_path));
 		return providers_list;
 	}
 	while (fetch_next_key_provider(fd, &curr_pos, &provider))
@@ -650,7 +649,7 @@ scan_key_provider_file(ProviderScanType scanType, void *scanKey, Oid dbOid)
 		}
 
 		ereport(DEBUG2,
-				(errmsg("read key provider ID=%d %s", provider.provider_id, provider.provider_name)));
+				errmsg("read key provider ID=%d %s", provider.provider_id, provider.provider_name));
 
 		if (scanType == PROVIDER_SCAN_BY_NAME)
 		{
@@ -745,8 +744,8 @@ load_file_keyring_provider_options(char *keyring_options)
 	if (file_keyring->file_name == NULL || file_keyring->file_name[0] == '\0')
 	{
 		ereport(WARNING,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("file path is missing in the keyring options")));
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("file path is missing in the keyring options"));
 		return NULL;
 	}
 
@@ -771,11 +770,11 @@ load_vaultV2_keyring_provider_options(char *keyring_options)
 		vaultV2_keyring->vault_mount_path == NULL || vaultV2_keyring->vault_mount_path[0] == '\0')
 	{
 		ereport(WARNING,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("missing in the keyring options:%s%s%s",
-						(vaultV2_keyring->vault_token != NULL && vaultV2_keyring->vault_token[0] != '\0') ? "" : " token",
-						(vaultV2_keyring->vault_url != NULL && vaultV2_keyring->vault_url[0] != '\0') ? "" : " url",
-						(vaultV2_keyring->vault_mount_path != NULL && vaultV2_keyring->vault_mount_path[0] != '\0') ? "" : " mountPath")));
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("missing in the keyring options:%s%s%s",
+					   (vaultV2_keyring->vault_token != NULL && vaultV2_keyring->vault_token[0] != '\0') ? "" : " token",
+					   (vaultV2_keyring->vault_url != NULL && vaultV2_keyring->vault_url[0] != '\0') ? "" : " url",
+					   (vaultV2_keyring->vault_mount_path != NULL && vaultV2_keyring->vault_mount_path[0] != '\0') ? "" : " mountPath"));
 		return NULL;
 	}
 
@@ -801,12 +800,12 @@ load_kmip_keyring_provider_options(char *keyring_options)
 		strlen(kmip_keyring->kmip_cert_path) == 0)
 	{
 		ereport(WARNING,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("missing in the keyring options:%s%s%s%s",
-						(kmip_keyring->kmip_host != NULL && kmip_keyring->kmip_host[0] != '\0') ? "" : " host",
-						(kmip_keyring->kmip_port != NULL && kmip_keyring->kmip_port[0] != '\0') ? "" : " port",
-						(kmip_keyring->kmip_ca_path != NULL && kmip_keyring->kmip_ca_path[0] != '\0') ? "" : " caPath",
-						(kmip_keyring->kmip_cert_path != NULL && kmip_keyring->kmip_cert_path[0] != '\0') ? "" : " certPath")));
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("missing in the keyring options:%s%s%s%s",
+					   (kmip_keyring->kmip_host != NULL && kmip_keyring->kmip_host[0] != '\0') ? "" : " host",
+					   (kmip_keyring->kmip_port != NULL && kmip_keyring->kmip_port[0] != '\0') ? "" : " port",
+					   (kmip_keyring->kmip_ca_path != NULL && kmip_keyring->kmip_ca_path[0] != '\0') ? "" : " caPath",
+					   (kmip_keyring->kmip_cert_path != NULL && kmip_keyring->kmip_cert_path[0] != '\0') ? "" : " certPath"));
 		return NULL;
 	}
 
@@ -871,9 +870,9 @@ fetch_next_key_provider(int fd, off_t *curr_pos, KeyringProviderRecord *provider
 		close(fd);
 		/* Corrupt file */
 		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("key provider info file is corrupted: %m"),
-				 errdetail("invalid key provider record size %ld expected %lu", bytes_read, sizeof(KeyringProviderRecord))));
+				errcode_for_file_access(),
+				errmsg("key provider info file is corrupted: %m"),
+				errdetail("invalid key provider record size %ld expected %lu", bytes_read, sizeof(KeyringProviderRecord)));
 	}
 	return true;
 }
@@ -919,9 +918,9 @@ GetKeyProviderByName(const char *provider_name, Oid dbOid)
 	else
 	{
 		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("key provider \"%s\" does not exists", provider_name),
-				 errhint("Create the key provider")));
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("key provider \"%s\" does not exists", provider_name),
+				errhint("Create the key provider"));
 	}
 	return keyring;
 }

--- a/contrib/pg_tde/src/catalog/tde_keyring_parse_opts.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring_parse_opts.c
@@ -189,8 +189,8 @@ ParseKeyringJSONOptions(ProviderType provider_type, void *out_opts, char *in_buf
 	if (jerr != JSON_SUCCESS)
 	{
 		ereport(ERROR,
-				(errmsg("parsing of keyring options failed: %s",
-						json_errdetail(jerr, jlex))));
+				errmsg("parsing of keyring options failed: %s",
+					   json_errdetail(jerr, jlex)));
 
 	}
 #if PG_VERSION_NUM >= 170000

--- a/contrib/pg_tde/src/common/pg_tde_shmem.c
+++ b/contrib/pg_tde/src/common/pg_tde_shmem.c
@@ -77,7 +77,7 @@ TdeShmemInit(void)
 
 	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
 	/* Create or attach to the shared memory state */
-	ereport(NOTICE, (errmsg("TdeShmemInit: requested %ld bytes", required_shmem_size)));
+	ereport(NOTICE, errmsg("TdeShmemInit: requested %ld bytes", required_shmem_size));
 	tdeState = ShmemInitStruct("pg_tde", required_shmem_size, &found);
 
 	if (!found)
@@ -110,7 +110,7 @@ TdeShmemInit(void)
 		Assert(dsa_area_size > 0);
 		tdeState->rawDsaArea = p;
 
-		ereport(LOG, (errmsg("creating DSA area of size %lu", dsa_area_size)));
+		ereport(LOG, errmsg("creating DSA area of size %lu", dsa_area_size));
 		dsa = dsa_create_in_place(tdeState->rawDsaArea,
 								  dsa_area_size,
 								  LWLockNewTrancheId(), 0);
@@ -125,7 +125,7 @@ TdeShmemInit(void)
 			if (routine->init_dsa_area_objects)
 				routine->init_dsa_area_objects(dsa, tdeState->rawDsaArea);
 		}
-		ereport(LOG, (errmsg("setting no limit to DSA area of size %lu", dsa_area_size)));
+		ereport(LOG, errmsg("setting no limit to DSA area of size %lu", dsa_area_size));
 
 		dsa_set_size_limit(dsa, -1);	/* Let it grow outside the shared
 										 * memory */

--- a/contrib/pg_tde/src/common/pg_tde_utils.c
+++ b/contrib/pg_tde/src/common/pg_tde_utils.c
@@ -47,8 +47,8 @@ pg_tde_is_encrypted(PG_FUNCTION_ARGS)
 
 	if (RelFileLocatorBackendIsTemp(rlocator) && !rel->rd_islocaltemp)
 		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("we cannot check if temporary relations from other backends are encrypted")));
+				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("we cannot check if temporary relations from other backends are encrypted"));
 
 	key = GetSMGRRelationKey(rlocator);
 

--- a/contrib/pg_tde/src/encryption/enc_aes.c
+++ b/contrib/pg_tde/src/encryption/enc_aes.c
@@ -75,14 +75,14 @@ AesRunCtr(EVP_CIPHER_CTX **ctxPtr, int enc, const unsigned char *key, const unsi
 
 		if (EVP_CipherInit_ex(*ctxPtr, cipher_ctr_ecb, NULL, key, iv, enc) == 0)
 			ereport(ERROR,
-					(errmsg("EVP_CipherInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+					errmsg("EVP_CipherInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 		EVP_CIPHER_CTX_set_padding(*ctxPtr, 0);
 	}
 
 	if (EVP_CipherUpdate(*ctxPtr, out, &out_len, in, in_len) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	Assert(out_len == in_len);
 }
@@ -101,17 +101,17 @@ AesRunCbc(int enc, const unsigned char *key, const unsigned char *iv, const unsi
 
 	if (EVP_CipherInit_ex(ctx, cipher_cbc, NULL, key, iv, enc) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CipherInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CipherInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 
 	if (EVP_CipherUpdate(ctx, out, &out_len, in, in_len) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_CipherFinal_ex(ctx, out + out_len, &out_len_final) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CipherFinal_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CipherFinal_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	/*
 	 * We encrypt one block (16 bytes) Our expectation is that the result

--- a/contrib/pg_tde/src/encryption/enc_tde.c
+++ b/contrib/pg_tde/src/encryption/enc_tde.c
@@ -53,8 +53,8 @@ pg_tde_crypt_simple(const char *iv_prefix, uint32 start_offset, const char *data
 
 		iv_prefix_debug(iv_prefix, ivp_debug);
 		ereport(LOG,
-				(errmsg("%s: Start offset: %lu Data_Len: %u, aes_start_block: %lu, aes_end_block: %lu, IV prefix: %s",
-						context ? context : "", start_offset, data_len, aes_start_block, aes_end_block, ivp_debug)));
+				errmsg("%s: Start offset: %lu Data_Len: %u, aes_start_block: %lu, aes_end_block: %lu, IV prefix: %s",
+					   context ? context : "", start_offset, data_len, aes_start_block, aes_end_block, ivp_debug));
 	}
 #endif
 
@@ -94,8 +94,8 @@ pg_tde_crypt_complex(const char *iv_prefix, uint32 start_offset, const char *dat
 
 			iv_prefix_debug(iv_prefix, ivp_debug);
 			ereport(LOG,
-					(errmsg("%s: Batch-No:%d Start offset: %lu Data_Len: %u, batch_start_block: %lu, batch_end_block: %lu, IV prefix: %s",
-							context ? context : "", batch_no, start_offset, data_len, batch_start_block, batch_end_block, ivp_debug)));
+					errmsg("%s: Batch-No:%d Start offset: %lu Data_Len: %u, batch_start_block: %lu, batch_end_block: %lu, IV prefix: %s",
+						   context ? context : "", batch_no, start_offset, data_len, batch_start_block, batch_end_block, ivp_debug));
 		}
 #endif
 

--- a/contrib/pg_tde/src/keyring/keyring_file.c
+++ b/contrib/pg_tde/src/keyring/keyring_file.c
@@ -78,10 +78,10 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 			/* Corrupt file */
 			*return_code = KEYRING_CODE_DATA_CORRUPTED;
 			ereport(WARNING,
-					(errcode_for_file_access(),
-					 errmsg("keyring file \"%s\" is corrupted: %m",
-							file_keyring->file_name),
-					 errdetail("invalid key size %lu expected %lu", bytes_read, sizeof(KeyInfo))));
+					errcode_for_file_access(),
+					errmsg("keyring file \"%s\" is corrupted: %m",
+						   file_keyring->file_name),
+					errdetail("invalid key size %lu expected %lu", bytes_read, sizeof(KeyInfo)));
 			return NULL;
 		}
 		if (strncasecmp(key->name, key_name, sizeof(key->name)) == 0)
@@ -111,15 +111,15 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 	if (existing_key)
 	{
 		ereport(ERROR,
-				(errmsg("Key with name %s already exists in keyring", key->name)));
+				errmsg("Key with name %s already exists in keyring", key->name));
 	}
 
 	fd = BasicOpenFile(file_keyring->file_name, O_CREAT | O_RDWR | PG_BINARY);
 	if (fd < 0)
 	{
 		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("Failed to open keyring file %s :%m", file_keyring->file_name)));
+				errcode_for_file_access(),
+				errmsg("Failed to open keyring file %s :%m", file_keyring->file_name));
 	}
 	/* Write key to the end of file */
 	curr_pos = lseek(fd, 0, SEEK_END);
@@ -128,18 +128,18 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 	{
 		close(fd);
 		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("keyring file \"%s\" can't be written: %m",
-						file_keyring->file_name)));
+				errcode_for_file_access(),
+				errmsg("keyring file \"%s\" can't be written: %m",
+					   file_keyring->file_name));
 	}
 
 	if (pg_fsync(fd) != 0)
 	{
 		close(fd);
 		ereport(ERROR,
-				(errcode_for_file_access(),
-				 errmsg("could not fsync file \"%s\": %m",
-						file_keyring->file_name)));
+				errcode_for_file_access(),
+				errmsg("could not fsync file \"%s\": %m",
+					   file_keyring->file_name));
 	}
 	close(fd);
 }

--- a/contrib/pg_tde/src/keyring/keyring_kmip.c
+++ b/contrib/pg_tde/src/keyring/keyring_kmip.c
@@ -55,21 +55,21 @@ kmipSslConnect(KmipCtx *ctx, KmipKeyring *kmip_keyring, bool throw_error)
 	if (SSL_CTX_use_certificate_file(ctx->ssl, kmip_keyring->kmip_cert_path, SSL_FILETYPE_PEM) != 1)
 	{
 		SSL_CTX_free(ctx->ssl);
-		ereport(level, (errmsg("SSL error: Loading the client certificate failed")));
+		ereport(level, errmsg("SSL error: Loading the client certificate failed"));
 		return false;
 	}
 
 	if (SSL_CTX_use_PrivateKey_file(ctx->ssl, kmip_keyring->kmip_cert_path, SSL_FILETYPE_PEM) != 1)
 	{
 		SSL_CTX_free(ctx->ssl);
-		ereport(level, (errmsg("SSL error: Loading the client key failed")));
+		ereport(level, errmsg("SSL error: Loading the client key failed"));
 		return false;
 	}
 
 	if (SSL_CTX_load_verify_locations(ctx->ssl, kmip_keyring->kmip_ca_path, NULL) != 1)
 	{
 		SSL_CTX_free(ctx->ssl);
-		ereport(level, (errmsg("SSL error: Loading the CA certificate failed")));
+		ereport(level, errmsg("SSL error: Loading the CA certificate failed"));
 		return false;
 	}
 
@@ -77,7 +77,7 @@ kmipSslConnect(KmipCtx *ctx, KmipKeyring *kmip_keyring, bool throw_error)
 	if (ctx->bio == NULL)
 	{
 		SSL_CTX_free(ctx->ssl);
-		ereport(level, (errmsg("SSL error: BIO_new_ssl_connect failed")));
+		ereport(level, errmsg("SSL error: BIO_new_ssl_connect failed"));
 		return false;
 	}
 
@@ -89,7 +89,7 @@ kmipSslConnect(KmipCtx *ctx, KmipKeyring *kmip_keyring, bool throw_error)
 	{
 		BIO_free_all(ctx->bio);
 		SSL_CTX_free(ctx->ssl);
-		ereport(level, (errmsg("SSL error: BIO_do_connect failed")));
+		ereport(level, errmsg("SSL error: BIO_do_connect failed"));
 		return false;
 	}
 
@@ -113,7 +113,7 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 	SSL_CTX_free(ctx.ssl);
 
 	if (result != 0)
-		ereport(ERROR, (errmsg("KMIP server reported error on register symmetric key: %i", result)));
+		ereport(ERROR, errmsg("KMIP server reported error on register symmetric key: %i", result));
 }
 
 static KeyInfo *
@@ -156,7 +156,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 
 		if (ids_found > 1)
 		{
-			ereport(WARNING, (errmsg("KMIP server contains multiple results for key, ignoring")));
+			ereport(WARNING, errmsg("KMIP server contains multiple results for key, ignoring"));
 			*return_code = KEYRING_CODE_RESOURCE_NOT_AVAILABLE;
 			BIO_free_all(ctx.bio);
 			SSL_CTX_free(ctx.ssl);
@@ -174,7 +174,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 
 		if (result != 0)
 		{
-			ereport(WARNING, (errmsg("KMIP server LOCATEd key, but GET failed with %i", result)));
+			ereport(WARNING, errmsg("KMIP server LOCATEd key, but GET failed with %i", result));
 			*return_code = KEYRING_CODE_RESOURCE_NOT_AVAILABLE;
 			pfree(key);
 			BIO_free_all(ctx.bio);
@@ -184,7 +184,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 
 		if (key->data.len > sizeof(key->data.data))
 		{
-			ereport(WARNING, (errmsg("keyring provider returned invalid key size: %d", key->data.len)));
+			ereport(WARNING, errmsg("keyring provider returned invalid key size: %d", key->data.len));
 			*return_code = KEYRING_CODE_INVALID_KEY_SIZE;
 			pfree(key);
 			BIO_free_all(ctx.bio);

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -197,8 +197,8 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 	if (!curl_perform(vault_keyring, url, &str, &httpCode, jsonText))
 	{
 		ereport(ERROR,
-				(errmsg("HTTP(S) request to keyring provider \"%s\" failed",
-						vault_keyring->keyring.provider_name)));
+				errmsg("HTTP(S) request to keyring provider \"%s\" failed",
+					   vault_keyring->keyring.provider_name));
 	}
 
 	if (str.ptr != NULL)
@@ -206,8 +206,8 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 
 	if (httpCode / 100 != 2)
 		ereport(ERROR,
-				(errmsg("Invalid HTTP response from keyring provider \"%s\": %ld",
-						vault_keyring->keyring.provider_name, httpCode)));
+				errmsg("Invalid HTTP response from keyring provider \"%s\": %ld",
+					   vault_keyring->keyring.provider_name, httpCode));
 }
 
 static KeyInfo *
@@ -232,8 +232,8 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 	{
 		*return_code = KEYRING_CODE_INVALID_KEY_SIZE;
 		ereport(WARNING,
-				(errmsg("HTTP(S) request to keyring provider \"%s\" failed",
-						vault_keyring->keyring.provider_name)));
+				errmsg("HTTP(S) request to keyring provider \"%s\" failed",
+					   vault_keyring->keyring.provider_name));
 		goto cleanup;
 	}
 
@@ -247,8 +247,8 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 	{
 		*return_code = KEYRING_CODE_INVALID_RESPONSE;
 		ereport(WARNING,
-				(errmsg("HTTP(S) request to keyring provider \"%s\" returned invalid response %li",
-						vault_keyring->keyring.provider_name, httpCode)));
+				errmsg("HTTP(S) request to keyring provider \"%s\" returned invalid response %li",
+					   vault_keyring->keyring.provider_name, httpCode));
 		goto cleanup;
 	}
 
@@ -263,8 +263,8 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 	{
 		*return_code = KEYRING_CODE_INVALID_RESPONSE;
 		ereport(WARNING,
-				(errmsg("HTTP(S) request to keyring provider \"%s\" returned incorrect JSON: %s",
-						vault_keyring->keyring.provider_name, json_errdetail(json_error, jlex))));
+				errmsg("HTTP(S) request to keyring provider \"%s\" returned incorrect JSON: %s",
+					   vault_keyring->keyring.provider_name, json_errdetail(json_error, jlex)));
 		goto cleanup;
 	}
 
@@ -283,8 +283,8 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 	{
 		*return_code = KEYRING_CODE_INVALID_KEY_SIZE;
 		ereport(WARNING,
-				(errmsg("keyring provider \"%s\" returned invalid key size: %d",
-						vault_keyring->keyring.provider_name, key->data.len)));
+				errmsg("keyring provider \"%s\" returned invalid key size: %d",
+					   vault_keyring->keyring.provider_name, key->data.len));
 		pfree(key);
 		key = NULL;
 		goto cleanup;

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -79,7 +79,7 @@ tde_shmem_request(void)
 		prev_shmem_request_hook();
 	RequestAddinShmemSpace(sz);
 	RequestNamedLWLockTranche(TDE_TRANCHE_NAME, required_locks);
-	ereport(LOG, (errmsg("tde_shmem_request: requested %ld bytes", sz)));
+	ereport(LOG, errmsg("tde_shmem_request: requested %ld bytes", sz));
 }
 
 static void
@@ -171,8 +171,8 @@ on_ext_install(pg_tde_on_ext_install_callback function, void *arg)
 {
 	if (on_ext_install_index >= MAX_ON_INSTALLS)
 		ereport(FATAL,
-				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-				 errmsg_internal("out of on extension install slots")));
+				errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				errmsg_internal("out of on extension install slots"));
 
 	on_ext_install_list[on_ext_install_index].function = function;
 	on_ext_install_list[on_ext_install_index].arg = arg;
@@ -190,9 +190,9 @@ pg_tde_init_data_dir(void)
 	{
 		if (MakePGDirectory(PG_TDE_DATA_DIR) < 0)
 			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not create tde directory \"%s\": %m",
-							PG_TDE_DATA_DIR)));
+					errcode_for_file_access(),
+					errmsg("could not create tde directory \"%s\": %m",
+						   PG_TDE_DATA_DIR));
 	}
 }
 

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -63,15 +63,15 @@ checkEncryptionClause(const char *accessMethod)
 		if (!pg_tde_principal_key_configured(MyDatabaseId))
 		{
 			ereport(ERROR,
-					(errmsg("principal key not configured"),
-					 errhint("create one using pg_tde_set_key before using encrypted tables")));
+					errmsg("principal key not configured"),
+					errhint("create one using pg_tde_set_key before using encrypted tables"));
 		}
 	}
 
 	if (EnforceEncryption && !tdeCurrentCreateEvent.encryptMode)
 	{
 		ereport(ERROR,
-				(errmsg("pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.")));
+				errmsg("pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed."));
 	}
 }
 
@@ -113,7 +113,7 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 	/* Ensure this function is being called as an event trigger */
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo))	/* internal error */
 		ereport(ERROR,
-				(errmsg("Function can only be fired by event trigger manager")));
+				errmsg("Function can only be fired by event trigger manager"));
 
 	trigdata = (EventTriggerData *) fcinfo->context;
 	parsetree = trigdata->parsetree;
@@ -148,7 +148,7 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 			}
 		}
 		else
-			ereport(DEBUG1, (errmsg("Failed to get relation Oid for relation:%s", stmt->relation->relname)));
+			ereport(DEBUG1, errmsg("Failed to get relation Oid for relation:%s", stmt->relation->relname));
 
 	}
 	else if (IsA(parsetree, CreateStmt))
@@ -267,7 +267,7 @@ pg_tde_ddl_command_end_capture(PG_FUNCTION_ARGS)
 	/* Ensure this function is being called as an event trigger */
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo))	/* internal error */
 		ereport(ERROR,
-				(errmsg("Function can only be fired by event trigger manager")));
+				errmsg("Function can only be fired by event trigger manager"));
 
 	if (IsA(parsetree, AlterTableStmt) && tdeCurrentCreateEvent.alterAccessMethodMode)
 	{

--- a/contrib/pg_tde/src/transam/pg_tde_xact_handler.c
+++ b/contrib/pg_tde/src/transam/pg_tde_xact_handler.c
@@ -41,8 +41,7 @@ pg_tde_xact_callback(XactEvent event, void *arg)
 	if (event == XACT_EVENT_PARALLEL_ABORT ||
 		event == XACT_EVENT_ABORT)
 	{
-		ereport(DEBUG2,
-				(errmsg("pg_tde_xact_callback: aborting transaction")));
+		ereport(DEBUG2, errmsg("pg_tde_xact_callback: aborting transaction"));
 		do_pending_deletes(false);
 	}
 	else if (event == XACT_EVENT_COMMIT)
@@ -64,13 +63,13 @@ pg_tde_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
 	if (event == SUBXACT_EVENT_ABORT_SUB)
 	{
 		ereport(DEBUG2,
-				(errmsg("pg_tde_subxact_callback: aborting subtransaction")));
+				errmsg("pg_tde_subxact_callback: aborting subtransaction"));
 		do_pending_deletes(false);
 	}
 	else if (event == SUBXACT_EVENT_COMMIT_SUB)
 	{
 		ereport(DEBUG2,
-				(errmsg("pg_tde_subxact_callback: committing subtransaction")));
+				errmsg("pg_tde_subxact_callback: committing subtransaction"));
 		reassign_pending_deletes_to_parent_xact();
 	}
 }
@@ -131,8 +130,8 @@ do_pending_deletes(bool isCommit)
 		if (pending->atCommit == isCommit)
 		{
 			ereport(LOG,
-					(errmsg("pg_tde_xact_callback: deleting entry at offset %d",
-							(int) (pending->map_entry_offset))));
+					errmsg("pg_tde_xact_callback: deleting entry at offset %d",
+						   (int) (pending->map_entry_offset)));
 			pg_tde_free_key_map_entry(&pending->rlocator, pending->map_entry_offset);
 		}
 		pfree(pending);


### PR DESCRIPTION
I had forgot about this until Anders pointed it out.

Commit e3a87b4991cc2d00b7a3082abb54c5f12baedfd1 added a way to call `ereport()` without any extra parentheses which was backported all the way back to PostgreSQL 12. The new modern way improves code readability slightly.