### PR TITLE
Use `append_conf()` helper in TAP tests

### DIFF
--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -10,11 +10,7 @@ use pgtde;
 PGTDE::setup_files_dir(basename($0));
 
 my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde'\n";
-close $conf;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -10,11 +10,7 @@ use pgtde;
 PGTDE::setup_files_dir(basename($0));
 
 my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde'\n";
-close $conf;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -7,11 +7,6 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-PGTDE::setup_files_dir(basename($0));
-
-my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
 {
 package MyWebServer;
  
@@ -52,9 +47,10 @@ sub resp_hello {
 
 my $pid = MyWebServer->new(8888)->background();
 
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde'\n";
-close $conf;
+PGTDE::setup_files_dir(basename($0));
+
+my $node = PGTDE->pgtde_init_pg();
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start();
 ok($rt_value == 1, "Start Server");

--- a/contrib/pg_tde/t/004_file_config.pl
+++ b/contrib/pg_tde/t/004_file_config.pl
@@ -10,11 +10,7 @@ use pgtde;
 PGTDE::setup_files_dir(basename($0));
 
 my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde'\n";
-close $conf;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 open my $conf2, '>>', "/tmp/datafile-location";
 print $conf2 "/tmp/keyring_data_file\n";

--- a/contrib/pg_tde/t/005_multiple_extensions.pl
+++ b/contrib/pg_tde/t/005_multiple_extensions.pl
@@ -17,13 +17,9 @@ if (index(lc($PG_VERSION_STRING), lc("Percona Distribution")) == -1)
 }
 
 my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde, pg_stat_monitor, pgaudit, set_user, pg_repack'\n";
-print $conf "pg_stat_monitor.pgsm_bucket_time = 360000\n";
-print $conf "pg_stat_monitor.pgsm_normalized_query = 'yes'\n";
-close $conf;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde, pg_stat_monitor, pgaudit, set_user, pg_repack'");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_bucket_time = 360000");
+$node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_normalized_query = 'yes'");
 
 open my $conf2, '>>', "/tmp/datafile-location";
 print $conf2 "/tmp/keyring_data_file\n";

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -8,11 +8,6 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-PGTDE::setup_files_dir(basename($0));
-
-my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
 {
 package MyWebServer;
  
@@ -60,9 +55,10 @@ sub resp_url {
 
 my $pid = MyWebServer->new(8889)->background();
 
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde'\n";
-close $conf;
+PGTDE::setup_files_dir(basename($0));
+
+my $node = PGTDE->pgtde_init_pg();
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start();
 ok($rt_value == 1, "Start Server");

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -9,19 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
-my $PG_VERSION_STRING = `pg_config --version`;
-
-if (index(lc($PG_VERSION_STRING), lc("Percona Server")) == -1)
-{
-    plan skip_all => "pg_tde test case only for Percona Server for PostgreSQL";
-}
-
 my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde'\n";
-close $conf;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");

--- a/contrib/pg_tde/t/008_key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/008_key_rotate_tablespace.pl
@@ -10,11 +10,7 @@ use pgtde;
 PGTDE::setup_files_dir(basename($0));
 
 my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde'\n";
-close $conf;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -10,14 +10,10 @@ use pgtde;
 PGTDE::setup_files_dir(basename($0));
 
 my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde'\n";
-print $conf "wal_level = 'logical'\n";
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
+$node->append_conf('postgresql.conf', "wal_level = 'logical'");
 # NOT testing that it can't start: the test framework doesn't have an easy way to do this
-# print $conf "pg_tde.wal_encrypt = 1\n";
-close $conf;
+#$node->append_conf('postgresql.conf', "pg_tde.wal_encrypt = 1"});
 
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -11,11 +11,7 @@ use pgtde;
 PGTDE::setup_files_dir(basename($0));
 
 my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde'\n";
-close $conf;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 unlink('/tmp/change_key_provider_1.per');
 unlink('/tmp/change_key_provider_2.per');

--- a/contrib/pg_tde/t/011_unlogged_tables.pl
+++ b/contrib/pg_tde/t/011_unlogged_tables.pl
@@ -10,11 +10,7 @@ use pgtde;
 PGTDE::setup_files_dir(basename($0));
 
 my $node = PGTDE->pgtde_init_pg();
-my $pgdata = $node->data_dir;
-
-open my $conf, '>>', "$pgdata/postgresql.conf";
-print $conf "shared_preload_libraries = 'pg_tde'\n";
-close $conf;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start;
 ok($rt_value == 1, "Start Server");


### PR DESCRIPTION
This is what PostgreSQL has been using since 9.6 so we can safely use it too in our tests.