### PR TITLE
PG-1482, PG-1289 Add coverage to repo and percona server version check.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,45 @@
+codecov:
+  strict_yaml_branch: TDE_REL_17_STABLE
+fixes:
+  - "src/::contrib/pg_tde/src/"  # move path for codecov file mappings e.g., "src/" => "contrib/pg_tde/src/"
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+        base: auto
+comment:
+  layout: "header, diff, components"
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        branches:
+          - "TDE_REL_17_STABLE"
+  individual_components:
+    - component_id: access
+      paths:
+        - contrib/pg_tde/src/access/**
+    - component_id: catalog
+      paths:
+        - contrib/pg_tde/src/catalog/**
+    - component_id: common
+      paths:
+        - contrib/pg_tde/src/common/**
+    - component_id: encryption
+      paths:
+        - contrib/pg_tde/src/encryption/**
+    - component_id: keyring
+      paths:
+        - contrib/pg_tde/src/keyring/**
+    - component_id: src
+      paths:
+        - contrib/pg_tde/src/*.c
+    - component_id: smgr
+      paths:
+        - contrib/pg_tde/src/smgr/**
+    - component_id: transam
+      paths:
+        - contrib/pg_tde/src/transam/**

--- a/.github/workflows/psp-matrix.yml
+++ b/.github/workflows/psp-matrix.yml
@@ -1,6 +1,9 @@
 name: PSP
 on:
   pull_request:
+  push:
+    branches:
+      - TDE_REL_17_STABLE
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/psp-reusable.yml
+++ b/.github/workflows/psp-reusable.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   artifact_name: build-${{ inputs.os }}-${{ inputs.build_script }}-${{ inputs.build_type }}
+  coverage_artifact_name: coverage-build-${{ inputs.os }}-${{ inputs.build_script }}-${{ inputs.build_type }}
 
 jobs:
   build:
@@ -33,7 +34,7 @@ jobs:
       - name: Build postgres
         run: src/ci_scripts/${{ inputs.build_script }}-build.sh ${{ inputs.build_type }}
 
-      - name: 'Tar files'
+      - name: Archive pginst to artifact tar file
         run: tar -czf artifacts.tar src pginst
 
       - name: Upload build artifacts
@@ -43,6 +44,36 @@ jobs:
           overwrite: true
           path: |
             artifacts.tar
+          retention-days: 1
+
+  build-coverage:
+    name: Build PSP for Coverage
+    runs-on: ${{ inputs.os }}
+    if: inputs.build_script == 'make' && inputs.build_type == 'debug'
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          path: 'src'
+          submodules: recursive
+          ref: ${{ github.ref }}
+
+      - name: Install dependencies
+        run: src/ci_scripts/ubuntu-deps.sh
+
+      - name: Build postgres
+        run: src/ci_scripts/${{ inputs.build_script }}-build.sh ${{ inputs.build_type }} --enable-coverage
+
+      - name: Archive pginst to artifact tar file
+        run: tar -czf coverage-artifacts.tar src pginst
+
+      - name: Upload build coverage-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.coverage_artifact_name }}
+          overwrite: true
+          path: |
+            coverage-artifacts.tar
           retention-days: 1
 
   test:
@@ -57,7 +88,7 @@ jobs:
           name: ${{ env.artifact_name }}
           path: .
 
-      - name: 'Untar files'
+      - name: Extract artifact file
         run: tar -xzf artifacts.tar
 
       - name: Install dependencies
@@ -95,15 +126,15 @@ jobs:
           name: ${{ env.artifact_name }}
           path: .
 
-      - name: 'Untar files'
+      - name: Extract artifact file
         run: tar -xzf artifacts.tar
 
       - name: Install dependencies
-        run: src/ci_scripts/ubuntu-deps.sh 
-  
+        run: src/ci_scripts/ubuntu-deps.sh
+
       - name: Setup kmip and vault
         run: src/ci_scripts/setup-keyring-servers.sh
-  
+
       - name: Test postgres with TDE
         run: src/ci_scripts/${{ inputs.build_script }}-test-tde.sh --continue
 
@@ -118,4 +149,55 @@ jobs:
             src/contrib/*/results
             src/contrib/*/regression.diffs
             src/contrib/*/regression.out
