### PR TITLE
Modernize the way we call ereport() part 2

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -216,8 +216,8 @@ pg_tde_change_global_key_provider(PG_FUNCTION_ARGS)
 {
 	if (!superuser())
 		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to modify global key providers")));
+				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("must be superuser to modify global key providers"));
 
 	return pg_tde_change_key_provider_internal(fcinfo, GLOBAL_DATA_TDE_OID);
 }
@@ -271,8 +271,8 @@ pg_tde_add_global_key_provider(PG_FUNCTION_ARGS)
 {
 	if (!superuser())
 		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to modify global key providers")));
+				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("must be superuser to modify global key providers"));
 
 	return pg_tde_add_key_provider_internal(fcinfo, GLOBAL_DATA_TDE_OID);
 }

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -487,8 +487,8 @@ pg_tde_set_default_key_using_global_key_provider(PG_FUNCTION_ARGS)
 
 	if (!superuser())
 		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to access global key providers")));
+				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("must be superuser to access global key providers"));
 
 	pg_tde_set_principal_key_internal(principal_key_name, GS_DEFAULT, provider_name, ensure_new_key);
 
@@ -516,8 +516,8 @@ pg_tde_set_key_using_global_key_provider(PG_FUNCTION_ARGS)
 
 	if (!superuser())
 		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to access global key providers")));
+				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("must be superuser to access global key providers"));
 
 	pg_tde_set_principal_key_internal(principal_key_name, GS_GLOBAL, provider_name, ensure_new_key);
 
@@ -533,8 +533,8 @@ pg_tde_set_server_key_using_global_key_provider(PG_FUNCTION_ARGS)
 
 	if (!superuser())
 		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to access global key providers")));
+				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("must be superuser to access global key providers"));
 
 	pg_tde_set_principal_key_internal(principal_key_name, GS_SERVER, provider_name, ensure_new_key);
 
@@ -1062,8 +1062,8 @@ pg_tde_delete_global_key_provider(PG_FUNCTION_ARGS)
 {
 	if (!superuser())
 		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be superuser to modify global key providers")));
+				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("must be superuser to modify global key providers"));
 
 	return pg_tde_delete_key_provider_internal(fcinfo, 1);
 }

--- a/contrib/pg_tde/src/encryption/enc_aes.c
+++ b/contrib/pg_tde/src/encryption/enc_aes.c
@@ -150,35 +150,35 @@ AesGcmEncrypt(const unsigned char *key, const unsigned char *iv, const unsigned 
 
 	if (EVP_EncryptInit_ex(ctx, cipher_gcm, NULL, NULL, NULL) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_EncryptInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_EncryptInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_CIPHER_CTX_set_padding(ctx, 0) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CIPHER_CTX_set_padding failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CIPHER_CTX_set_padding failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 16, NULL) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CTRL_GCM_SET_IVLEN failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CTRL_GCM_SET_IVLEN failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_EncryptInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_EncryptInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_EncryptUpdate(ctx, NULL, &out_len, (unsigned char *) aad, aad_len) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_EncryptUpdate(ctx, out, &out_len, in, in_len) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_EncryptFinal_ex(ctx, out + out_len, &out_len_final) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CipherFinal_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CipherFinal_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, tag) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CTRL_GCM_GET_TAG failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CTRL_GCM_GET_TAG failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	/*
 	 * We encrypt one block (16 bytes) Our expectation is that the result
@@ -205,31 +205,31 @@ AesGcmDecrypt(const unsigned char *key, const unsigned char *iv, const unsigned 
 
 	if (EVP_DecryptInit_ex(ctx, cipher_gcm, NULL, NULL, NULL) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_EncryptInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_EncryptInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_CIPHER_CTX_set_padding(ctx, 0) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CIPHER_CTX_set_padding failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CIPHER_CTX_set_padding failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 16, NULL) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CTRL_GCM_SET_IVLEN failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CTRL_GCM_SET_IVLEN failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_EncryptInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_EncryptInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, tag) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CTRL_GCM_SET_TAG failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CTRL_GCM_SET_TAG failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_DecryptUpdate(ctx, NULL, &out_len, aad, aad_len) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_DecryptUpdate(ctx, out, &out_len, in, in_len) == 0)
 		ereport(ERROR,
-				(errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL))));
+				errmsg("EVP_CipherUpdate failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
 	if (EVP_DecryptFinal_ex(ctx, out + out_len, &out_len_final) == 0)
 	{

--- a/contrib/pg_tde/src/keyring/keyring_api.c
+++ b/contrib/pg_tde/src/keyring/keyring_api.c
@@ -78,7 +78,7 @@ RegisterKeyProviderType(const TDEKeyringRoutine *routine, ProviderType type)
 	kp = find_key_provider_type(type);
 	if (kp)
 		ereport(ERROR,
-				(errmsg("Key provider of type %d already registered", type)));
+				errmsg("Key provider of type %d already registered", type));
 
 #ifndef FRONTEND
 	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
@@ -102,7 +102,7 @@ KeyringGetKey(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes 
 	if (kp == NULL)
 	{
 		ereport(WARNING,
-				(errmsg("Key provider of type %d not registered", keyring->type)));
+				errmsg("Key provider of type %d not registered", keyring->type));
 		*returnCode = KEYRING_CODE_INVALID_PROVIDER;
 		return NULL;
 	}
@@ -116,7 +116,7 @@ KeyringStoreKey(GenericKeyring *keyring, KeyInfo *key)
 
 	if (kp == NULL)
 		ereport(ERROR,
-				(errmsg("Key provider of type %d not registered", keyring->type)));
+				errmsg("Key provider of type %d not registered", keyring->type));
 
 	kp->routine->keyring_store_key(keyring, key);
 }


### PR DESCRIPTION
These were not updated in 725c34da520cca4597f6751d1d671c6191466200 and we still want to use this way of calling ereport() everywhere.