### PR TITLE
PG-1441 Clean up the descriptions we get when inspecting pg_tde WAL

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -764,7 +764,7 @@ pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_p
 	/* Insert the XLog record */
 	XLogBeginInsert();
 	XLogRegisterData((char *) xlrec, xlrec_size);
-	XLogInsert(RM_TDERMGR_ID, XLOG_TDE_ROTATE_KEY);
+	XLogInsert(RM_TDERMGR_ID, XLOG_TDE_ROTATE_PRINCIPAL_KEY);
 
 	pfree(xlrec);
 

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -30,10 +30,8 @@ static void tdeheap_rmgr_redo(XLogReaderState *record);
 static void tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record);
 static const char *tdeheap_rmgr_identify(uint8 info);
 
-#define RM_TDERMGR_NAME	"test_tdeheap_custom_rmgr"
-
 static const RmgrData tdeheap_rmgr = {
-	.rm_name = RM_TDERMGR_NAME,
+	.rm_name = "pg_tde",
 	.rm_redo = tdeheap_rmgr_redo,
 	.rm_desc = tdeheap_rmgr_desc,
 	.rm_identify = tdeheap_rmgr_identify,

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -99,31 +99,31 @@ tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 	{
 		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
 
-		appendStringInfo(buf, "add tde internal key for relation %u/%u", xlrec->pkInfo.data.databaseId, xlrec->mapEntry.relNumber);
+		appendStringInfo(buf, "rel: %u/%u/%u", xlrec->mapEntry.spcOid, xlrec->pkInfo.data.databaseId, xlrec->mapEntry.relNumber);
 	}
 	else if (info == XLOG_TDE_ADD_PRINCIPAL_KEY)
 	{
 		TDEPrincipalKeyInfo *xlrec = (TDEPrincipalKeyInfo *) XLogRecGetData(record);
 
-		appendStringInfo(buf, "add tde principal key for db %u", xlrec->databaseId);
+		appendStringInfo(buf, "db: %u", xlrec->databaseId);
 	}
 	else if (info == XLOG_TDE_EXTENSION_INSTALL_KEY)
 	{
 		XLogExtensionInstall *xlrec = (XLogExtensionInstall *) XLogRecGetData(record);
 
-		appendStringInfo(buf, "tde extension install for db %u", xlrec->database_id);
+		appendStringInfo(buf, "db: %u", xlrec->database_id);
 	}
 	else if (info == XLOG_TDE_ROTATE_KEY)
 	{
 		XLogPrincipalKeyRotate *xlrec = (XLogPrincipalKeyRotate *) XLogRecGetData(record);
 
-		appendStringInfo(buf, "rotate principal key for %u", xlrec->databaseId);
+		appendStringInfo(buf, "db: %u", xlrec->databaseId);
 	}
 	else if (info == XLOG_TDE_ADD_KEY_PROVIDER_KEY)
 	{
 		KeyringProviderXLRecord *xlrec = (KeyringProviderXLRecord *) XLogRecGetData(record);
 
-		appendStringInfo(buf, "add key provider %s for %u", xlrec->provider.provider_name, xlrec->database_id);
+		appendStringInfo(buf, "db: %u, provider id: %d", xlrec->database_id, xlrec->provider.provider_id);
 	}
 }
 
@@ -133,11 +133,11 @@ tdeheap_rmgr_identify(uint8 info)
 	switch (info & ~XLR_INFO_MASK)
 	{
 		case XLOG_TDE_ADD_RELATION_KEY:
-			return "XLOG_TDE_ADD_RELATION_KEY";
+			return "ADD_RELATION_KEY";
 		case XLOG_TDE_ADD_PRINCIPAL_KEY:
-			return "XLOG_TDE_ADD_PRINCIPAL_KEY";
+			return "ADD_PRINCIPAL_KEY";
 		case XLOG_TDE_EXTENSION_INSTALL_KEY:
-			return "XLOG_TDE_EXTENSION_INSTALL_KEY";
+			return "EXTENSION_INSTALL_KEY";
 		default:
 			return NULL;
 	}

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -125,6 +125,12 @@ tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 
 		appendStringInfo(buf, "db: %u, provider id: %d", xlrec->database_id, xlrec->provider.provider_id);
 	}
