### PR TITLE
Improve TAP tests

### DIFF
--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -7,23 +7,18 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
 
-# Start server
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-# CREATE EXTENSION IF NOT EXISTS and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
@@ -35,11 +30,8 @@ PGTDE::append_to_file($stdout);
 $rt_value = $node->psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 ok($rt_value == 3, "Failing query");
 
-
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $node->stop();
-
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
@@ -55,7 +47,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -79,18 +70,15 @@ PGTDE::append_to_file($strings);
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# DROP EXTENSION
 $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "DROP PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
-# Stop the server
+
 $node->stop();
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare,0,"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -48,8 +48,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;'
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgtde;

--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -25,7 +25,7 @@ PGTDE::psql($node, 'postgres', 'SELECT extname, extversion FROM pg_extension WHE
 
 PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -40,7 +40,7 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc (k) VALUES (\'foobar\'),(\'
 
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -54,11 +54,11 @@ $tablefile .= $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\'test_e
 
 my $strings = 'TABLEFILE FOUND: ';
 $strings .= `(ls  $tablefile >/dev/null && echo yes) || echo no`;
-PGTDE::append_to_file($strings);
+PGTDE::append_to_result_file($strings);
 
 $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile | grep foo`;
-PGTDE::append_to_file($strings);
+PGTDE::append_to_result_file($strings);
 
 PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc;');
 

--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -19,41 +19,33 @@ close $conf;
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "CREATE PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
-my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'SELECT extname, extversion FROM pg_extension WHERE extname = \'pg_tde\';', extra_params => ['-a']);
-ok($cmdret == 0, "SELECT PGTDE VERSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT extname, extversion FROM pg_extension WHERE extname = \'pg_tde\';');
 
-$rt_value = $node->psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-ok($rt_value == 3, "Failing query");
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');", extra_params => ['-a']);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');");
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');");
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;');
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc (k) VALUES (\'foobar\'),(\'barfoo\');');
+
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 # Verify that we can't see the data in the file
 my $tablefile = $node->safe_psql('postgres', 'SHOW data_directory;');
@@ -68,12 +60,9 @@ $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile | grep foo`;
 PGTDE::append_to_file($strings);
 
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc;');
 
-$stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "DROP PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
 $node->stop();
 

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -23,7 +23,7 @@ PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -47,7 +47,7 @@ PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');");
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -60,7 +60,7 @@ PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');");
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -73,7 +73,7 @@ PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-key', 'file-3', false);");
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -89,7 +89,7 @@ PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX', 'file-2', false);");
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -101,7 +101,7 @@ PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;');
 
 # Things still work after a restart
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -119,7 +119,7 @@ PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc;');
 
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM RESET pg_tde.inherit_global_providers;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -62,8 +62,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;'
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -80,8 +81,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;'
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -98,8 +100,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;'
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -119,8 +122,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;'
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -135,8 +139,9 @@ PGTDE::append_to_file($stdout);
 
 # Things still work after a restart
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 # But now can't be changed to another global provider
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX2', 'file-2', false);", extra_params => ['-a']);
@@ -161,8 +166,10 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'ALTER SYSTEM RESET pg_tde.inherit_global_providers;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-$rt_value = $node->stop();
+PGTDE::append_to_file("-- server restart");
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgtde;

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -7,36 +7,27 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
 
-# Start server
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-# CREATE EXTENSION IF NOT EXISTS and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
-
 $rt_value = $node->psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 ok($rt_value == 3, "Failing query");
 
-
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $node->stop();
-
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
@@ -64,13 +55,12 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-#rotate key
+# Rotate key
 $stdout = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -83,14 +73,12 @@ PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-
-#Again rotate key
+# Again rotate key
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -103,13 +91,12 @@ PGTDE::append_to_file($stderr);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-#Again rotate key
+# Again rotate key
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-key', 'file-3', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -125,13 +112,12 @@ PGTDE::append_to_file($stdout);
 # TODO: add method to query current info
 # And maybe debug tools to show what's in a file keyring?
 
-#Again rotate key
+# Again rotate key
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX', 'file-2', false);", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -148,7 +134,6 @@ $stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.inherit_global_p
 PGTDE::append_to_file($stdout);
 
 # Things still work after a restart
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -170,9 +155,6 @@ PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 
-
-# end
-
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
@@ -182,18 +164,15 @@ PGTDE::append_to_file($stdout);
 $rt_value = $node->stop();
 $rt_value = $node->start();
 
-# DROP EXTENSION
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
-# Stop the server
+
 $node->stop();
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare,0,"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -19,123 +19,86 @@ close $conf;
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "CREATE PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
-$rt_value = $node->psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-ok($rt_value == 3, "Failing query");
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2g.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-3','/tmp/pg_tde_test_keyring_3.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_global_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2g.per');");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_global_key_provider_file('file-3','/tmp/pg_tde_test_keyring_3.per');");
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_list_all_database_key_providers();");
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');");
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc (k) VALUES (5),(6);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc (k) VALUES (5),(6);');
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 # Rotate key
-$stdout = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();");
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 # Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();");
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 # Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-key', 'file-3', false);", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-key', 'file-3', false);");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();");
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 # TODO: add method to query current info
 # And maybe debug tools to show what's in a file keyring?
 
 # Again rotate key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX', 'file-2', false);", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX', 'file-2', false);");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();");
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
-$stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;');
 
 # Things still work after a restart
 PGTDE::append_to_file("-- server restart");
@@ -144,36 +107,24 @@ $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 # But now can't be changed to another global provider
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX2', 'file-2', false);", extra_params => ['-a']);
-PGTDE::append_to_file($stderr);
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX2', 'file-2', false);");
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();");
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();");
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');");
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();");
+PGTDE::psql($node, 'postgres', "SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();");
 
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc;');
 
-$stdout = $node->safe_psql('postgres', 'ALTER SYSTEM RESET pg_tde.inherit_global_providers;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'ALTER SYSTEM RESET pg_tde.inherit_global_providers;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-($cmdret, $stdout, $stderr) = $node->psql('postgres', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
+PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde CASCADE;');
 
 $node->stop();
 

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -56,9 +56,8 @@ open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
 
-my $rt_value = $node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+my $rt_value = $node->start();
+ok($rt_value == 1, "Start Server");
 
 my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
@@ -77,8 +76,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgtde;

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -7,10 +7,8 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
@@ -22,7 +20,6 @@ use base qw(HTTP::Server::Simple::CGI);
  
 my %dispatch = (
     '/hello' => \&resp_hello,
-    # ...
 );
  
 sub handle_request {
@@ -52,10 +49,9 @@ sub resp_hello {
 }
  
 }
+
 my $pid = MyWebServer->new(8888)->background();
 
-
-# UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
@@ -80,7 +76,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -91,20 +86,17 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc2;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# DROP EXTENSION
 $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "DROP PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
-# Stop the server
+
 $node->stop();
 
 system("kill $pid");
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare,0,"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -70,7 +70,7 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (5),(6);');
 
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -59,36 +59,27 @@ close $conf;
 my $rt_value = $node->start();
 ok($rt_value == 1, "Start Server");
 
-my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "CREATE PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello' ));", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');", extra_params => ['-a']);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello' ));");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');");
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc2 (k) VALUES (5),(6);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (5),(6);');
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc2;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');
 
-$stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "DROP PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
 $node->stop();
 

--- a/contrib/pg_tde/t/004_file_config.pl
+++ b/contrib/pg_tde/t/004_file_config.pl
@@ -34,7 +34,7 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc1 (k) VALUES (5),(6);');
 
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");

--- a/contrib/pg_tde/t/004_file_config.pl
+++ b/contrib/pg_tde/t/004_file_config.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgtde;
@@ -15,8 +13,6 @@ PGTDE::setup_files_dir(basename($0));
 # CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
-
-copy("$pgdata/postgresql.conf", "$pgdata/postgresql.conf.bak");
 
 # UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";

--- a/contrib/pg_tde/t/004_file_config.pl
+++ b/contrib/pg_tde/t/004_file_config.pl
@@ -23,36 +23,27 @@ close $conf2;
 my $rt_value = $node->start();
 ok($rt_value == 1, "Start Server");
 
-my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "CREATE PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');", extra_params => ['-a']);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');");
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc1 (k) VALUES (5),(6);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc1 (k) VALUES (5),(6);');
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;');
 
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc1;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc1;');
 
