### PR TITLE
XLog signed info when creating a Principal Key 

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -290,7 +290,7 @@ pg_tde_save_principal_key_redo(const TDESignedPrincipalKeyInfo *signed_key_info)
  * The caller must have an EXCLUSIVE LOCK on the files before calling this function.
  */
 void
-pg_tde_save_principal_key(const TDEPrincipalKey *principal_key)
+pg_tde_save_principal_key(const TDEPrincipalKey *principal_key, bool write_xlog)
 {
 	int			map_fd = -1;
 	off_t		curr_pos = 0;
@@ -303,6 +303,13 @@ pg_tde_save_principal_key(const TDEPrincipalKey *principal_key)
 	ereport(DEBUG2, (errmsg("pg_tde_save_principal_key")));
 
 	pg_tde_sign_principal_key_info(&signed_key_Info, principal_key);
+
+	if (write_xlog)
+	{
+		XLogBeginInsert();
+		XLogRegisterData((char *) &signed_key_Info, sizeof(TDESignedPrincipalKeyInfo));
+		XLogInsert(RM_TDERMGR_ID, XLOG_TDE_ADD_PRINCIPAL_KEY);
+	}
 
 	map_fd = pg_tde_open_file_write(db_map_path, &signed_key_Info, true, &curr_pos);
 	close(map_fd);

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -343,13 +343,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 	if (!already_has_key)
 	{
 		/* First key created for the database */
-		pg_tde_save_principal_key(new_principal_key);
-
-		/* XLog the new key */
-		XLogBeginInsert();
-		XLogRegisterData((char *) &new_principal_key->keyInfo, sizeof(TDEPrincipalKeyInfo));
-		XLogInsert(RM_TDERMGR_ID, XLOG_TDE_ADD_PRINCIPAL_KEY);
-
+		pg_tde_save_principal_key(new_principal_key, true);
 		push_principal_key_to_cache(new_principal_key);
 	}
 	else
@@ -839,7 +833,7 @@ GetPrincipalKey(Oid dbOid, LWLockMode lockMode)
 	*newPrincipalKey = *principalKey;
 	newPrincipalKey->keyInfo.databaseId = dbOid;
 
-	pg_tde_save_principal_key(newPrincipalKey);
+	pg_tde_save_principal_key(newPrincipalKey, false);
 
 	push_principal_key_to_cache(newPrincipalKey);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -118,7 +118,7 @@ extern void pg_tde_delete_tde_files(Oid dbOid);
 
 extern TDESignedPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
 extern bool pg_tde_verify_principal_key_info(TDESignedPrincipalKeyInfo *signed_key_info, const TDEPrincipalKey *principal_key);
-extern void pg_tde_save_principal_key(const TDEPrincipalKey *principal_key);
+extern void pg_tde_save_principal_key(const TDEPrincipalKey *principal_key, bool write_xlog);
 extern void pg_tde_save_principal_key_redo(const TDESignedPrincipalKeyInfo *signed_key_info);
 extern void pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern void pg_tde_write_map_keydata_file(off_t size, char *file_data);


### PR DESCRIPTION
Before this commit, we XLogged an unsigned PrincipalKey info when
creating the key. Which leads to:

1. In case of crash recovery, the redo would rewrite a map_ file with
an empty sign info. And the server would later fail to start with
"Failed to verify principal key header..."

2. Replicas would create a _map file with an empty sign info. Which in
turn leads to a fail on restart.


For PG-1539