### PR TITLE
PG-1504 Clean up pg_tde's event trigger

### DIFF
--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -31,7 +31,7 @@
 #include "catalog/tde_global_space.h"
 
 /* Global variable that gets set at ddl start and cleard out at ddl end*/
-static TdeCreateEvent tdeCurrentCreateEvent = {.tid = {.value = 0},.relation = NULL};
+static TdeCreateEvent tdeCurrentCreateEvent = {.tid = {.value = 0}};
 static bool alterSetAccessMethod = false;
 
 static void reset_current_tde_create_event(void);
@@ -129,7 +129,6 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 		tdeCurrentCreateEvent.tid = GetCurrentFullTransactionId();
 
 		tdeCurrentCreateEvent.baseTableOid = relationId;
-		tdeCurrentCreateEvent.relation = stmt->relation;
 
 		if (relationId != InvalidOid)
 		{
@@ -158,8 +157,6 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 		validateCurrentEventTriggerState(true);
 		tdeCurrentCreateEvent.tid = GetCurrentFullTransactionId();
 
-		tdeCurrentCreateEvent.relation = stmt->relation;
-
 		if (shouldEncryptTable(stmt->accessMethod))
 			tdeCurrentCreateEvent.encryptMode = true;
 
@@ -171,8 +168,6 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 
 		validateCurrentEventTriggerState(true);
 		tdeCurrentCreateEvent.tid = GetCurrentFullTransactionId();
-
-		tdeCurrentCreateEvent.relation = stmt->into->rel;
 
 		if (shouldEncryptTable(stmt->into->accessMethod))
 			tdeCurrentCreateEvent.encryptMode = true;
@@ -194,7 +189,6 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 
 			if (cmd->subtype == AT_SetAccessMethod)
 			{
-				tdeCurrentCreateEvent.relation = stmt->relation;
 				tdeCurrentCreateEvent.baseTableOid = relationId;
 				tdeCurrentCreateEvent.alterAccessMethodMode = true;
 
@@ -216,7 +210,6 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 			 */
 
 			tdeCurrentCreateEvent.baseTableOid = relationId;
-			tdeCurrentCreateEvent.relation = stmt->relation;
 
 			if (relationId != InvalidOid)
 			{
@@ -314,10 +307,9 @@ reset_current_tde_create_event(void)
 {
 	tdeCurrentCreateEvent.encryptMode = false;
 	tdeCurrentCreateEvent.baseTableOid = InvalidOid;
-	tdeCurrentCreateEvent.relation = NULL;
 	tdeCurrentCreateEvent.tid = InvalidFullTransactionId;
-	alterSetAccessMethod = false;
 	tdeCurrentCreateEvent.alterAccessMethodMode = false;
+	alterSetAccessMethod = false;
 }
 
 static Oid

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -244,7 +244,8 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 			reset_current_tde_create_event();
 		}
 	}
-	PG_RETURN_NULL();
+
+	PG_RETURN_VOID();
 }
 
 /*
@@ -299,7 +300,7 @@ pg_tde_ddl_command_end_capture(PG_FUNCTION_ARGS)
 		reset_current_tde_create_event();
 	}
 
-	PG_RETURN_NULL();
+	PG_RETURN_VOID();
 }
 
 static void

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -86,9 +86,8 @@ validateCurrentEventTriggerState(bool mightStartTransaction)
 	if (RecoveryInProgress())
 	{
 		reset_current_tde_create_event();
-		return;
 	}
-	if (tdeCurrentCreateEvent.tid.value != InvalidFullTransactionId.value && tid.value != tdeCurrentCreateEvent.tid.value)
+	else if (tdeCurrentCreateEvent.tid.value != InvalidFullTransactionId.value && tid.value != tdeCurrentCreateEvent.tid.value)
 	{
 		/* There was a failed query, end event trigger didn't execute */
 		reset_current_tde_create_event();

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -117,12 +117,12 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				errmsg("Function can only be fired by event trigger manager"));
 
-	trigdata = (EventTriggerData *) fcinfo->context;
+	trigdata = castNode(EventTriggerData, fcinfo->context);
 	parsetree = trigdata->parsetree;
 
 	if (IsA(parsetree, IndexStmt))
 	{
-		IndexStmt  *stmt = (IndexStmt *) parsetree;
+		IndexStmt  *stmt = castNode(IndexStmt, parsetree);
 		Oid			relationId = RangeVarGetRelid(stmt->relation, AccessShareLock, true);
 
 		validateCurrentEventTriggerState(true);
@@ -152,7 +152,7 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 	}
 	else if (IsA(parsetree, CreateStmt))
 	{
-		CreateStmt *stmt = (CreateStmt *) parsetree;
+		CreateStmt *stmt = castNode(CreateStmt, parsetree);
 
 		validateCurrentEventTriggerState(true);
 		tdeCurrentCreateEvent.tid = GetCurrentFullTransactionId();
@@ -164,7 +164,7 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 	}
 	else if (IsA(parsetree, CreateTableAsStmt))
 	{
-		CreateTableAsStmt *stmt = (CreateTableAsStmt *) parsetree;
+		CreateTableAsStmt *stmt = castNode(CreateTableAsStmt, parsetree);
 
 		validateCurrentEventTriggerState(true);
 		tdeCurrentCreateEvent.tid = GetCurrentFullTransactionId();
@@ -176,7 +176,7 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 	}
 	else if (IsA(parsetree, AlterTableStmt))
 	{
-		AlterTableStmt *stmt = (AlterTableStmt *) parsetree;
+		AlterTableStmt *stmt = castNode(AlterTableStmt, parsetree);
 		ListCell   *lcmd;
 		Oid			relationId = RangeVarGetRelid(stmt->relation, AccessShareLock, true);
 
@@ -185,7 +185,7 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 
 		foreach(lcmd, stmt->cmds)
 		{
-			AlterTableCmd *cmd = (AlterTableCmd *) lfirst(lcmd);
+			AlterTableCmd *cmd = castNode(AlterTableCmd, lfirst(lcmd));
 
 			if (cmd->subtype == AT_SetAccessMethod)
 			{
@@ -257,13 +257,13 @@ pg_tde_ddl_command_end_capture(PG_FUNCTION_ARGS)
 	EventTriggerData *trigdata;
 	Node	   *parsetree;
 
-	trigdata = (EventTriggerData *) fcinfo->context;
-	parsetree = trigdata->parsetree;
-
 	/* Ensure this function is being called as an event trigger */
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo))	/* internal error */
 		ereport(ERROR,
 				errmsg("Function can only be fired by event trigger manager"));
+
+	trigdata = castNode(EventTriggerData, fcinfo->context);
+	parsetree = trigdata->parsetree;
 
 	if (IsA(parsetree, AlterTableStmt) && tdeCurrentCreateEvent.alterAccessMethodMode)
 	{


### PR DESCRIPTION
While working on the even trigger code I found some code improvements.

- Simplify and split `checkEncryptionClause()` so we do not use it for two purposes and that it does not have side effects
- Avoid a confusing early return
- Remove an unused field from the event struct
- Use `castNode()` for casting nodes
- Return NULL pointer instead of SQL NULL for even triggers.
- Open relation directly using rangevar instead of first looking up oid.