+	else if (info == XLOG_TDE_FREE_MAP_ENTRY)
+	{
+		RelFileLocator *xlrec = (RelFileLocator *) XLogRecGetData(record);
+
+		appendStringInfo(buf, "rel: %u/%u/%u", xlrec->spcOid, xlrec->dbOid, xlrec->relNumber);
+	}
 }
 
 static const char *
@@ -138,6 +144,12 @@ tdeheap_rmgr_identify(uint8 info)
 			return "ADD_PRINCIPAL_KEY";
 		case XLOG_TDE_EXTENSION_INSTALL_KEY:
 			return "EXTENSION_INSTALL_KEY";
+		case XLOG_TDE_ROTATE_KEY:
+			return "ROTATE_KEY";
+		case XLOG_TDE_ADD_KEY_PROVIDER_KEY:
+			return "ADD_KEY_PROVIDER_KEY";
+		case XLOG_TDE_FREE_MAP_ENTRY:
+			return "FREE_MAP_ENTRY";
 		default:
 			return NULL;
 	}

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -60,25 +60,25 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 
 		pg_tde_save_principal_key_redo(mkey);
 	}
-	else if (info == XLOG_TDE_EXTENSION_INSTALL_KEY)
+	else if (info == XLOG_TDE_INSTALL_EXTENSION)
 	{
 		XLogExtensionInstall *xlrec = (XLogExtensionInstall *) XLogRecGetData(record);
 
 		extension_install_redo(xlrec);
 	}
-	else if (info == XLOG_TDE_ADD_KEY_PROVIDER_KEY)
+	else if (info == XLOG_TDE_WRITE_KEY_PROVIDER)
 	{
 		KeyringProviderXLRecord *xlrec = (KeyringProviderXLRecord *) XLogRecGetData(record);
 
 		redo_key_provider_info(xlrec);
 	}
-	else if (info == XLOG_TDE_ROTATE_KEY)
+	else if (info == XLOG_TDE_ROTATE_PRINCIPAL_KEY)
 	{
 		XLogPrincipalKeyRotate *xlrec = (XLogPrincipalKeyRotate *) XLogRecGetData(record);
 
 		xl_tde_perform_rotate_key(xlrec);
 	}
-	else if (info == XLOG_TDE_FREE_MAP_ENTRY)
+	else if (info == XLOG_TDE_REMOVE_RELATION_KEY)
 	{
 		RelFileLocator *xlrec = (RelFileLocator *) XLogRecGetData(record);
 
@@ -107,25 +107,25 @@ tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 
 		appendStringInfo(buf, "db: %u", xlrec->databaseId);
 	}
-	else if (info == XLOG_TDE_EXTENSION_INSTALL_KEY)
+	else if (info == XLOG_TDE_INSTALL_EXTENSION)
 	{
 		XLogExtensionInstall *xlrec = (XLogExtensionInstall *) XLogRecGetData(record);
 
 		appendStringInfo(buf, "db: %u", xlrec->database_id);
 	}
-	else if (info == XLOG_TDE_ROTATE_KEY)
+	else if (info == XLOG_TDE_ROTATE_PRINCIPAL_KEY)
 	{
 		XLogPrincipalKeyRotate *xlrec = (XLogPrincipalKeyRotate *) XLogRecGetData(record);
 
 		appendStringInfo(buf, "db: %u", xlrec->databaseId);
 	}
-	else if (info == XLOG_TDE_ADD_KEY_PROVIDER_KEY)
+	else if (info == XLOG_TDE_WRITE_KEY_PROVIDER)
 	{
 		KeyringProviderXLRecord *xlrec = (KeyringProviderXLRecord *) XLogRecGetData(record);
 
 		appendStringInfo(buf, "db: %u, provider id: %d", xlrec->database_id, xlrec->provider.provider_id);
 	}