-$stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "DROP PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
 $node->stop();
 

--- a/contrib/pg_tde/t/004_file_config.pl
+++ b/contrib/pg_tde/t/004_file_config.pl
@@ -7,14 +7,11 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
@@ -42,7 +39,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -53,18 +49,15 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc1;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# DROP EXTENSION
 $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "DROP PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
-# Stop the server
+
 $node->stop();
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare,0,"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/004_file_config.pl
+++ b/contrib/pg_tde/t/004_file_config.pl
@@ -40,8 +40,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/005_multiple_extensions.pl
+++ b/contrib/pg_tde/t/005_multiple_extensions.pl
@@ -19,7 +19,6 @@ if (index(lc($PG_VERSION_STRING), lc("Percona Distribution")) == -1)
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_stat_monitor library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde, pg_stat_monitor, pgaudit, set_user, pg_repack'\n";
 print $conf "pg_stat_monitor.pgsm_bucket_time = 360000\n";

--- a/contrib/pg_tde/t/005_multiple_extensions.pl
+++ b/contrib/pg_tde/t/005_multiple_extensions.pl
@@ -7,7 +7,6 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
 my $PG_VERSION_STRING = `pg_config --version`;
@@ -17,7 +16,6 @@ if (index(lc($PG_VERSION_STRING), lc("Percona Distribution")) == -1)
     plan skip_all => "pg_tde test case only for PPG server package install with extensions.";
 }
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
@@ -32,7 +30,6 @@ open my $conf2, '>>', "/tmp/datafile-location";
 print $conf2 "/tmp/keyring_data_file\n";
 close $conf2;
 
-# Start server
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
@@ -94,7 +91,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -131,24 +127,19 @@ ok($cmdret == 0, "Run pgbench");
 ok($cmdret == 0, "SELECT XXX FROM pg_stat_monitor");
 PGTDE::append_to_debug_file($stdout);
 
-# DROP EXTENSION
 $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "DROP PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
-# DROP EXTENSION
 $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_stat_monitor;', extra_params => ['-a']);
 ok($cmdret == 0, "DROP PGTDE EXTENSION");
 PGTDE::append_to_debug_file($stdout);
 
-# Stop the server
 $node->stop();
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare,0,"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/005_multiple_extensions.pl
+++ b/contrib/pg_tde/t/005_multiple_extensions.pl
@@ -44,7 +44,7 @@ PGTDE::append_to_debug_file($stdout);
 # Create pg_tde extension
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::append_to_result_file($stdout);
 
 # Create Other extensions
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS IF NOT EXISTS pgaudit;', extra_params => ['-a']);
@@ -82,24 +82,24 @@ $rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_fil
 $rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');", extra_params => ['-a']);
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::append_to_result_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc1 (k) VALUES (5),(6);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::append_to_result_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::append_to_result_file($stdout);
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::append_to_result_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc1;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::append_to_result_file($stdout);
 
 # Print PGSM settings 
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', "SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_shared_buffer';", extra_params => ['-a', '-Pformat=aligned','-Ptuples_only=off']);
@@ -129,7 +129,7 @@ PGTDE::append_to_debug_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "DROP PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::append_to_result_file($stdout);
 
 $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_stat_monitor;', extra_params => ['-a']);
 ok($cmdret == 0, "DROP PGTDE EXTENSION");

--- a/contrib/pg_tde/t/005_multiple_extensions.pl
+++ b/contrib/pg_tde/t/005_multiple_extensions.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgtde;
@@ -22,8 +20,6 @@ if (index(lc($PG_VERSION_STRING), lc("Percona Distribution")) == -1)
 # CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
-
-copy("$pgdata/postgresql.conf", "$pgdata/postgresql.conf.bak");
 
 # UPDATE postgresql.conf to include/load pg_stat_monitor library
 open my $conf, '>>', "$pgdata/postgresql.conf";

--- a/contrib/pg_tde/t/005_multiple_extensions.pl
+++ b/contrib/pg_tde/t/005_multiple_extensions.pl
@@ -92,8 +92,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -78,7 +78,7 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (5),(6);');
 
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -64,9 +64,8 @@ open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
 
-my $rt_value = $node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+my $rt_value = $node->start();
+ok($rt_value == 1, "Start Server");
 
 my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
@@ -85,8 +84,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -2,13 +2,11 @@
 
 use strict;
 use warnings;
+use Env;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgtde;
-use Env;
 
 # Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -67,36 +67,27 @@ close $conf;
 my $rt_value = $node->start();
 ok($rt_value == 1, "Start Server");
 
-my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "CREATE PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url' ), to_json('secret'::text), NULL);", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','vault-provider');", extra_params => ['-a']);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url' ), to_json('secret'::text), NULL);");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','vault-provider');");
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc2 (k) VALUES (5),(6);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (5),(6);');
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc2;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');
 
-$stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "DROP PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
 $node->stop();
 

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -8,10 +8,8 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
@@ -24,7 +22,6 @@ use base qw(HTTP::Server::Simple::CGI);
 my %dispatch = (
     '/token' => \&resp_token,
     '/url' => \&resp_url,
-    # ...
 );
  
 sub handle_request {
@@ -60,10 +57,9 @@ sub resp_url {
 }
  
 }
+
 my $pid = MyWebServer->new(8889)->background();
 
-
-# UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
@@ -88,7 +84,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -99,20 +94,17 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc2;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# DROP EXTENSION
 $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "DROP PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
-# Stop the server
+
 $node->stop();
 
 system("kill -9 $pid");
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare,0,"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -7,7 +7,6 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
 my $PG_VERSION_STRING = `pg_config --version`;
@@ -17,43 +16,32 @@ if (index(lc($PG_VERSION_STRING), lc("Percona Server")) == -1)
     plan skip_all => "pg_tde test case only for Percona Server for PostgreSQL";
 }
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
 
-# Start server
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-# CREATE EXTENSION IF NOT EXISTS and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
 
-
 $rt_value = $node->psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 ok($rt_value == 3, "Failing query");
 
-
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $node->stop();
-
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 $rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
 $rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');", extra_params => ['-a']);
 
-
-
 ######################### test_enc1 (simple create table w tde_heap)
