### PR TITLE
PG-1366 Clean up architecture documentation and make it up to date

### DIFF
--- a/contrib/pg_tde/documentation/docs/architecture.md
+++ b/contrib/pg_tde/documentation/docs/architecture.md
@@ -18,7 +18,7 @@ Let's break down what it means.
 
 * Table data files
 * Indexes
-* Seqeunces
+* Sequences
 * Temporary tables
 * Write Ahead Log (WAL)
 * System tables (not yet implemented)

--- a/contrib/pg_tde/documentation/docs/architecture.md
+++ b/contrib/pg_tde/documentation/docs/architecture.md
@@ -278,8 +278,6 @@ For keys and providers administration, it provides two pair of functions:
 pg_tde_(grant/revoke)_database_key_management_to_role
 ```
 
-There's one special behavior: When `pg_tde.inherit_global_providers` is `on`, users with database local permissions can list global providers, but can't use the show function to query configuration details. When `pg_tde.inherit_global_providers` is `off`, they can't execute the function at all, it will return an error.
-
 ### Creating and rotating keys
 
 Principal keys can be created or rotated using the following functions:


### PR DESCRIPTION
The architecture documentation was outdated so this makes it up to date plus improves various minor issues found while updating the documentation.

Some function names are fixed in #229.