### PR TITLE
pfree tmp key when set principal key

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -361,6 +361,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 	LWLockRelease(lock_files);
 
 	pfree(new_keyring);
+	pfree(new_principal_key);
 }
 
 /*


### PR DESCRIPTION
Pushing a principal key to the cache, we copy it to the shared mem. Hence, the palloced tmp version can be freed.