### PR TITLE
PG-1468 Fix issue with intolerably slow recovery

### DIFF
--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -195,7 +195,10 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 {
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
 	InternalKey *key;
-	TdeCreateEvent *event = GetCurrentTdeCreateEvent();
+
+	/* Copied from mdcreate() in md.c */
+	if (isRedo && tdereln->md_num_open_segs[forknum] > 0)
+		return;
 
 	/*
 	 * Make sure that even if a statement failed, and an event trigger end
@@ -215,6 +218,8 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 
 	if (forknum == MAIN_FORKNUM || forknum == INIT_FORKNUM)
 	{
+		TdeCreateEvent *event = GetCurrentTdeCreateEvent();
+
 		/*
 		 * Only create keys when creating the main/init fork. Other forks can
 		 * be created later, even during tde creation events. We definitely do


### PR DESCRIPTION
When we did a recovery, even if tde_heap was not used, 98% of the time was spent in pg_tde_get_key_from_file() due to our SMGR missing the shortcicruit from mdcreate() which skips running if the fork already is open.

The issue was made worse by us not caching negative SMGR key lookups but that is the subject of another commit.