### PR TITLE
PG-1535 Do not delete global key provider in use

### DIFF
--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -39,8 +39,9 @@ ERROR:  Can't delete a provider which is currently in use
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  id | provider_name 
 ----+---------------
+ -1 | file-keyring
  -3 | file-provider
-(1 row)
+(2 rows)
 
 -- Should fail: no principal key for the database yet
 SELECT  key_provider_id, key_provider_name, key_name

--- a/contrib/pg_tde/expected/default_principal_key_1.out
+++ b/contrib/pg_tde/expected/default_principal_key_1.out
@@ -40,8 +40,9 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  id |  provider_name  
 ----+-----------------
  -1 | reg_file-global
+ -2 | file-keyring
  -4 | file-provider
-(2 rows)
+(3 rows)
 
 -- Should fail: no principal key for the database yet
 SELECT  key_provider_id, key_provider_name, key_name

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -139,16 +139,13 @@ SELECT pg_tde_set_key_using_global_key_provider('test-db-key', 'file-keyring', f
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-keyring');
- pg_tde_delete_global_key_provider 
------------------------------------
- 
-(1 row)
-
+ERROR:  Can't delete a provider which is currently in use
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  id | provider_name 
 ----+---------------
+ -1 | file-keyring
  -2 | file-keyring2
-(1 row)
+(2 rows)
 
 -- works
 SELECT pg_tde_delete_global_key_provider('file-keyring2');
@@ -160,6 +157,7 @@ SELECT pg_tde_delete_global_key_provider('file-keyring2');
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  id | provider_name 
 ----+---------------
-(0 rows)
+ -1 | file-keyring
+(1 row)
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/key_provider_1.out
+++ b/contrib/pg_tde/expected/key_provider_1.out
@@ -141,17 +141,14 @@ SELECT pg_tde_set_key_using_global_key_provider('test-db-key', 'file-keyring', f
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-keyring');
- pg_tde_delete_global_key_provider 
------------------------------------
- 
-(1 row)
-
+ERROR:  Can't delete a provider which is currently in use
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  id |  provider_name  
 ----+-----------------
  -1 | reg_file-global
+ -2 | file-keyring
  -3 | file-keyring2
-(2 rows)
+(3 rows)
 
 -- works
 SELECT pg_tde_delete_global_key_provider('file-keyring2');
@@ -164,6 +161,7 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
  id |  provider_name  
 ----+-----------------
  -1 | reg_file-global
-(1 row)
+ -2 | file-keyring
+(2 rows)
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -953,7 +953,7 @@ pg_tde_is_provider_used(Oid databaseOid, Oid providerId)
 				continue;
 			}
 
-			if (providerId == principal_key->keyInfo.keyringId && principal_key->keyInfo.databaseId == GLOBAL_DATA_TDE_OID)
+			if (providerId == principal_key->keyInfo.keyringId)
 			{
 				systable_endscan(scan);
 				table_close(rel, AccessShareLock);


### PR DESCRIPTION
The code wrongly assumed that the databaseId set in the keyInfo returned from GetPrincipalKeyNoDefault() would be the Oid of the key provider owner, while in reality it is the Oid of the database using it as a principal key.