### PR TITLE
Remove `pgtde_init_pg()` TAP helper

### DIFF
--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -9,7 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start;

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -9,7 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start;

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -49,7 +49,8 @@ my $pid = MyWebServer->new(8888)->background();
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start();

--- a/contrib/pg_tde/t/004_file_config.pl
+++ b/contrib/pg_tde/t/004_file_config.pl
@@ -9,7 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 open my $conf2, '>>', "/tmp/datafile-location";

--- a/contrib/pg_tde/t/005_multiple_extensions.pl
+++ b/contrib/pg_tde/t/005_multiple_extensions.pl
@@ -16,7 +16,8 @@ if (index(lc($PG_VERSION_STRING), lc("Percona Distribution")) == -1)
     plan skip_all => "pg_tde test case only for PPG server package install with extensions.";
 }
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde, pg_stat_monitor, pgaudit, set_user, pg_repack'");
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_bucket_time = 360000");
 $node->append_conf('postgresql.conf', "pg_stat_monitor.pgsm_normalized_query = 'yes'");

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -57,7 +57,8 @@ my $pid = MyWebServer->new(8889)->background();
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start();

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -9,7 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start;

--- a/contrib/pg_tde/t/008_key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/008_key_rotate_tablespace.pl
@@ -9,7 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start;

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -9,7 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 $node->append_conf('postgresql.conf', "wal_level = 'logical'");
 # NOT testing that it can't start: the test framework doesn't have an easy way to do this

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -10,7 +10,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 unlink('/tmp/change_key_provider_1.per');

--- a/contrib/pg_tde/t/011_unlogged_tables.pl
+++ b/contrib/pg_tde/t/011_unlogged_tables.pl
@@ -9,7 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PGTDE->pgtde_init_pg();
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 
 my $rt_value = $node->start;

--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -19,14 +19,6 @@ our $debug_out_filename_with_path;
 my $expected_folder = "t/expected";
 my $results_folder = "t/results";
 
-sub pgtde_init_pg
-{
-    my $node = PostgreSQL::Test::Cluster->new('pgtde_regression');
-    $node->dump_info;
-    $node->init;
-    return $node;
-}
-
 sub psql
 {
     my ($node, $dbname, $sql) = @_;


### PR DESCRIPTION
This helper mostly added confusion by making it seem like it did more work than is actually did. And especially since we will want to call init in the future with different parameters for some tests or initialize from a backup.