### PR TITLE
Disallow empty key provider name

### DIFF
--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -163,4 +163,26 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 ----+---------------
 (0 rows)
 
+-- Do not allow empty key provider name
+SELECT pg_tde_add_database_key_provider_file('','/tmp/pg_tde_test_keyring.per');
+ERROR:  key provider name cannot be empty
+SELECT pg_tde_add_global_key_provider_file('','/tmp/pg_tde_test_keyring.per');
+ERROR:  key provider name cannot be empty
+-- Do not allow duplicate key provider name
+SELECT pg_tde_add_database_key_provider_file('duplicate-key-provider','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     3
+(1 row)
+
+SELECT pg_tde_add_database_key_provider_file('duplicate-key-provider','/tmp/pg_tde_test_keyring.per');
+ERROR:  key provider "duplicate-key-provider" already exists
+SELECT pg_tde_add_global_key_provider_file('duplicate-key-provider','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_global_key_provider_file 
+-------------------------------------
+                                  -3
+(1 row)
+
+SELECT pg_tde_add_global_key_provider_file('duplicate-key-provider','/tmp/pg_tde_test_keyring.per');
+ERROR:  key provider "duplicate-key-provider" already exists
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -54,5 +54,15 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 SELECT pg_tde_delete_global_key_provider('file-keyring2');
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 
+-- Do not allow empty key provider name
+SELECT pg_tde_add_database_key_provider_file('','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_global_key_provider_file('','/tmp/pg_tde_test_keyring.per');
+
+-- Do not allow duplicate key provider name
+SELECT pg_tde_add_database_key_provider_file('duplicate-key-provider','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('duplicate-key-provider','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_global_key_provider_file('duplicate-key-provider','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_global_key_provider_file('duplicate-key-provider','/tmp/pg_tde_test_keyring.per');
+
 DROP EXTENSION pg_tde;
 

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -278,6 +278,10 @@ pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 	KeyringProviderRecord provider;
 
 	nlen = strlen(provider_name);
+	if (nlen == 0)
+		ereport(ERROR,
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("key provider name cannot be empty"));
 	if (nlen >= sizeof(provider.provider_name) - 1)
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),


### PR DESCRIPTION
We had a bug here where multiple key providers using the same name could be added if that name was the empty string. Simply disallow the empty string as a key provider name to prevent this.

Also add a regression test to ensure duplicate key names are not allowed.