### PR TITLE
PG-1441 Do not replicate relation keys

### DIFF
--- a/contrib/pg_tde/meson.build
+++ b/contrib/pg_tde/meson.build
@@ -113,6 +113,7 @@ tap_tests = [
   't/009_wal_encrypt.pl',
   't/010_change_key_provider.pl',
   't/011_unlogged_tables.pl',
+  't/012_replication.pl',
 ]
 
 tests += {
@@ -125,7 +126,8 @@ tests += {
     'runningcheck': false,
   },
   'tap': {
-    'tests': tap_tests  },
+    'tests': tap_tests
+  },
 }
 
 pg_tde_inc = incdir

--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -52,7 +52,7 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 	{
 		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
 
-		pg_tde_write_key_map_entry_redo(&xlrec->mapEntry, &xlrec->pkInfo);
+		pg_tde_create_smgr_key_perm_redo(&xlrec->rlocator);
 	}
 	else if (info == XLOG_TDE_ADD_PRINCIPAL_KEY)
 	{
@@ -93,7 +93,7 @@ tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 	{
 		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
 
-		appendStringInfo(buf, "rel: %u/%u/%u", xlrec->mapEntry.spcOid, xlrec->pkInfo.data.databaseId, xlrec->mapEntry.relNumber);
+		appendStringInfo(buf, "rel: %u/%u/%u", xlrec->rlocator.spcOid, xlrec->rlocator.dbOid, xlrec->rlocator.relNumber);
 	}
 	else if (info == XLOG_TDE_ADD_PRINCIPAL_KEY)
 	{

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -66,8 +66,7 @@ typedef struct TDEMapEntry
 
 typedef struct XLogRelKey
 {
-	TDEMapEntry mapEntry;
-	TDESignedPrincipalKeyInfo pkInfo;
+	RelFileLocator rlocator;
 } XLogRelKey;
 
 /*
@@ -99,9 +98,9 @@ extern WALKeyCacheRec *pg_tde_get_wal_cache_keys(void);
 extern void pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path);
 
 extern InternalKey *pg_tde_create_smgr_key(const RelFileLocatorBackend *newrlocator);
+extern void pg_tde_create_smgr_key_perm_redo(const RelFileLocator *newrlocator);
 extern void pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocator, uint32 flags);
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator);
-extern void pg_tde_write_key_map_entry_redo(const TDEMapEntry *write_map_entry, TDESignedPrincipalKeyInfo *signed_key_info);
 
 #define PG_TDE_MAP_FILENAME			"pg_tde_%d_map"
 

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -243,10 +243,13 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 		 *
 		 * Later calls then decide to encrypt or not based on the existence of
 		 * the key.
+		 *
+		 * Since event triggers do not fire on the standby or in recovery we
+		 * do not try to generate any new keys and instead trust the xlog.
 		 */
 		InternalKey *key = tde_smgr_get_key(&reln->smgr_rlocator);
 
-		if (!key && tde_smgr_should_encrypt(&reln->smgr_rlocator, &relold))
+		if (!isRedo && !key && tde_smgr_should_encrypt(&reln->smgr_rlocator, &relold))
 			key = pg_tde_create_smgr_key(&reln->smgr_rlocator);
 
 		if (key)

--- a/contrib/pg_tde/t/012_replication.pl
+++ b/contrib/pg_tde/t/012_replication.pl
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use File::Basename;
+use Test::More;
+use lib 't';
+use pgtde;
+
+PGTDE::setup_files_dir(basename($0));
+
+my $primary = PostgreSQL::Test::Cluster->new('primary');
+$primary->init(allows_streaming => 1);
+$primary->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
+$primary->start;
+
+$primary->backup('backup');
+my $replica = PostgreSQL::Test::Cluster->new('replica');
+$replica->init_from_backup($primary, 'backup', has_streaming => 1);
+$replica->set_standby_mode();
+$replica->start;
+
+PGTDE::append_to_result_file("-- At primary");
+
+PGTDE::psql($primary, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+PGTDE::psql($primary, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');");
+PGTDE::psql($primary, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');");
+
+PGTDE::psql($primary, 'postgres', "CREATE TABLE test_enc (x int PRIMARY KEY) USING tde_heap;");
+PGTDE::psql($primary, 'postgres', "INSERT INTO test_enc (x) VALUES (1), (2);");
+
+PGTDE::psql($primary, 'postgres', "CREATE TABLE test_plain (x int PRIMARY KEY) USING heap;");
+PGTDE::psql($primary, 'postgres', "INSERT INTO test_plain (x) VALUES (3), (4);");
+
+$primary->wait_for_catchup('replica');
+
+PGTDE::append_to_result_file("-- At replica");
+
+PGTDE::psql($replica, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
+PGTDE::psql($replica, 'postgres', "SELECT pg_tde_is_encrypted('test_enc_pkey');");
+PGTDE::psql($replica, 'postgres', "SELECT * FROM test_enc ORDER BY x;");
+
+PGTDE::psql($replica, 'postgres', "SELECT pg_tde_is_encrypted('test_plain');");
+PGTDE::psql($replica, 'postgres', "SELECT pg_tde_is_encrypted('test_plain_pkey');");
+PGTDE::psql($replica, 'postgres', "SELECT * FROM test_plain ORDER BY x;");
+
+$replica->stop;
+
+$primary->stop;
+
+# Compare the expected and out file
+my $compare = PGTDE->compare_results();
+
+is($compare, 0, "Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
+
+done_testing();

--- a/contrib/pg_tde/t/012_replication.pl
+++ b/contrib/pg_tde/t/012_replication.pl
@@ -11,7 +11,8 @@ PGTDE::setup_files_dir(basename($0));
 
 my $primary = PostgreSQL::Test::Cluster->new('primary');
 $primary->init(allows_streaming => 1);
-$primary->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
+$primary->append_conf('postgresql.conf',
+	"shared_preload_libraries = 'pg_tde'");
 $primary->start;
 
 $primary->backup('backup');
@@ -23,34 +24,46 @@ $replica->start;
 PGTDE::append_to_result_file("-- At primary");
 
 PGTDE::psql($primary, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
-PGTDE::psql($primary, 'postgres', "SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');");
-PGTDE::psql($primary, 'postgres', "SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');");
+PGTDE::psql($primary, 'postgres',
+	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');"
+);
+PGTDE::psql($primary, 'postgres',
+	"SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');"
+);
 
-PGTDE::psql($primary, 'postgres', "CREATE TABLE test_enc (x int PRIMARY KEY) USING tde_heap;");
-PGTDE::psql($primary, 'postgres', "INSERT INTO test_enc (x) VALUES (1), (2);");
+PGTDE::psql($primary, 'postgres',
+	"CREATE TABLE test_enc (x int PRIMARY KEY) USING tde_heap;");
+PGTDE::psql($primary, 'postgres',
+	"INSERT INTO test_enc (x) VALUES (1), (2);");
 
-PGTDE::psql($primary, 'postgres', "CREATE TABLE test_plain (x int PRIMARY KEY) USING heap;");
-PGTDE::psql($primary, 'postgres', "INSERT INTO test_plain (x) VALUES (3), (4);");
+PGTDE::psql($primary, 'postgres',
+	"CREATE TABLE test_plain (x int PRIMARY KEY) USING heap;");
+PGTDE::psql($primary, 'postgres',
+	"INSERT INTO test_plain (x) VALUES (3), (4);");
 
 $primary->wait_for_catchup('replica');
 
 PGTDE::append_to_result_file("-- At replica");
 
 PGTDE::psql($replica, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
-PGTDE::psql($replica, 'postgres', "SELECT pg_tde_is_encrypted('test_enc_pkey');");
+PGTDE::psql($replica, 'postgres',
+	"SELECT pg_tde_is_encrypted('test_enc_pkey');");
 PGTDE::psql($replica, 'postgres', "SELECT * FROM test_enc ORDER BY x;");
 
-PGTDE::psql($replica, 'postgres', "SELECT pg_tde_is_encrypted('test_plain');");
-PGTDE::psql($replica, 'postgres', "SELECT pg_tde_is_encrypted('test_plain_pkey');");
+PGTDE::psql($replica, 'postgres',
+	"SELECT pg_tde_is_encrypted('test_plain');");
+PGTDE::psql($replica, 'postgres',
+	"SELECT pg_tde_is_encrypted('test_plain_pkey');");
 PGTDE::psql($replica, 'postgres', "SELECT * FROM test_plain ORDER BY x;");
 
 $replica->stop;
-
 $primary->stop;
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();
 
-is($compare, 0, "Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
+is($compare, 0,
+	"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files."
+);
 
 done_testing();

--- a/contrib/pg_tde/t/expected/012_replication.out
+++ b/contrib/pg_tde/t/expected/012_replication.out
@@ -1,0 +1,57 @@
+-- At primary
+CREATE EXTENSION IF NOT EXISTS pg_tde;
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
+SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
+
+CREATE TABLE test_enc (x int PRIMARY KEY) USING tde_heap;
+INSERT INTO test_enc (x) VALUES (1), (2);
+CREATE TABLE test_plain (x int PRIMARY KEY) USING heap;
+INSERT INTO test_plain (x) VALUES (3), (4);
+-- At replica
+SELECT pg_tde_is_encrypted('test_enc');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_enc_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+SELECT * FROM test_enc ORDER BY x;
+ x 
+---
+ 1
+ 2
+(2 rows)
+
+SELECT pg_tde_is_encrypted('test_plain');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_plain_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT * FROM test_plain ORDER BY x;
+ x 
+---
+ 3
+ 4
+(2 rows)
+


### PR DESCRIPTION
Instead of replicating relation keys we generate new ones on replay of
the `XLOG_TDE_ADD_RELATION_KEY` record at the replica server. This means a
replica and its master server will end up with different sets of
relation keys making a simple binary diff impossible but that is a
dubious advantage since the WAL keys will differ anyway and on on the
flip-side the new code is simpler and easier to reason about. Especially
since now WAL keys and relation keys are treated in a bit more similar
ways.                                                           

To prevent duplicate keys in the key file we skip generating and adding
a key if there already is an entry in the file for the same relation.

Also while changing this we make sure to add a simple replication test plus add code preventing the SMGR code at a replica from generating any new keys. Keys should only be created on WAL replay. But these changes should have been done either way.