-	else if (info == XLOG_TDE_FREE_MAP_ENTRY)
+	else if (info == XLOG_TDE_REMOVE_RELATION_KEY)
 	{
 		RelFileLocator *xlrec = (RelFileLocator *) XLogRecGetData(record);
 
@@ -142,14 +142,14 @@ tdeheap_rmgr_identify(uint8 info)
 			return "ADD_RELATION_KEY";
 		case XLOG_TDE_ADD_PRINCIPAL_KEY:
 			return "ADD_PRINCIPAL_KEY";
-		case XLOG_TDE_EXTENSION_INSTALL_KEY:
-			return "EXTENSION_INSTALL_KEY";
-		case XLOG_TDE_ROTATE_KEY:
-			return "ROTATE_KEY";
-		case XLOG_TDE_ADD_KEY_PROVIDER_KEY:
-			return "ADD_KEY_PROVIDER_KEY";
-		case XLOG_TDE_FREE_MAP_ENTRY:
-			return "FREE_MAP_ENTRY";
+		case XLOG_TDE_INSTALL_EXTENSION:
+			return "INSTALL_EXTENSION";
+		case XLOG_TDE_ROTATE_PRINCIPAL_KEY:
+			return "ROTATE_PRINCIPAL_KEY";
+		case XLOG_TDE_WRITE_KEY_PROVIDER:
+			return "WRITE_KEY_PROVIDER";
+		case XLOG_TDE_REMOVE_RELATION_KEY:
+			return "REMOVE_RELATION_KEY";
 		default:
 			return NULL;
 	}

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -512,7 +512,7 @@ write_key_provider_info(KeyringProviderRecord *provider, Oid database_id,
 
 			XLogBeginInsert();
 			XLogRegisterData((char *) &xlrec, sizeof(KeyringProviderXLRecord));
-			XLogInsert(RM_TDERMGR_ID, XLOG_TDE_ADD_KEY_PROVIDER_KEY);
+			XLogInsert(RM_TDERMGR_ID, XLOG_TDE_WRITE_KEY_PROVIDER);
 #else
 			Assert(0);
 #endif

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog.h
@@ -16,10 +16,10 @@
 /* TDE XLOG resource manager */
 #define XLOG_TDE_ADD_RELATION_KEY		0x00
 #define XLOG_TDE_ADD_PRINCIPAL_KEY		0x10
-#define XLOG_TDE_EXTENSION_INSTALL_KEY	0x20
-#define XLOG_TDE_ROTATE_KEY				0x30
-#define XLOG_TDE_ADD_KEY_PROVIDER_KEY 	0x40
-#define XLOG_TDE_FREE_MAP_ENTRY		 	0x50
+#define XLOG_TDE_INSTALL_EXTENSION		0x20
+#define XLOG_TDE_ROTATE_PRINCIPAL_KEY	0x30
+#define XLOG_TDE_WRITE_KEY_PROVIDER 	0x40
+#define XLOG_TDE_REMOVE_RELATION_KEY	0x50
 
 /* ID 140 is registered for Percona TDE extension: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
 #define RM_TDERMGR_ID	140

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog.h
@@ -13,13 +13,13 @@
 
 #include "postgres.h"
 
-/* TDE XLOG resource manager */
+/* TDE XLOG record types */
 #define XLOG_TDE_ADD_RELATION_KEY		0x00
-#define XLOG_TDE_ADD_PRINCIPAL_KEY		0x10
-#define XLOG_TDE_INSTALL_EXTENSION		0x20
+#define XLOG_TDE_REMOVE_RELATION_KEY	0x10
+#define XLOG_TDE_ADD_PRINCIPAL_KEY		0x20
 #define XLOG_TDE_ROTATE_PRINCIPAL_KEY	0x30
 #define XLOG_TDE_WRITE_KEY_PROVIDER 	0x40
-#define XLOG_TDE_REMOVE_RELATION_KEY	0x50
+#define XLOG_TDE_INSTALL_EXTENSION		0x50
 
 /* ID 140 is registered for Percona TDE extension: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
 #define RM_TDERMGR_ID	140

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -147,7 +147,7 @@ pg_tde_extension_initialize(PG_FUNCTION_ARGS)
 	 */
 	XLogBeginInsert();
 	XLogRegisterData((char *) &xlrec, sizeof(XLogExtensionInstall));
-	XLogInsert(RM_TDERMGR_ID, XLOG_TDE_EXTENSION_INSTALL_KEY);
+	XLogInsert(RM_TDERMGR_ID, XLOG_TDE_INSTALL_EXTENSION);
 
 	PG_RETURN_NULL();
 }