-
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc1(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -100,7 +88,6 @@ $stdout = $node->safe_psql('postgres', 'SET default_table_access_method = "tde_h
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc4 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-
 ######################### test_enc5 (create tde_heap + truncate)
 
 $stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc5(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
@@ -121,7 +108,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc5 ORDER BY id ASC;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -167,9 +153,6 @@ $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile2 | grep foo`;
 PGTDE::append_to_file($strings);
 
-
-
-
 # Verify that we can't see the data in the file
 my $tablefile3 = $node->safe_psql('postgres', 'SHOW data_directory;');
 $tablefile3 .= '/';
@@ -183,9 +166,6 @@ $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile3 | grep foo`;
 PGTDE::append_to_file($strings);
 
-
-
-
 # Verify that we can't see the data in the file
 my $tablefile4 = $node->safe_psql('postgres', 'SHOW data_directory;');
 $tablefile4 .= '/';
@@ -198,8 +178,6 @@ PGTDE::append_to_file($strings);
 $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile4 | grep foo`;
 PGTDE::append_to_file($strings);
-
-
 
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc1;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
@@ -216,18 +194,15 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc5;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# DROP EXTENSION
 $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "DROP PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
-# Stop the server
+
 $node->stop();
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare,0,"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgtde;

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -26,87 +26,67 @@ close $conf;
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "CREATE PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
-$rt_value = $node->psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-ok($rt_value == 3, "Failing query");
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$rt_value = $node->psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
-$rt_value = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');", extra_params => ['-a']);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');");
 
 ######################### test_enc1 (simple create table w tde_heap)
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc1(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc1(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc1 (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc1 (k) VALUES (\'foobar\'),(\'barfoo\');');
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;');
 
 ######################### test_enc2 (create heap + alter to tde_heap)
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc2(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc2(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc2 (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (\'foobar\'),(\'barfoo\');');
 
-$stdout = $node->safe_psql('postgres', 'ALTER TABLE test_enc2 SET ACCESS METHOD tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'ALTER TABLE test_enc2 SET ACCESS METHOD tde_heap;');
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
 ######################### test_enc3 (default_table_access_method)
 
-$stdout = $node->safe_psql('postgres', 'SET default_table_access_method = "tde_heap"; CREATE TABLE test_enc3(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SET default_table_access_method = "tde_heap"; CREATE TABLE test_enc3(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc3 (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc3 (k) VALUES (\'foobar\'),(\'barfoo\');');
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc3 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc3 ORDER BY id ASC;');
 
 ######################### test_enc4 (create heap + alter default)
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc4(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING heap;', extra_params => ['-a']);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc4(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING heap;');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc4 (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SET default_table_access_method = "tde_heap"; ALTER TABLE test_enc4 SET ACCESS METHOD DEFAULT;', extra_params => ['-a']);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc4 (k) VALUES (\'foobar\'),(\'barfoo\');');
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc4 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SET default_table_access_method = "tde_heap"; ALTER TABLE test_enc4 SET ACCESS METHOD DEFAULT;');
+
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc4 ORDER BY id ASC;');
 
 ######################### test_enc5 (create tde_heap + truncate)
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc5(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc5(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc5 (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc5 (k) VALUES (\'foobar\'),(\'barfoo\');');
 
-$stdout = $node->safe_psql('postgres', 'CHECKPOINT;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CHECKPOINT;');
 
-$stdout = $node->safe_psql('postgres', 'TRUNCATE test_enc5;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'TRUNCATE test_enc5;');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc5 (k) VALUES (\'foobar\'),(\'barfoo\');', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc5 (k) VALUES (\'foobar\'),(\'barfoo\');');
 
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc5 ORDER BY id ASC;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc5 ORDER BY id ASC;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
@@ -123,8 +103,7 @@ sub verify_table
     $tablefile .= '/';
     $tablefile .= $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\''.$table.'\');');
 
-    $stdout = $node->safe_psql('postgres', 'SELECT * FROM ' . $table . ' ORDER BY id ASC;', extra_params => ['-a']);
-    PGTDE::append_to_file($stdout);
+    PGTDE::psql($node, 'postgres', 'SELECT * FROM ' . $table . ' ORDER BY id ASC;');
 
     my $strings = 'TABLEFILE FOR ' . $table . ' FOUND: ';
     $strings .= `(ls  $tablefile >/dev/null && echo -n yes) || echo -n no`;
@@ -180,24 +159,13 @@ $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile4 | grep foo`;
 PGTDE::append_to_file($strings);
 
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc1;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc1;');
+PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');
+PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc3;');
+PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc4;');
+PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc5;');
 
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc2;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc3;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc4;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-
-$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc5;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-
-$stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "DROP PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
 $node->stop();
 

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -30,7 +30,7 @@ PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -88,14 +88,14 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc5 (k) VALUES (\'foobar\'),(\
 
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc5 ORDER BY id ASC;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 sub verify_table
 {
-    PGTDE::append_to_file('###########################');
+    PGTDE::append_to_result_file('###########################');
 
     my ($table) = @_;
 
@@ -107,11 +107,11 @@ sub verify_table
 
     my $strings = 'TABLEFILE FOR ' . $table . ' FOUND: ';
     $strings .= `(ls  $tablefile >/dev/null && echo -n yes) || echo -n no`;
-    PGTDE::append_to_file($strings);
+    PGTDE::append_to_result_file($strings);
 
     $strings = 'CONTAINS FOO (should be empty): ';
     $strings .= `strings $tablefile | grep foo`;
-    PGTDE::append_to_file($strings);
+    PGTDE::append_to_result_file($strings);
 }
 
 verify_table('test_enc1');
@@ -127,11 +127,11 @@ $tablefile2 .= $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\'test_
 
 my  $strings = 'TABLEFILE2 FOUND: ';
 $strings .= `(ls  $tablefile2 >/dev/null && echo yes) || echo no`;
-PGTDE::append_to_file($strings);
+PGTDE::append_to_result_file($strings);
 
 $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile2 | grep foo`;
-PGTDE::append_to_file($strings);
+PGTDE::append_to_result_file($strings);
 
 # Verify that we can't see the data in the file
 my $tablefile3 = $node->safe_psql('postgres', 'SHOW data_directory;');
@@ -140,11 +140,11 @@ $tablefile3 .= $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\'test_
 
 $strings = 'TABLEFILE3 FOUND: ';
 $strings .= `(ls  $tablefile3 >/dev/null && echo yes) || echo no`;
-PGTDE::append_to_file($strings);
+PGTDE::append_to_result_file($strings);
 
 $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile3 | grep foo`;
-PGTDE::append_to_file($strings);
+PGTDE::append_to_result_file($strings);
 
 # Verify that we can't see the data in the file
 my $tablefile4 = $node->safe_psql('postgres', 'SHOW data_directory;');
@@ -153,11 +153,11 @@ $tablefile4 .= $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\'test_
 
 $strings = 'TABLEFILE4 FOUND: ';
 $strings .= `(ls  $tablefile4 >/dev/null && echo yes) || echo no`;
-PGTDE::append_to_file($strings);
+PGTDE::append_to_result_file($strings);
 
 $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile4 | grep foo`;
-PGTDE::append_to_file($strings);
+PGTDE::append_to_result_file($strings);
 
 PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc1;');
 PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -109,8 +109,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc5 ORDER BY id ASC;
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 sub verify_table
 {

--- a/contrib/pg_tde/t/008_key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/008_key_rotate_tablespace.pl
@@ -45,7 +45,7 @@ PGTDE::psql($node, 'tbc', 'SELECT * FROM country_table;');
 
 PGTDE::psql($node, 'tbc', "SELECT pg_tde_set_key_using_database_key_provider('new-k', 'file-vault');");
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");

--- a/contrib/pg_tde/t/008_key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/008_key_rotate_tablespace.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgtde;

--- a/contrib/pg_tde/t/008_key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/008_key_rotate_tablespace.pl
@@ -7,21 +7,17 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
 my ($cmdret, $stdout);
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
 
-# Start server
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
@@ -54,23 +50,18 @@ SELECT * FROM country_table;
 }, extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-
 $cmdret = $node->psql('tbc', "SELECT pg_tde_set_key_using_database_key_provider('new-k', 'file-vault');", extra_params => ['-a']);
 ok($cmdret == 0, "ROTATE KEY");
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $node->stop();
-
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 $stdout = $node->safe_psql('tbc', 'SELECT * FROM country_table;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-
-# DROP EXTENSION
 $stdout = $node->safe_psql('tbc', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
 ok($cmdret == 0, "DROP PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
@@ -81,14 +72,12 @@ DROP TABLESPACE test_tblspace;
 }, extra_params => ['-a']);
 ok($cmdret == 0, "DROP DATABSE");
 PGTDE::append_to_file($stdout);
-# Stop the server
+
 $node->stop();
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare,0,"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -7,14 +7,11 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 print $conf "wal_level = 'logical'\n";
@@ -37,7 +34,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server, it should work with encryption now
 PGTDE::append_to_file("-- server restart with wal encryption");
 $node->stop();
 $rt_value = $node->start();
@@ -72,7 +68,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-
 PGTDE::append_to_file("-- server restart with wal encryption");
 $node->stop();
 $rt_value = $node->start();
@@ -101,17 +96,14 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_drop_replication_slot('tde_slot');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# DROP EXTENSION
 $stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
-# Stop the server
+
 $node->stop();
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare,0,"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -30,7 +30,7 @@ PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_server_key_using_global_key_pr
 
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;');
 
-PGTDE::append_to_file("-- server restart with wal encryption");
+PGTDE::append_to_result_file("-- server restart with wal encryption");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -45,7 +45,7 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_wal (k) VALUES (1), (2);');
 
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = off;');
 
-PGTDE::append_to_file("-- server restart without wal encryption");
+PGTDE::append_to_result_file("-- server restart without wal encryption");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -56,7 +56,7 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_wal (k) VALUES (3), (4);');
 
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;');
 
-PGTDE::append_to_file("-- server restart with wal encryption");
+PGTDE::append_to_result_file("-- server restart with wal encryption");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -65,7 +65,7 @@ PGTDE::psql($node, 'postgres', "SHOW pg_tde.wal_encrypt;");
 
 PGTDE::psql($node, 'postgres', 'INSERT INTO test_wal (k) VALUES (5), (6);');
 
-PGTDE::append_to_file("-- server restart with still wal encryption");
+PGTDE::append_to_result_file("-- server restart with still wal encryption");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgtde;

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -22,82 +22,63 @@ close $conf;
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-my $stdout = $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');");
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-010');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-010');");
 
-$stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;');
 
 PGTDE::append_to_file("-- server restart with wal encryption");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', "SHOW pg_tde.wal_encrypt;", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SHOW pg_tde.wal_encrypt;");
 
-$stdout = $node->safe_psql('postgres', "SELECT slot_name FROM pg_create_logical_replication_slot('tde_slot', 'test_decoding');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT slot_name FROM pg_create_logical_replication_slot('tde_slot', 'test_decoding');");
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_wal (id SERIAL, k INTEGER, PRIMARY KEY (id));', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_wal (id SERIAL, k INTEGER, PRIMARY KEY (id));');
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_wal (k) VALUES (1), (2);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_wal (k) VALUES (1), (2);');
 
-$stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = off;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = off;');
 
 PGTDE::append_to_file("-- server restart without wal encryption");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', "SHOW pg_tde.wal_encrypt;", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SHOW pg_tde.wal_encrypt;");
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_wal (k) VALUES (3), (4);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_wal (k) VALUES (3), (4);');
 
-$stdout = $node->safe_psql('postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;');
 
 PGTDE::append_to_file("-- server restart with wal encryption");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', "SHOW pg_tde.wal_encrypt;", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SHOW pg_tde.wal_encrypt;");
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_wal (k) VALUES (5), (6);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_wal (k) VALUES (5), (6);');
 
 PGTDE::append_to_file("-- server restart with still wal encryption");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
-$stdout = $node->safe_psql('postgres', "SHOW pg_tde.wal_encrypt;", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SHOW pg_tde.wal_encrypt;");
 
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_wal (k) VALUES (7), (8);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_wal (k) VALUES (7), (8);');
 
-$stdout = $node->safe_psql('postgres', "SELECT data FROM pg_logical_slot_get_changes('tde_slot', NULL, NULL);", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT data FROM pg_logical_slot_get_changes('tde_slot', NULL, NULL);");
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_drop_replication_slot('tde_slot');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_drop_replication_slot('tde_slot');");
 
-$stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
 $node->stop();
 

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -25,43 +25,28 @@ unlink('/tmp/change_key_provider_4.per');
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "CREATE PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_list_all_database_key_providers();");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');");
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc (k) VALUES (5), (6);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;');
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc (k) VALUES (5), (6);');
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 # Change provider and move file
 PGTDE::append_to_file("-- mv /tmp/change_key_provider_1.per /tmp/change_key_provider_2.per");
 move('/tmp/change_key_provider_1.per', '/tmp/change_key_provider_2.per');
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_list_all_database_key_providers();");
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
@@ -69,26 +54,17 @@ $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 # Verify
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 # Change provider and do not move file
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_list_all_database_key_providers();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_list_all_database_key_providers();");
 
-(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
@@ -96,15 +72,9 @@ $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 # Verify
-(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
-(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
-(undef, $stdout, $stderr) = $node->psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_file("-- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_3.per");
 move('/tmp/change_key_provider_2.per', '/tmp/change_key_provider_3.per');
@@ -115,41 +85,26 @@ $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 # Verify
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
-(undef, $stdout, $stderr) = $node->psql('postgres', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
+PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde CASCADE;');
 
-($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "CREATE PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 # Change provider and generate a new principal key
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');");
 
-$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc (k) VALUES (5), (6);', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;');
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc (k) VALUES (5), (6);');
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');");
 
 PGTDE::append_to_file("-- server restart");
 $node->stop();
@@ -157,33 +112,19 @@ $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
 
 # Verify
-(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
-(undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
-(undef, $stdout, $stderr) = $node->psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
-(undef, $stdout, $stderr) = $node->psql('postgres', 'CREATE TABLE test_enc2 (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
+PGTDE::psql($node, 'postgres', 'CREATE TABLE test_enc2 (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;');
 
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');");
 
 # Verify
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_is_encrypted('test_enc');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
-(undef, $stdout, $stderr) = $node->psql('postgres', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-PGTDE::append_to_file($stderr);
+PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde CASCADE;');
 
 $node->stop();
 

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -3,7 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
 use File::Copy;
 use Test::More;
 use lib 't';

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -39,7 +39,7 @@ PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 # Change provider and move file
-PGTDE::append_to_file("-- mv /tmp/change_key_provider_1.per /tmp/change_key_provider_2.per");
+PGTDE::append_to_result_file("-- mv /tmp/change_key_provider_1.per /tmp/change_key_provider_2.per");
 move('/tmp/change_key_provider_1.per', '/tmp/change_key_provider_2.per');
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');");
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_list_all_database_key_providers();");
@@ -48,7 +48,7 @@ PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -66,7 +66,7 @@ PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -76,10 +76,10 @@ PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
-PGTDE::append_to_file("-- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_3.per");
+PGTDE::append_to_result_file("-- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_3.per");
 move('/tmp/change_key_provider_2.per', '/tmp/change_key_provider_3.per');
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");
@@ -106,7 +106,7 @@ PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');");
 
-PGTDE::append_to_file("-- server restart");
+PGTDE::append_to_result_file("-- server restart");
 $node->stop();
 $rt_value = $node->start();
 ok($rt_value == 1, "Restart Server");

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -8,14 +8,11 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
@@ -25,11 +22,9 @@ unlink('/tmp/change_key_provider_2.per');
 unlink('/tmp/change_key_provider_3.per');
 unlink('/tmp/change_key_provider_4.per');
 
-# Start server
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-# CREATE EXTENSION IF NOT EXISTS and change out file permissions
 my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
@@ -68,7 +63,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -95,7 +89,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -114,7 +107,6 @@ PGTDE::append_to_file($stderr);
 PGTDE::append_to_file("-- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_3.per");
 move('/tmp/change_key_provider_2.per', '/tmp/change_key_provider_3.per');
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -127,12 +119,10 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# DROP EXTENSION
 (undef, $stdout, $stderr) = $node->psql('postgres', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 
-# CREATE EXTENSION
 ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_file($stdout);
@@ -158,7 +148,6 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Restart the server
 PGTDE::append_to_file("-- server restart");
 $rt_value = $node->stop();
 $rt_value = $node->start();
@@ -188,19 +177,15 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# DROP EXTENSION
 (undef, $stdout, $stderr) = $node->psql('postgres', 'DROP EXTENSION pg_tde CASCADE;', extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 PGTDE::append_to_file($stderr);
 
-# Stop the server
 $node->stop();
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare, 0, "Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -64,8 +64,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', ex
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 # Verify
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
@@ -90,8 +91,9 @@ $stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id;', ex
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 # Verify
 (undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
@@ -108,8 +110,9 @@ PGTDE::append_to_file("-- mv /tmp/change_key_provider_2.per /tmp/change_key_prov
 move('/tmp/change_key_provider_2.per', '/tmp/change_key_provider_3.per');
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 # Verify
 $stdout = $node->safe_psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);
@@ -149,8 +152,9 @@ $stdout = $node->safe_psql('postgres', "SELECT pg_tde_change_database_key_provid
 PGTDE::append_to_file($stdout);
 
 PGTDE::append_to_file("-- server restart");
-$rt_value = $node->stop();
+$node->stop();
 $rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
 
 # Verify
 (undef, $stdout, $stderr) = $node->psql('postgres', "SELECT pg_tde_verify_key();", extra_params => ['-a']);

--- a/contrib/pg_tde/t/011_unlogged_tables.pl
+++ b/contrib/pg_tde/t/011_unlogged_tables.pl
@@ -7,19 +7,15 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# Get file name and CREATE out file name and dirs WHERE requried
 PGTDE::setup_files_dir(basename($0));
 
-# CREATE new PostgreSQL node and do initdb
 my $node = PGTDE->pgtde_init_pg();
 my $pgdata = $node->data_dir;
 
-# UPDATE postgresql.conf to include/load pg_tde library
 open my $conf, '>>', "$pgdata/postgresql.conf";
 print $conf "shared_preload_libraries = 'pg_tde'\n";
 close $conf;
 
-# Start server
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
@@ -43,7 +39,6 @@ PGTDE::append_to_file($stdout);
 PGTDE::append_to_file("-- kill -9");
 $node->kill9();
 
-# Start server
 PGTDE::append_to_file("-- server start");
 $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
@@ -54,14 +49,11 @@ PGTDE::append_to_file($stdout);
 $stdout = $node->safe_psql('postgres', "INSERT INTO t SELECT generate_series(1, 4);", extra_params => ['-a']);
 PGTDE::append_to_file($stdout);
 
-# Stop the server
 $node->stop();
 
-# compare the expected and out file
+# Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-# Test/check if expected and result/out file match. If Yes, test passes.
 is($compare, 0, "Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
 
-# Done testing for this testcase file.
 done_testing();

--- a/contrib/pg_tde/t/011_unlogged_tables.pl
+++ b/contrib/pg_tde/t/011_unlogged_tables.pl
@@ -29,10 +29,10 @@ PGTDE::psql($node, 'postgres', "INSERT INTO t SELECT generate_series(1, 4);");
 
 PGTDE::psql($node, 'postgres', "CHECKPOINT;");
 
-PGTDE::append_to_file("-- kill -9");
+PGTDE::append_to_result_file("-- kill -9");
 $node->kill9();
 
-PGTDE::append_to_file("-- server start");
+PGTDE::append_to_result_file("-- server start");
 $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 

--- a/contrib/pg_tde/t/011_unlogged_tables.pl
+++ b/contrib/pg_tde/t/011_unlogged_tables.pl
@@ -3,8 +3,6 @@
 use strict;
 use warnings;
 use File::Basename;
-use File::Compare;
-use File::Copy;
 use Test::More;
 use lib 't';
 use pgtde;

--- a/contrib/pg_tde/t/011_unlogged_tables.pl
+++ b/contrib/pg_tde/t/011_unlogged_tables.pl
@@ -19,22 +19,15 @@ close $conf;
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;', extra_params => ['-a']);
-ok($cmdret == 0, "CREATE PGTDE EXTENSION");
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
-$stdout = $node->safe_psql('postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');");
+PGTDE::psql($node, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');");
 
-$stdout = $node->safe_psql('postgres', "CREATE UNLOGGED TABLE t (x int PRIMARY KEY) USING tde_heap;", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "CREATE UNLOGGED TABLE t (x int PRIMARY KEY) USING tde_heap;");
 
-$stdout = $node->safe_psql('postgres', "INSERT INTO t SELECT generate_series(1, 4);", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "INSERT INTO t SELECT generate_series(1, 4);");
 
-$stdout = $node->safe_psql('postgres', "CHECKPOINT;", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "CHECKPOINT;");
 
 PGTDE::append_to_file("-- kill -9");
 $node->kill9();
@@ -43,11 +36,9 @@ PGTDE::append_to_file("-- server start");
 $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");
 
-$stdout = $node->safe_psql('postgres', "TABLE t;", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "TABLE t;");
 
-$stdout = $node->safe_psql('postgres', "INSERT INTO t SELECT generate_series(1, 4);", extra_params => ['-a']);
-PGTDE::append_to_file($stdout);
+PGTDE::psql($node, 'postgres', "INSERT INTO t SELECT generate_series(1, 4);");
 
 $node->stop();
 

--- a/contrib/pg_tde/t/expected/001_basic.out
+++ b/contrib/pg_tde/t/expected/001_basic.out
@@ -1,7 +1,14 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_tde';
 pg_tde|1.0-rc
+CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
+psql:<stdin>:1: ERROR:  principal key not configured
+HINT:  create one using pg_tde_set_key before using encrypted tables
 -- server restart
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+1
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+
 CREATE TABLE test_enc(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES ('foobar'),('barfoo');
 SELECT * FROM test_enc ORDER BY id ASC;

--- a/contrib/pg_tde/t/expected/001_basic.out
+++ b/contrib/pg_tde/t/expected/001_basic.out
@@ -1,23 +1,43 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_tde';
-pg_tde|1.0-rc
+ extname | extversion 
+---------+------------
+ pg_tde  | 1.0-rc
+(1 row)
+
 CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 psql:<stdin>:1: ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_key before using encrypted tables
 -- server restart
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-1
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 CREATE TABLE test_enc(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES ('foobar'),('barfoo');
 SELECT * FROM test_enc ORDER BY id ASC;
-1|foobar
-2|barfoo
+ id |   k    
+----+--------
+  1 | foobar
+  2 | barfoo
+(2 rows)
+
 -- server restart
 SELECT * FROM test_enc ORDER BY id ASC;
-1|foobar
-2|barfoo
+ id |   k    
+----+--------
+  1 | foobar
+  2 | barfoo
+(2 rows)
+
 TABLEFILE FOUND: yes
 
 CONTAINS FOO (should be empty): 

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -1,4 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
+psql:<stdin>:1: ERROR:  principal key not configured
+HINT:  create one using pg_tde_set_key before using encrypted tables
 -- server restart
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 1
@@ -18,7 +21,8 @@ INSERT INTO test_enc (k) VALUES (5),(6);
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
-0
+SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');
+
 SELECT * FROM test_enc ORDER BY id ASC;
 1|5
 2|6
@@ -75,6 +79,7 @@ SELECT * FROM test_enc ORDER BY id ASC;
 2|6
 ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;
 -- server restart
+SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX2', 'file-2', false);
 psql:<stdin>:1: ERROR:  Usage of global key providers is disabled. Enable it with pg_tde.inherit_global_providers = ON
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 -1|file-2|rotated-keyX

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -90,5 +90,5 @@ psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
 DROP TABLE test_enc;
 ALTER SYSTEM RESET pg_tde.inherit_global_providers;
+-- server restart
 DROP EXTENSION pg_tde CASCADE;
-

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -4,92 +4,196 @@ psql:<stdin>:1: ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_key before using encrypted tables
 -- server restart
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-1
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
 SELECT pg_tde_add_database_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');
-2
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     2
+(1 row)
+
 SELECT pg_tde_add_global_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2g.per');
--1
+ pg_tde_add_global_key_provider_file 
+-------------------------------------
+                                  -1
+(1 row)
+
 SELECT pg_tde_add_global_key_provider_file('file-3','/tmp/pg_tde_test_keyring_3.per');
--2
+ pg_tde_add_global_key_provider_file 
+-------------------------------------
+                                  -2
+(1 row)
+
 SELECT pg_tde_list_all_database_key_providers();
-(1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring.per""}")
-(2,file-2,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring_2.per""}")
+                          pg_tde_list_all_database_key_providers                          
+------------------------------------------------------------------------------------------
+ (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring.per""}")
+ (2,file-2,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring_2.per""}")
+(2 rows)
+
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5),(6);
 SELECT * FROM test_enc ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 SELECT * FROM test_enc ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 -- server restart
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
-1|file-vault|rotated-key1
+ key_provider_id | key_provider_name |   key_name   
+-----------------+-------------------+--------------
+               1 | file-vault        | rotated-key1
+(1 row)
+
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 SELECT * FROM test_enc ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 -- server restart
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
-2|file-2|rotated-key2
+ key_provider_id | key_provider_name |   key_name   
+-----------------+-------------------+--------------
+               2 | file-2            | rotated-key2
+(1 row)
+
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 SELECT pg_tde_set_key_using_global_key_provider('rotated-key', 'file-3', false);
+ pg_tde_set_key_using_global_key_provider 
+------------------------------------------
+ 
+(1 row)
 
 SELECT * FROM test_enc ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 -- server restart
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
--2|file-3|rotated-key
+ key_provider_id | key_provider_name |  key_name   
+-----------------+-------------------+-------------
+              -2 | file-3            | rotated-key
+(1 row)
+
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX', 'file-2', false);
+ pg_tde_set_key_using_global_key_provider 
+------------------------------------------
+ 
+(1 row)
 
 SELECT * FROM test_enc ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 -- server restart
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
--1|file-2|rotated-keyX
+ key_provider_id | key_provider_name |   key_name   
+-----------------+-------------------+--------------
+              -1 | file-2            | rotated-keyX
+(1 row)
+
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
 SELECT * FROM test_enc ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;
 -- server restart
 SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX2', 'file-2', false);
 psql:<stdin>:1: ERROR:  Usage of global key providers is disabled. Enable it with pg_tde.inherit_global_providers = ON
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
--1|file-2|rotated-keyX
+ key_provider_id | key_provider_name |   key_name   
+-----------------+-------------------+--------------
+              -1 | file-2            | rotated-keyX
+(1 row)
+
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
 SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
-2|file-2|rotated-key2
+ key_provider_id | key_provider_name |   key_name   
+-----------------+-------------------+--------------
+               2 | file-2            | rotated-key2
+(1 row)
+
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key

--- a/contrib/pg_tde/t/expected/003_remote_config.out
+++ b/contrib/pg_tde/t/expected/003_remote_config.out
@@ -1,16 +1,32 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello' ));
-1
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc2 (k) VALUES (5),(6);
 SELECT * FROM test_enc2 ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 -- server restart
 SELECT * FROM test_enc2 ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 DROP TABLE test_enc2;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/t/expected/003_remote_config.out
+++ b/contrib/pg_tde/t/expected/003_remote_config.out
@@ -1,4 +1,8 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
+SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello' ));
+1
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');
+
 CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc2 (k) VALUES (5),(6);
 SELECT * FROM test_enc2 ORDER BY id ASC;

--- a/contrib/pg_tde/t/expected/004_file_config.out
+++ b/contrib/pg_tde/t/expected/004_file_config.out
@@ -1,4 +1,8 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
+SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));
+1
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');
+
 CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc1 (k) VALUES (5),(6);
 SELECT * FROM test_enc1 ORDER BY id ASC;

--- a/contrib/pg_tde/t/expected/004_file_config.out
+++ b/contrib/pg_tde/t/expected/004_file_config.out
@@ -1,16 +1,32 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));
-1
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc1 (k) VALUES (5),(6);
 SELECT * FROM test_enc1 ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 -- server restart
 SELECT * FROM test_enc1 ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 DROP TABLE test_enc1;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/t/expected/006_remote_vault_config.out
+++ b/contrib/pg_tde/t/expected/006_remote_vault_config.out
@@ -1,16 +1,32 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url' ), to_json('secret'::text), NULL);
-1
+ pg_tde_add_database_key_provider_vault_v2 
+-------------------------------------------
+                                         1
+(1 row)
+
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','vault-provider');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc2 (k) VALUES (5),(6);
 SELECT * FROM test_enc2 ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 -- server restart
 SELECT * FROM test_enc2 ORDER BY id ASC;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 DROP TABLE test_enc2;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/t/expected/006_remote_vault_config.out
+++ b/contrib/pg_tde/t/expected/006_remote_vault_config.out
@@ -1,4 +1,8 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url' ), to_json('secret'::text), NULL);
+1
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','vault-provider');
+
 CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc2 (k) VALUES (5),(6);
 SELECT * FROM test_enc2 ORDER BY id ASC;

--- a/contrib/pg_tde/t/expected/007_tde_heap.out
+++ b/contrib/pg_tde/t/expected/007_tde_heap.out
@@ -1,5 +1,12 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
+psql:<stdin>:1: ERROR:  principal key not configured
+HINT:  create one using pg_tde_set_key before using encrypted tables
 -- server restart
+SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+1
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+
 CREATE TABLE test_enc1(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc1 (k) VALUES ('foobar'),('barfoo');
 SELECT * FROM test_enc1 ORDER BY id ASC;
@@ -16,7 +23,9 @@ INSERT INTO test_enc3 (k) VALUES ('foobar'),('barfoo');
 SELECT * FROM test_enc3 ORDER BY id ASC;
 1|foobar
 2|barfoo
+CREATE TABLE test_enc4(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING heap;
 INSERT INTO test_enc4 (k) VALUES ('foobar'),('barfoo');
+SET default_table_access_method = "tde_heap"; ALTER TABLE test_enc4 SET ACCESS METHOD DEFAULT;
 SELECT * FROM test_enc4 ORDER BY id ASC;
 1|foobar
 2|barfoo

--- a/contrib/pg_tde/t/expected/007_tde_heap.out
+++ b/contrib/pg_tde/t/expected/007_tde_heap.out
@@ -4,68 +4,116 @@ psql:<stdin>:1: ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_key before using encrypted tables
 -- server restart
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-1
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 CREATE TABLE test_enc1(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc1 (k) VALUES ('foobar'),('barfoo');
 SELECT * FROM test_enc1 ORDER BY id ASC;
-1|foobar
-2|barfoo
+ id |   k    
+----+--------
+  1 | foobar
+  2 | barfoo
+(2 rows)
+
 CREATE TABLE test_enc2(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));
 INSERT INTO test_enc2 (k) VALUES ('foobar'),('barfoo');
 ALTER TABLE test_enc2 SET ACCESS METHOD tde_heap;
 SELECT * FROM test_enc2 ORDER BY id ASC;
-1|foobar
-2|barfoo
+ id |   k    
+----+--------
+  1 | foobar
+  2 | barfoo
+(2 rows)
+
 SET default_table_access_method = "tde_heap"; CREATE TABLE test_enc3(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));
 INSERT INTO test_enc3 (k) VALUES ('foobar'),('barfoo');
 SELECT * FROM test_enc3 ORDER BY id ASC;
-1|foobar
-2|barfoo
+ id |   k    
+----+--------
+  1 | foobar
+  2 | barfoo
+(2 rows)
+
 CREATE TABLE test_enc4(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING heap;
 INSERT INTO test_enc4 (k) VALUES ('foobar'),('barfoo');
 SET default_table_access_method = "tde_heap"; ALTER TABLE test_enc4 SET ACCESS METHOD DEFAULT;
 SELECT * FROM test_enc4 ORDER BY id ASC;
-1|foobar
-2|barfoo
+ id |   k    
+----+--------
+  1 | foobar
+  2 | barfoo
+(2 rows)
+
 CREATE TABLE test_enc5(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc5 (k) VALUES ('foobar'),('barfoo');
 CHECKPOINT;
 TRUNCATE test_enc5;
 INSERT INTO test_enc5 (k) VALUES ('foobar'),('barfoo');
 SELECT * FROM test_enc5 ORDER BY id ASC;
-3|foobar
-4|barfoo
+ id |   k    
+----+--------
+  3 | foobar
+  4 | barfoo
+(2 rows)
+
 -- server restart
 ###########################
 SELECT * FROM test_enc1 ORDER BY id ASC;
-1|foobar
-2|barfoo
+ id |   k    
+----+--------
+  1 | foobar
+  2 | barfoo
+(2 rows)
+
 TABLEFILE FOR test_enc1 FOUND: yes
 CONTAINS FOO (should be empty): 
 ###########################
 SELECT * FROM test_enc2 ORDER BY id ASC;
-1|foobar
-2|barfoo
+ id |   k    
+----+--------
+  1 | foobar
+  2 | barfoo
+(2 rows)
+
 TABLEFILE FOR test_enc2 FOUND: yes
 CONTAINS FOO (should be empty): 
 ###########################
 SELECT * FROM test_enc3 ORDER BY id ASC;
-1|foobar
-2|barfoo
+ id |   k    
+----+--------
+  1 | foobar
+  2 | barfoo
+(2 rows)
+
 TABLEFILE FOR test_enc3 FOUND: yes
 CONTAINS FOO (should be empty): 
 ###########################
 SELECT * FROM test_enc4 ORDER BY id ASC;
-1|foobar
-2|barfoo
+ id |   k    
+----+--------
+  1 | foobar
+  2 | barfoo
+(2 rows)
+
 TABLEFILE FOR test_enc4 FOUND: yes
 CONTAINS FOO (should be empty): 
 ###########################
 SELECT * FROM test_enc5 ORDER BY id ASC;
-3|foobar
-4|barfoo
+ id |   k    
+----+--------
+  3 | foobar
+  4 | barfoo
+(2 rows)
+
 TABLEFILE FOR test_enc5 FOUND: yes
 CONTAINS FOO (should be empty): 
 TABLEFILE2 FOUND: yes

--- a/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
+++ b/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
@@ -1,3 +1,5 @@
+SET allow_in_place_tablespaces = true; CREATE TABLESPACE test_tblspace LOCATION '';
+CREATE DATABASE tbc TABLESPACE = test_tblspace;
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 1
@@ -16,29 +18,14 @@ SELECT * FROM country_table;
 1|Japan|Asia
 2|UK|Europe
 3|USA|North America
-CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-1
-SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('new-k', 'file-vault');
 
-CREATE TABLE country_table (
-     country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
-) USING tde_heap;
-INSERT INTO country_table (country_name, continent)
-     VALUES ('Japan', 'Asia'),
-            ('UK', 'Europe'),
-            ('USA', 'North America');
-SELECT * FROM country_table;
-1|Japan|Asia
-2|UK|Europe
-3|USA|North America
 -- server restart
 SELECT * FROM country_table;
 1|Japan|Asia
 2|UK|Europe
 3|USA|North America
 DROP EXTENSION pg_tde CASCADE;
+psql:<stdin>:1: NOTICE:  drop cascades to table country_table
 DROP DATABASE tbc;
 DROP TABLESPACE test_tblspace;

--- a/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
+++ b/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
@@ -2,8 +2,16 @@ SET allow_in_place_tablespaces = true; CREATE TABLESPACE test_tblspace LOCATION 
 CREATE DATABASE tbc TABLESPACE = test_tblspace;
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-1
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 CREATE TABLE country_table (
      country_id        serial primary key,
@@ -15,16 +23,28 @@ INSERT INTO country_table (country_name, continent)
             ('UK', 'Europe'),
             ('USA', 'North America');
 SELECT * FROM country_table;
-1|Japan|Asia
-2|UK|Europe
-3|USA|North America
+ country_id | country_name |   continent   
+------------+--------------+---------------
+          1 | Japan        | Asia
+          2 | UK           | Europe
+          3 | USA          | North America
+(3 rows)
+
 SELECT pg_tde_set_key_using_database_key_provider('new-k', 'file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 -- server restart
 SELECT * FROM country_table;
-1|Japan|Asia
-2|UK|Europe
-3|USA|North America
+ country_id | country_name |   continent   
+------------+--------------+---------------
+          1 | Japan        | Asia
+          2 | UK           | Europe
+          3 | USA          | North America
+(3 rows)
+
 DROP EXTENSION pg_tde CASCADE;
 psql:<stdin>:1: NOTICE:  drop cascades to table country_table
 DROP DATABASE tbc;

--- a/contrib/pg_tde/t/expected/009_wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/009_wal_encrypt.out
@@ -1,49 +1,85 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');
--1
+ pg_tde_add_global_key_provider_file 
+-------------------------------------
+                                  -1
+(1 row)
+
 SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-010');
+ pg_tde_set_server_key_using_global_key_provider 
+-------------------------------------------------
+ 
+(1 row)
 
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 -- server restart with wal encryption
 SHOW pg_tde.wal_encrypt;
-on
+ pg_tde.wal_encrypt 
+--------------------
+ on
+(1 row)
+
 SELECT slot_name FROM pg_create_logical_replication_slot('tde_slot', 'test_decoding');
-tde_slot
+ slot_name 
+-----------
+ tde_slot
+(1 row)
+
 CREATE TABLE test_wal (id SERIAL, k INTEGER, PRIMARY KEY (id));
 INSERT INTO test_wal (k) VALUES (1), (2);
 ALTER SYSTEM SET pg_tde.wal_encrypt = off;
 -- server restart without wal encryption
 SHOW pg_tde.wal_encrypt;
-off
+ pg_tde.wal_encrypt 
+--------------------
+ off
+(1 row)
+
 INSERT INTO test_wal (k) VALUES (3), (4);
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 -- server restart with wal encryption
 SHOW pg_tde.wal_encrypt;
-on
+ pg_tde.wal_encrypt 
+--------------------
+ on
+(1 row)
+
 INSERT INTO test_wal (k) VALUES (5), (6);
 -- server restart with still wal encryption
 SHOW pg_tde.wal_encrypt;
-on
+ pg_tde.wal_encrypt 
+--------------------
+ on
+(1 row)
+
 INSERT INTO test_wal (k) VALUES (7), (8);
 SELECT data FROM pg_logical_slot_get_changes('tde_slot', NULL, NULL);
-BEGIN 739
-COMMIT 739
-BEGIN 740
-table public.test_wal: INSERT: id[integer]:1 k[integer]:1
-table public.test_wal: INSERT: id[integer]:2 k[integer]:2
-COMMIT 740
-BEGIN 741
-table public.test_wal: INSERT: id[integer]:3 k[integer]:3
-table public.test_wal: INSERT: id[integer]:4 k[integer]:4
-COMMIT 741
-BEGIN 742
-table public.test_wal: INSERT: id[integer]:5 k[integer]:5
-table public.test_wal: INSERT: id[integer]:6 k[integer]:6
-COMMIT 742
-BEGIN 743
-table public.test_wal: INSERT: id[integer]:7 k[integer]:7
-table public.test_wal: INSERT: id[integer]:8 k[integer]:8
-COMMIT 743
+                           data                            
+-----------------------------------------------------------
+ BEGIN 739
+ COMMIT 739
+ BEGIN 740
+ table public.test_wal: INSERT: id[integer]:1 k[integer]:1
+ table public.test_wal: INSERT: id[integer]:2 k[integer]:2
+ COMMIT 740
+ BEGIN 741
+ table public.test_wal: INSERT: id[integer]:3 k[integer]:3
+ table public.test_wal: INSERT: id[integer]:4 k[integer]:4
+ COMMIT 741
+ BEGIN 742
+ table public.test_wal: INSERT: id[integer]:5 k[integer]:5
+ table public.test_wal: INSERT: id[integer]:6 k[integer]:6
+ COMMIT 742
+ BEGIN 743
+ table public.test_wal: INSERT: id[integer]:7 k[integer]:7
+ table public.test_wal: INSERT: id[integer]:8 k[integer]:8
+ COMMIT 743
+(18 rows)
+
 SELECT pg_drop_replication_slot('tde_slot');
+ pg_drop_replication_slot 
+--------------------------
+ 
+(1 row)
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -66,7 +66,8 @@ psql:<stdin>:1: NOTICE:  drop cascades to table test_enc
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');
 1
-0
+SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');
+
 CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5), (6);
 SELECT pg_tde_verify_key();

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -1,50 +1,122 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');
-1
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
 SELECT pg_tde_list_all_database_key_providers();
-(1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_1.per""}")
+                           pg_tde_list_all_database_key_providers                           
+--------------------------------------------------------------------------------------------
+ (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_1.per""}")
+(1 row)
+
 SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5), (6);
 SELECT pg_tde_verify_key();
+ pg_tde_verify_key 
+-------------------
+ 
+(1 row)
 
 SELECT pg_tde_is_encrypted('test_enc');
-t
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 -- mv /tmp/change_key_provider_1.per /tmp/change_key_provider_2.per
 SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');
-1
+ pg_tde_change_database_key_provider_file 
+------------------------------------------
+                                        1
+(1 row)
+
 SELECT pg_tde_list_all_database_key_providers();
-(1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_2.per""}")
+                           pg_tde_list_all_database_key_providers                           
+--------------------------------------------------------------------------------------------
+ (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_2.per""}")
+(1 row)
+
 SELECT pg_tde_verify_key();
+ pg_tde_verify_key 
+-------------------
+ 
+(1 row)
 
 SELECT pg_tde_is_encrypted('test_enc');
-t
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 -- server restart
 SELECT pg_tde_verify_key();
+ pg_tde_verify_key 
+-------------------
+ 
+(1 row)
 
 SELECT pg_tde_is_encrypted('test_enc');
-t
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');
-1
+ pg_tde_change_database_key_provider_file 
+------------------------------------------
+                                        1
+(1 row)
+
 SELECT pg_tde_list_all_database_key_providers();
-(1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_3.per""}")
+                           pg_tde_list_all_database_key_providers                           
+--------------------------------------------------------------------------------------------
+ (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_3.per""}")
+(1 row)
+
 SELECT pg_tde_verify_key();
 psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
 SELECT pg_tde_is_encrypted('test_enc');
-t
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 -- server restart
 SELECT pg_tde_verify_key();
 psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
@@ -55,30 +127,66 @@ psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring w
 -- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_3.per
 -- server restart
 SELECT pg_tde_verify_key();
+ pg_tde_verify_key 
+-------------------
+ 
+(1 row)
 
 SELECT pg_tde_is_encrypted('test_enc');
-t
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 DROP EXTENSION pg_tde CASCADE;
 psql:<stdin>:1: NOTICE:  drop cascades to table test_enc
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');
-1
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
 SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 CREATE TABLE test_enc (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (5), (6);
 SELECT pg_tde_verify_key();
+ pg_tde_verify_key 
+-------------------
+ 
+(1 row)
 
 SELECT pg_tde_is_encrypted('test_enc');
-t
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_3.per');
-1
+ pg_tde_change_database_key_provider_file 
+------------------------------------------
+                                        1
+(1 row)
+
 -- server restart
 SELECT pg_tde_verify_key();
 psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, incorrect principal key or corrupted key file
@@ -89,13 +197,29 @@ psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, 
 CREATE TABLE test_enc2 (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;
 psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, incorrect principal key or corrupted key file
 SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_4.per');
-1
+ pg_tde_change_database_key_provider_file 
+------------------------------------------
+                                        1
+(1 row)
+
 SELECT pg_tde_verify_key();
+ pg_tde_verify_key 
+-------------------
+ 
+(1 row)
 
 SELECT pg_tde_is_encrypted('test_enc');
-t
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
-1|5
-2|6
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
 DROP EXTENSION pg_tde CASCADE;
 psql:<stdin>:1: NOTICE:  drop cascades to table test_enc

--- a/contrib/pg_tde/t/expected/011_unlogged_tables.out
+++ b/contrib/pg_tde/t/expected/011_unlogged_tables.out
@@ -1,7 +1,15 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');
-1
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
 SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
 
 CREATE UNLOGGED TABLE t (x int PRIMARY KEY) USING tde_heap;
 INSERT INTO t SELECT generate_series(1, 4);
@@ -9,4 +17,8 @@ CHECKPOINT;
 -- kill -9
 -- server start
 TABLE t;
+ x 
+---
+(0 rows)
+
 INSERT INTO t SELECT generate_series(1, 4);

--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -27,9 +27,15 @@ BEGIN {
     $PG_MAJOR_VERSION =~ s/^\s+|\s+$//g;
 
     if ($PG_MAJOR_VERSION >= 15) {
-        eval { require PostgreSQL::Test::Cluster; };
+        eval {
+            require PostgreSQL::Test::Cluster;
+            import PostgreSQL::Test::Utils;
+        }
     } else {
-        eval { require PostgresNode; };
+        eval {
+            require PostgresNode;
+            import TestLib;
+        }
     }
 }
 
@@ -58,34 +64,26 @@ sub psql
     my (undef, $stdout, $stderr) = $node->psql($dbname, $sql, extra_params => ['-a']);
 
     if ($stdout ne '') {
-        append_to_file($stdout);
+        append_to_result_file($stdout);
     }
 
     if ($stderr ne '') {
-        append_to_file($stderr);
+        append_to_result_file($stderr);
     }
 }
 
-sub append_to_file
+sub append_to_result_file
 {
     my ($str) = @_;
 
-    if ($PG_MAJOR_VERSION >= 15) {
-        PostgreSQL::Test::Utils::append_to_file($out_filename_with_path, $str . "\n");
-    } else {
-        TestLib::append_to_file($out_filename_with_path, $str . "\n");
-    }
+    append_to_file($out_filename_with_path, $str . "\n");
 }
 
 sub append_to_debug_file
 {
     my ($str) = @_;
 
-    if ($PG_MAJOR_VERSION >= 15) {
-        PostgreSQL::Test::Utils::append_to_file($debug_out_filename_with_path, $str . "\n");
-    } else {
-        TestLib::append_to_file($debug_out_filename_with_path, $str . "\n");
-    }
+    append_to_file($debug_out_filename_with_path, $str . "\n");
 }
 
 sub setup_files_dir

--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -9,9 +9,6 @@ our @ISA = qw(Exporter);
 # These CAN be exported.
 our @EXPORT = qw(pgtde_init_pg pgtde_start_pg pgtde_stop_pg pgtde_psql_cmd pgtde_setup_pg_tde pgtde_create_extension pgtde_drop_extension);
 
-# Instance of pg server that would be spanwed by TAP testing. A new server will be created for each TAP test.
-our $pg_node;
-
 # Expected .out filename of TAP testcase being executed. These are already part of repo under t/expected/*.
 our $expected_filename_with_path;
 
@@ -38,18 +35,20 @@ BEGIN {
 
 sub pgtde_init_pg
 {
+    my $node;
+
     print "Postgres major version: $PG_MAJOR_VERSION \n";
 
     # For Server version 15 & above, spawn the server using PostgreSQL::Test::Cluster
     if ($PG_MAJOR_VERSION >= 15) {
-        $pg_node = PostgreSQL::Test::Cluster->new('pgtde_regression');
+        $node = PostgreSQL::Test::Cluster->new('pgtde_regression');
     } else {
-        $pg_node = PostgresNode->get_new_node('pgtde_regression');
+        $node = PostgresNode->get_new_node('pgtde_regression');
     }
 
-    $pg_node->dump_info;
-    $pg_node->init;
-    return $pg_node;
+    $node->dump_info;
+    $node->init;
+    return $node;
 }
 
 sub append_to_file

--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -61,7 +61,7 @@ sub psql
 {
     my ($node, $dbname, $sql) = @_;
 
-    my (undef, $stdout, $stderr) = $node->psql($dbname, $sql, extra_params => ['-a']);
+    my (undef, $stdout, $stderr) = $node->psql($dbname, $sql, extra_params => ['-a', '-Pformat=aligned', '-Ptuples_only=off']);
 
     if ($stdout ne '') {
         append_to_result_file($stdout);

--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -51,6 +51,21 @@ sub pgtde_init_pg
     return $node;
 }
 
+sub psql
+{
+    my ($node, $dbname, $sql) = @_;
+
+    my (undef, $stdout, $stderr) = $node->psql($dbname, $sql, extra_params => ['-a']);
+
+    if ($stdout ne '') {
+        append_to_file($stdout);
+    }
+
+    if ($stderr ne '') {
+        append_to_file($stderr);
+    }
+}
+
 sub append_to_file
 {
     my ($str) = @_;


### PR DESCRIPTION
Having worked a bit too much with out TAP tests during the last week I realized that one way they could be improved while still using this way of prepending we are like `pg_regress` is to do it more properly instead of halfhearted so I added a `PGTDE::psql()` helper which calls runs the query and then appends both stderr and stdout to the file when later will diff.

The reason for this is because right now when something goes wrong and some query fails you just get a truncated output file and then have to start modifying the test case to add debug output. Ideally we should have the error message of the failing query easily visible when the test run fails.

What do you think? The alternative would to abandon the idea of diffing the two files and instead aim for more idiomatic TAP tests instead because just running `safe_psql()` does not seem to give us much.

Edit: This is ready for review now.