### PR TITLE
Use restart TAP helper and do not assert result

### DIFF
--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -12,9 +12,7 @@ PGTDE::setup_files_dir(basename($0));
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
-
-my $rt_value = $node->start;
-ok($rt_value == 1, "Start Server");
+$node->start;
 
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
@@ -27,9 +25,7 @@ PGTDE::psql($node, 'postgres',
 );
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');"
@@ -49,9 +45,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
@@ -73,7 +67,7 @@ PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc;');
 
 PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
-$node->stop();
+$node->stop;
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -12,9 +12,7 @@ PGTDE::setup_files_dir(basename($0));
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
-
-my $rt_value = $node->start;
-ok($rt_value == 1, "Start Server");
+$node->start;
 
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
@@ -23,9 +21,7 @@ PGTDE::psql($node, 'postgres',
 );
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');"
@@ -61,9 +57,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres',
 	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"
@@ -80,9 +74,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres',
 	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"
@@ -99,9 +91,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres',
 	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"
@@ -121,9 +111,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres',
 	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"
@@ -138,9 +126,7 @@ PGTDE::psql($node, 'postgres',
 
 # Things still work after a restart
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 # But now can't be changed to another global provider
 PGTDE::psql($node, 'postgres',
@@ -169,13 +155,11 @@ PGTDE::psql($node, 'postgres',
 	'ALTER SYSTEM RESET pg_tde.inherit_global_providers;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde CASCADE;');
 
-$node->stop();
+$node->stop;
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -55,9 +55,7 @@ PGTDE::setup_files_dir(basename($0));
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
-
-my $rt_value = $node->start();
-ok($rt_value == 1, "Start Server");
+$node->start;
 
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
@@ -77,9 +75,7 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (5),(6);');
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
@@ -87,7 +83,7 @@ PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');
 
 PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
-$node->stop();
+$node->stop;
 
 system("kill $pid");
 

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -64,9 +64,7 @@ PGTDE::setup_files_dir(basename($0));
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
-
-my $rt_value = $node->start();
-ok($rt_value == 1, "Start Server");
+$node->start;
 
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
@@ -86,9 +84,7 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (5),(6);');
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
 
@@ -96,7 +92,7 @@ PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');
 
 PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
-$node->stop();
+$node->stop;
 
 system("kill -9 $pid");
 

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -12,9 +12,7 @@ PGTDE::setup_files_dir(basename($0));
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
-
-my $rt_value = $node->start;
-ok($rt_value == 1, "Start Server");
+$node->start;
 
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
@@ -23,9 +21,7 @@ PGTDE::psql($node, 'postgres',
 );
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');"
@@ -103,9 +99,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc5 ORDER BY id ASC;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 sub verify_table
 {
@@ -186,7 +180,7 @@ PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc5;');
 
 PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
-$node->stop();
+$node->stop;
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/contrib/pg_tde/t/008_key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/008_key_rotate_tablespace.pl
@@ -12,9 +12,7 @@ PGTDE::setup_files_dir(basename($0));
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
-
-my $rt_value = $node->start;
-ok($rt_value == 1, "Start Server");
+$node->start;
 
 PGTDE::psql($node, 'postgres',
 	"SET allow_in_place_tablespaces = true; CREATE TABLESPACE test_tblspace LOCATION '';"
@@ -54,9 +52,7 @@ PGTDE::psql($node, 'tbc',
 );
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'tbc', 'SELECT * FROM country_table;');
 
@@ -65,7 +61,7 @@ PGTDE::psql($node, 'tbc', 'DROP EXTENSION pg_tde CASCADE;');
 PGTDE::psql($node, 'postgres', 'DROP DATABASE tbc;');
 PGTDE::psql($node, 'postgres', 'DROP TABLESPACE test_tblspace;');
 
-$node->stop();
+$node->stop;
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -15,9 +15,7 @@ $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 $node->append_conf('postgresql.conf', "wal_level = 'logical'");
 # NOT testing that it can't start: the test framework doesn't have an easy way to do this
 #$node->append_conf('postgresql.conf', "pg_tde.wal_encrypt = 1"});
-
-my $rt_value = $node->start;
-ok($rt_value == 1, "Start Server");
+$node->start;
 
 PGTDE::psql($node, 'postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 
@@ -32,9 +30,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;');
 
 PGTDE::append_to_result_file("-- server restart with wal encryption");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres', "SHOW pg_tde.wal_encrypt;");
 
@@ -50,9 +46,7 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_wal (k) VALUES (1), (2);');
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = off;');
 
 PGTDE::append_to_result_file("-- server restart without wal encryption");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres', "SHOW pg_tde.wal_encrypt;");
 
@@ -61,18 +55,14 @@ PGTDE::psql($node, 'postgres', 'INSERT INTO test_wal (k) VALUES (3), (4);');
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;');
 
 PGTDE::append_to_result_file("-- server restart with wal encryption");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres', "SHOW pg_tde.wal_encrypt;");
 
 PGTDE::psql($node, 'postgres', 'INSERT INTO test_wal (k) VALUES (5), (6);');
 
 PGTDE::append_to_result_file("-- server restart with still wal encryption");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 PGTDE::psql($node, 'postgres', "SHOW pg_tde.wal_encrypt;");
 
@@ -86,7 +76,7 @@ PGTDE::psql($node, 'postgres',
 
 PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
-$node->stop();
+$node->stop;
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/contrib/pg_tde/t/010_change_key_provider.pl
+++ b/contrib/pg_tde/t/010_change_key_provider.pl
@@ -10,17 +10,15 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
-my $node = PostgreSQL::Test::Cluster->new('main');
-$node->init;
-$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
-
 unlink('/tmp/change_key_provider_1.per');
 unlink('/tmp/change_key_provider_2.per');
 unlink('/tmp/change_key_provider_3.per');
 unlink('/tmp/change_key_provider_4.per');
 
-my $rt_value = $node->start;
-ok($rt_value == 1, "Start Server");
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
+$node->start;
 
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
@@ -57,9 +55,7 @@ PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 # Verify
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
@@ -78,9 +74,7 @@ PGTDE::psql($node, 'postgres', "SELECT pg_tde_is_encrypted('test_enc');");
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 # Verify
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
@@ -92,9 +86,7 @@ PGTDE::append_to_result_file(
 move('/tmp/change_key_provider_2.per', '/tmp/change_key_provider_3.per');
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 # Verify
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
@@ -127,9 +119,7 @@ PGTDE::psql($node, 'postgres',
 );
 
 PGTDE::append_to_result_file("-- server restart");
-$node->stop();
-$rt_value = $node->start();
-ok($rt_value == 1, "Restart Server");
+$node->restart;
 
 # Verify
 PGTDE::psql($node, 'postgres', "SELECT pg_tde_verify_key();");
@@ -150,7 +140,7 @@ PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde CASCADE;');
 
-$node->stop();
+$node->stop;
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/contrib/pg_tde/t/011_unlogged_tables.pl
+++ b/contrib/pg_tde/t/011_unlogged_tables.pl
@@ -12,9 +12,7 @@ PGTDE::setup_files_dir(basename($0));
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
-
-my $rt_value = $node->start;
-ok($rt_value == 1, "Start Server");
+$node->start;
 
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 PGTDE::psql($node, 'postgres',
@@ -35,14 +33,13 @@ PGTDE::append_to_result_file("-- kill -9");
 $node->kill9();
 
 PGTDE::append_to_result_file("-- server start");
-$rt_value = $node->start;
-ok($rt_value == 1, "Start Server");
+$node->start;
 
 PGTDE::psql($node, 'postgres', "TABLE t;");
 
 PGTDE::psql($node, 'postgres', "INSERT INTO t SELECT generate_series(1, 4);");
 
-$node->stop();
+$node->stop;
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();


### PR DESCRIPTION
There is a restart function so there is not and need to call first stop and then start. And since by default a start, stop or restart call does not return on error it is totally pointless to assert anything about the return value. And since PostgreSQL's own tests also are fine with just bailing out on error we do the same.

While at it we also always call these three functions without parentheses to be consistent.