### PR TITLE
Only check `pg_tde` indentation with the combined typedefs

### DIFF
--- a/ci_scripts/dump-typedefs.sh
+++ b/ci_scripts/dump-typedefs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
-cd "$SCRIPT_DIR/../"
+cd "$SCRIPT_DIR/.."
 
 if ! test -f src/backend/postgres; then
   echo "src/backend/postgres doesn't exists, run make-build.sh first in debug mode"
@@ -13,21 +13,7 @@ if ! test -f contrib/pg_tde/pg_tde.so; then
   exit 1
 fi
 
-objdump -W src/backend/postgres |\
-    egrep -A3 DW_TAG_typedef |\
-    perl -e ' while (<>) { chomp; @flds = split;next unless (1 < @flds);\
-        next if $flds[0]  ne "DW_AT_name" && $flds[1] ne "DW_AT_name";\
-        next if $flds[-1] =~ /^DW_FORM_str/;\
-        print $flds[-1],"\n"; }'  |\
-    sort | uniq > percona.typedefs
-
-objdump -W contrib/pg_tde/pg_tde.so |\
-    egrep -A3 DW_TAG_typedef |\
-    perl -e ' while (<>) { chomp; @flds = split;next unless (1 < @flds);\
-        next if $flds[0]  ne "DW_AT_name" && $flds[1] ne "DW_AT_name";\
-        next if $flds[-1] =~ /^DW_FORM_str/;\
-        print $flds[-1],"\n"; }'  |\
-    sort | uniq > tde.typedefs
+src/tools/find_typedef src/backend contrib/pg_tde > percona.typedefs
 
 # Combine with original typedefs
-cat percona.typedefs tde.typedefs src/tools/pgindent/typedefs.list | sort | uniq > combined.typedefs
+cat percona.typedefs src/tools/pgindent/typedefs.list | sort -u > combined.typedefs

--- a/ci_scripts/dump-typedefs.sh
+++ b/ci_scripts/dump-typedefs.sh
@@ -3,17 +3,12 @@
 SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 cd "$SCRIPT_DIR/.."
 
-if ! test -f src/backend/postgres; then
-  echo "src/backend/postgres doesn't exists, run make-build.sh first in debug mode"
-  exit 1
-fi
-
 if ! test -f contrib/pg_tde/pg_tde.so; then
   echo "contrib/pg_tde/pg_tde.so doesn't exists, run make-build.sh first in debug mode"
   exit 1
 fi
 
-src/tools/find_typedef src/backend contrib/pg_tde > percona.typedefs
+src/tools/find_typedef contrib/pg_tde > pg_tde.typedefs
 
 # Combine with original typedefs
-cat percona.typedefs src/tools/pgindent/typedefs.list | sort -u > combined.typedefs
+cat pg_tde.typedefs src/tools/pgindent/typedefs.list | sort -u > combined.typedefs

--- a/ci_scripts/run-pgindent.sh
+++ b/ci_scripts/run-pgindent.sh
@@ -16,4 +16,8 @@ cd "$SCRIPT_DIR/.."
 
 export PATH=$SCRIPT_DIR/../src/tools/pgindent/:$INSTALL_DIR/bin/:$PATH
 
-pgindent --typedefs=combined.typedefs "$@" .
+# Check everything except pg_tde with the list in the repo
+pgindent --typedefs=src/tools/pgindent/typedefs.list --excludes=<(echo "contrib/pg_tde") "$@" .
+
+# Check pg_tde with the fresh list extraxted from the object file
+pgindent --typedefs=combined.typedefs "$@" contrib/pg_tde

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -945,7 +945,7 @@ typedef struct PartitionRangeDatum
 typedef struct SinglePartitionSpec
 {
 	NodeTag		type;
-} SinglePartitionSpec;
+}			SinglePartitionSpec;
 
 /*
  * PartitionCmd - info for ALTER TABLE/INDEX ATTACH/DETACH PARTITION commands

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -1607,6 +1607,7 @@ ManyTestResourceKind
 Material
 MaterialPath
 MaterialState
+MdSMgrRelationData
 MdfdVec
 Memoize
 MemoizeEntry
@@ -3206,6 +3207,7 @@ XLogRecordBuffer
 XLogRecoveryCtlData
 XLogRedoAction
 XLogSegNo
+XLogSmgr
 XLogSource
 XLogStats
 XLogwrtResult


### PR DESCRIPTION
The reason to do this is that the old approach actually created an
    unnecessary diff against upstream where they had forgot
    `SinglePartitionSpec` in typedefs.list. Additionally add the new struct
    for our SMGR patch to the list.

Also make sure to use `src/tools/find_typedef` for this instead of using an own very similar script.