+          retention-days: 3
+
+  test_tde_coverage:
+    name: Generate Codecov Code Coverage
+    runs-on: ${{ inputs.os }}
+    if: inputs.build_script == 'make' && inputs.build_type == 'debug'
+    needs: build
+
+    steps:
+      - name: Download build coverage-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.coverage_artifact_name }}
+          path: .
+
+      - name: Extract artifact file
+        run: tar -xzf coverage-artifacts.tar
+
+      - name: Install dependencies
+        run: src/ci_scripts/ubuntu-deps.sh
+
+      - name: Setup kmip and vault
+        run: src/ci_scripts/setup-keyring-servers.sh
+
+      - name: Test postgres with TDE to generate coverage
+        run: src/ci_scripts/${{ inputs.build_script }}-test-tde.sh --continue --tde-only
+
+      - name: Run code coverage
+        run: find src/ -type f -name "*.c" ! -path '*libkmip*' | xargs -t gcov -abcfu
+        working-directory: src/contrib/pg_tde
+
+      - name: Upload coverage data to codecov.io
+        uses: codecov/codecov-action@v5
+        with:
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          working-directory: src/contrib/pg_tde
+          files: "*.c.gcov"
+
+      - name: Report on test fail
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: coverage-testlog-tde-${{ inputs.os }}-${{  inputs.build_script }}-${{ inputs.build_type }}
+          path: |
+            src/build/testrun/
+            src/contrib/pg_tde/t/
+            src/contrib/pg_tde/results
+            src/contrib/pg_tde/regression.diffs
+            src/contrib/pg_tde/regression.out
+            src/contrib/pg_tde/*.gcov
           retention-days: 3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/github/percona/postgres/graph/badge.svg?token=Wow78BMYdP)](https://codecov.io/github/percona/postgres)
+
 Percona Server for PostgreSQL
 =============================
 

--- a/ci_scripts/configure-tde-server.sh
+++ b/ci_scripts/configure-tde-server.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 set -e
 
-# This script is used to configure a TDE server for testing purposes.
-export TDE_MODE=1
-
 SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 INSTALL_DIR="$SCRIPT_DIR/../../pginst"
+source $SCRIPT_DIR/env.sh
 
 cd "$SCRIPT_DIR/.."
 

--- a/ci_scripts/env.sh
+++ b/ci_scripts/env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export TDE_MODE=1
+export PERCONA_SERVER_VERSION=17.4.1

--- a/ci_scripts/make-build.sh
+++ b/ci_scripts/make-build.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
-export TDE_MODE=1
+ENABLE_COVERAGE=
+
+for arg in "$@"
+do
+    case "$arg" in
+        --enable-coverage)
+            ENABLE_COVERAGE="--enable-coverage"
+            shift;;
+    esac
+done
 
 SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 INSTALL_DIR="$SCRIPT_DIR/../../pginst"
+source $SCRIPT_DIR/env.sh
 
 cd "$SCRIPT_DIR/.."
 
@@ -12,5 +22,5 @@ if [ "$1" = "debugoptimized" ]; then
     export CXXFLAGS="-O2"
 fi
 
-./configure --enable-debug --enable-cassert --enable-tap-tests --prefix=$INSTALL_DIR
+./configure --enable-debug --enable-cassert --enable-tap-tests --prefix=$INSTALL_DIR $ENABLE_COVERAGE
 make install-world -j

--- a/ci_scripts/make-test-tde.sh
+++ b/ci_scripts/make-test-tde.sh
@@ -1,16 +1,30 @@
 #!/bin/bash
 
 set -e
+ADD_FLAGS=
+TDE_ONLY=0
 
-export TDE_MODE=1
+for arg in "$@"
+do
+    case "$arg" in
+        --continue)
+            ADD_FLAGS="-k"
+            shift;;
+        --tde-only)
+            TDE_ONLY=1
+            shift;;
+    esac
+done
 
 SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
+source $SCRIPT_DIR/env.sh
 source $SCRIPT_DIR/configure-tde-server.sh
 
-ADD_FLAGS=
-
-if [ "$1" = "--continue" ]; then
-    ADD_FLAGS="-k"
+if [ "$TDE_ONLY" -eq 1 ];
+then
+    cd "$SCRIPT_DIR/../contrib/pg_tde"
+    EXTRA_REGRESS_OPTS="--extra-setup=$SCRIPT_DIR/tde_setup.sql" make -s installcheck $ADD_FLAGS
+else
+    cd "$SCRIPT_DIR/.."
+    EXTRA_REGRESS_OPTS="--extra-setup=$SCRIPT_DIR/tde_setup.sql" make -s installcheck-world $ADD_FLAGS
 fi
-
-EXTRA_REGRESS_OPTS="--extra-setup=$SCRIPT_DIR/tde_setup.sql" make -s installcheck-world $ADD_FLAGS

--- a/ci_scripts/make-test.sh
+++ b/ci_scripts/make-test.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-export TDE_MODE=1
-
 SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
 INSTALL_DIR="$SCRIPT_DIR/../../pginst"
+source $SCRIPT_DIR/env.sh
 
 cd "$SCRIPT_DIR/.."
 

--- a/ci_scripts/ubuntu-deps.sh
+++ b/ci_scripts/ubuntu-deps.sh
@@ -42,6 +42,7 @@ DEPS=(
     # Test pg_tde
     python3-pykmip
     libhttp-server-simple-perl
+    lcov
 )
 
 sudo apt-get update

--- a/src/test/modules/test_misc/t/008_percona_server_version.pl
+++ b/src/test/modules/test_misc/t/008_percona_server_version.pl
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+use lib 't';
+use Env;
+
+plan tests => 6;
+
+# Initialize a test cluster
+my $node = PostgreSQL::Test::Cluster->new('pg_server');
+$node->init();
+my $pgdata = $node->data_dir;
+
+# To make this testcase work, PERCONA_SERVER_VERSION variable should be available in environment.
+# If you are using ci_scripts it is already declated in ci_scripts/env.sh
+# If you are using command line make for regression then export like:
+# export PERCONA_SERVER_VERSION=17.4.1
+
+if (!defined($ENV{PERCONA_SERVER_VERSION}))
+{
+     BAIL_OUT("PERCONA_SERVER_VERSION variable not present in the environment");
+}
+
+my $percona_expected_server_version = $ENV{PERCONA_SERVER_VERSION};
+
+# Start server
+my $rt_value = $node->start;
+ok($rt_value == 1, "Start Server");
+
+# Get PG Server version (e.g 17.4) from pg_config
+my $pg_server_version = `pg_config --version | awk {'print \$2'}`;
+$pg_server_version=~ s/^\s+|\s+$//g;
+
+# Check pg_config output.
+my $pg_config_output = `pg_config --version`;
+$pg_config_output=~ s/^\s+|\s+$//g;
+cmp_ok($pg_config_output,'eq',"PostgreSQL $pg_server_version - Percona Server for PostgreSQL $percona_expected_server_version", "Test pg_config --version output");
+
+# Check psql --version output.
+my $psql_version_output = `psql --version`;
+$psql_version_output=~ s/^\s+|\s+$//g;
+cmp_ok($psql_version_output,'eq',"psql (PostgreSQL) $pg_server_version - Percona Server for PostgreSQL $percona_expected_server_version", "Test psql --version output");
+
+# Check postgres --version output.
+my $postgres_output = `postgres --version`;
+$postgres_output=~ s/^\s+|\s+$//g;
+cmp_ok($postgres_output,'eq',"postgres (PostgreSQL) $pg_server_version - Percona Server for PostgreSQL $percona_expected_server_version", "Test postgres --version output");
+
+# Check select version() output.
+my ($cmdret, $stdout, $stderr) = $node->psql('postgres', "select version();", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=on']);
+ok($cmdret == 0, "# Get output of select version();");
+$stdout=~ s/^\s+|\s+$//g;
+like($stdout, "/PostgreSQL $pg_server_version - Percona Server for PostgreSQL $percona_expected_server_version/", "Test select version() output");
+
+# Stop the server
+$node->stop;
+
+# Done testing for this testcase file.
+done_testing();


### PR DESCRIPTION
- Added code coverage to link repo to codecov.io for coverage stats on PR and merge. 
- Added coverage badge on the landing page (readme) of the repo. 
- Updated GH action to run on PUSH/MERGE, as this is required for code coverage. 
- Updated bash files in ci_scripts folder to accommodate tde installcheck only. 
- Added percona server version scheme verification TAP test case.