### PR DESCRIPTION
While working on the WAL I ran into the issue that the output was a mess so to more comfortably use it during development I cleaned up the output.

Before:

```
# SELECT * FROM pg_get_wal_records_info('0/01000000', '0/02000000') WHERE resource_manager LIKE '%tde%';
 start_lsn |  end_lsn  | prev_lsn  | xid |     resource_manager     |          record_type           | record_length | main_data_length | fpi_length |                description                | block_ref 
-----------+-----------+-----------+-----+--------------------------+--------------------------------+---------------+------------------+------------+-------------------------------------------+-----------
 0/185EDF8 | 0/185EE18 | 0/185EDB8 | 740 | test_tdeheap_custom_rmgr | XLOG_TDE_EXTENSION_INSTALL_KEY |            30 |                4 |          0 | tde extension install for db 5            | 
 0/1877B50 | 0/1878020 | 0/1877B18 |   0 | test_tdeheap_custom_rmgr | UNKNOWN (40)                   |          1205 |             1176 |          0 | add key provider reg_file-vault for 5     | 
 0/1878068 | 0/18781C0 | 0/1878020 |   0 | test_tdeheap_custom_rmgr | XLOG_TDE_ADD_PRINCIPAL_KEY     |           341 |              312 |          0 | add tde principal key for db 5            | 
 0/1878228 | 0/18783E0 | 0/18781F8 | 741 | test_tdeheap_custom_rmgr | XLOG_TDE_ADD_RELATION_KEY      |           437 |              408 |          0 | add tde internal key for relation 5/16450 | 
 0/1886B88 | 0/1886D40 | 0/1886B58 | 742 | test_tdeheap_custom_rmgr | XLOG_TDE_ADD_RELATION_KEY      |           437 |              408 |          0 | add tde internal key for relation 5/16453 | 
(5 rows)
```

After:

```
# SELECT * FROM pg_get_wal_records_info('0/01000000', '0/02000000') WHERE resource_manager = 'pg_tde';
 start_lsn |  end_lsn  | prev_lsn  | xid | resource_manager |    record_type    | record_length | main_data_length | fpi_length |    description     | block_ref 
-----------+-----------+-----------+-----+------------------+-------------------+---------------+------------------+------------+--------------------+-----------
 0/185EE30 | 0/185EE50 | 0/185EDF0 | 740 | pg_tde           | INSTALL_EXTENSION |            30 |                4 |          0 | db: 5              | 
 0/1877B88 | 0/1878058 | 0/1877B50 |   0 | pg_tde           | ADD_KEY_PROVIDER  |          1205 |             1176 |          0 | db: 5, provider: 1 | 
 0/18780A0 | 0/18781F8 | 0/1878058 |   0 | pg_tde           | ADD_PRINCIPAL_KEY |           341 |              312 |          0 | db: 5              | 
 0/1878228 | 0/18783E0 | 0/18781F8 | 741 | pg_tde           | ADD_RELATION_KEY  |           437 |              408 |          0 | rel: 1663/5/16450  | 
 0/1886B88 | 0/1886D40 | 0/1886B58 | 742 | pg_tde           | ADD_RELATION_KEY  |           437 |              408 |          0 | rel: 1663/5/16453  | 
(5 rows)
```