### PR TITLE
Clean up `pgtde.pm`

### DIFF
--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -16,6 +16,9 @@ our $out_filename_with_path;
 # Runtime output file that is used only for debugging purposes for comparison to PGSS, blocks and timings.
 our $debug_out_filename_with_path;
 
+my $expected_folder = "t/expected";
+my $results_folder = "t/results";
+
 sub pgtde_init_pg
 {
     my $node = PostgreSQL::Test::Cluster->new('pgtde_regression');
@@ -55,37 +58,23 @@ sub append_to_debug_file
 
 sub setup_files_dir
 {
-    my ($perlfilename) = @_;
-
-    my $expected_folder = "t/expected";
-    my $results_folder = "t/results";
+    my ($test_filename) = @_;
 
     unless (-d $results_folder)
     {
         mkdir $results_folder or die "Can't create folder $results_folder: $!\n";
     }
 
-    unless (-d $expected_folder)
-    {
-        BAIL_OUT "Expected files folder $expected_folder doesn't exist: \n";
-    }
+    my ($test_name) = $test_filename =~ /([^.]*)/;
 
-    my @split_arr = split /\./, $perlfilename;
-
-    my $filename_without_extension = $split_arr[0];
-
-    my $expected_filename = "${filename_without_extension}.out";
-    $expected_filename_with_path = "${expected_folder}/${expected_filename}";
-
-    my $out_filename = "${filename_without_extension}.out";
-    $out_filename_with_path = "${results_folder}/${out_filename}";
+    $expected_filename_with_path = "${expected_folder}/${test_name}.out";
+    $out_filename_with_path = "${results_folder}/${test_name}.out";
+    $debug_out_filename_with_path = "${results_folder}/${test_name}.out.debug";
 
     if (-f $out_filename_with_path)
     {
         unlink($out_filename_with_path) or die "Can't delete already existing $out_filename_with_path: $!\n";
     }
-
-    $debug_out_filename_with_path = "${results_folder}/${out_filename}.debug";
 }
 
 sub compare_results

--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -1,5 +1,8 @@
 package PGTDE;
 
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+
 use File::Basename;
 use File::Compare;
 use Test::More;
@@ -7,45 +10,15 @@ use Test::More;
 # Expected .out filename of TAP testcase being executed. These are already part of repo under t/expected/*.
 our $expected_filename_with_path;
 
-# Major version of PG Server that we are using.
-our $PG_MAJOR_VERSION;
-
 # Result .out filename of TAP testcase being executed. Where needed, a new *.out will be created for each TAP test.
 our $out_filename_with_path;
 
 # Runtime output file that is used only for debugging purposes for comparison to PGSS, blocks and timings.
 our $debug_out_filename_with_path;
 
-BEGIN {
-    $PG_MAJOR_VERSION = `pg_config --version | awk {'print \$2'} | cut -f1 -d"." | sed -e 's/[^0-9].*\$//g'`;
-    $PG_MAJOR_VERSION =~ s/^\s+|\s+$//g;
-
-    if ($PG_MAJOR_VERSION >= 15) {
-        eval {
-            require PostgreSQL::Test::Cluster;
-            import PostgreSQL::Test::Utils;
-        }
-    } else {
-        eval {
-            require PostgresNode;
-            import TestLib;
-        }
-    }
-}
-
 sub pgtde_init_pg
 {
-    my $node;
-
-    print "Postgres major version: $PG_MAJOR_VERSION\n";
-
-    # For Server version 15 & above, spawn the server using PostgreSQL::Test::Cluster
-    if ($PG_MAJOR_VERSION >= 15) {
-        $node = PostgreSQL::Test::Cluster->new('pgtde_regression');
-    } else {
-        $node = PostgresNode->get_new_node('pgtde_regression');
-    }
-
+    my $node = PostgreSQL::Test::Cluster->new('pgtde_regression');
     $node->dump_info;
     $node->init;
     return $node;

--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -4,11 +4,6 @@ use File::Basename;
 use File::Compare;
 use Test::More;
 
-our @ISA = qw(Exporter);
-
-# These CAN be exported.
-our @EXPORT = qw(pgtde_init_pg pgtde_start_pg pgtde_stop_pg pgtde_psql_cmd pgtde_setup_pg_tde pgtde_create_extension pgtde_drop_extension);
-
 # Expected .out filename of TAP testcase being executed. These are already part of repo under t/expected/*.
 our $expected_filename_with_path;
 
@@ -22,7 +17,6 @@ our $out_filename_with_path;
 our $debug_out_filename_with_path;
 
 BEGIN {
-    # Get PG Server Major version from pg_config 
     $PG_MAJOR_VERSION = `pg_config --version | awk {'print \$2'} | cut -f1 -d"." | sed -e 's/[^0-9].*\$//g'`;
     $PG_MAJOR_VERSION =~ s/^\s+|\s+$//g;
 
@@ -43,7 +37,7 @@ sub pgtde_init_pg
 {
     my $node;
 
-    print "Postgres major version: $PG_MAJOR_VERSION \n";
+    print "Postgres major version: $PG_MAJOR_VERSION\n";
 
     # For Server version 15 & above, spawn the server using PostgreSQL::Test::Cluster
     if ($PG_MAJOR_VERSION >= 15) {
@@ -90,40 +84,30 @@ sub setup_files_dir
 {
     my ($perlfilename) = @_;
 
-    # Expected folder where expected output will be present
     my $expected_folder = "t/expected";
-
-    # Results/out folder where generated results files will be placed
     my $results_folder = "t/results";
 
-    # Check if results folder exists or not, create if it doesn't
     unless (-d $results_folder)
     {
         mkdir $results_folder or die "Can't create folder $results_folder: $!\n";
     }
 
-    # Check if expected folder exists or not, bail out if it doesn't
     unless (-d $expected_folder)
     {
         BAIL_OUT "Expected files folder $expected_folder doesn't exist: \n";
     }
 
-    #Remove .pl from filename and store in a variable
     my @split_arr = split /\./, $perlfilename;
 
     my $filename_without_extension = $split_arr[0];
 
-    # Create expected filename with path
     my $expected_filename = "${filename_without_extension}.out";
-
     $expected_filename_with_path = "${expected_folder}/${expected_filename}";
 
-    # Create results filename with path
     my $out_filename = "${filename_without_extension}.out";
     $out_filename_with_path = "${results_folder}/${out_filename}";
 
-    # Delete already existing result out file, if it exists.
-    if ( -f $out_filename_with_path)
+    if (-f $out_filename_with_path)
     {
         unlink($out_filename_with_path) or die "Can't delete already existing $out_filename_with_path: $!\n";
     }
@@ -133,7 +117,6 @@ sub setup_files_dir
 
 sub compare_results
 {
-    # Compare expected and results files and return the result
     return compare($expected_filename_with_path, $out_filename_with_path);
 }
 


### PR DESCRIPTION
We can improve the readability of `pgtde.pm` quite a bit, especially by stopping to pretend that we support PostgreSQL 14 and older until we actually have CI which verifies it. The support is very likely to be broken when we never run it. And once we do it is trivial to re-add.