### PR TITLE
Rename `pg_tde_xlog_encrypt.{c,h}` to `pg_tde_xlog_smgr.{c,h}`

### DIFF
--- a/contrib/pg_tde/Makefile
+++ b/contrib/pg_tde/Makefile
@@ -31,7 +31,7 @@ OBJS = src/encryption/enc_tde.o \
 src/encryption/enc_aes.o \
 src/access/pg_tde_tdemap.o \
 src/access/pg_tde_xlog.o \
-src/access/pg_tde_xlog_encrypt.o \
+src/access/pg_tde_xlog_smgr.o \
 src/keyring/keyring_curl.o \
 src/keyring/keyring_file.o \
 src/keyring/keyring_vault.o \

--- a/contrib/pg_tde/Makefile.tools
+++ b/contrib/pg_tde/Makefile.tools
@@ -1,5 +1,5 @@
 TDE_XLOG_OBJS = \
-	src/access/pg_tde_xlog_encrypt.frontend
+	src/access/pg_tde_xlog_smgr.frontend
 
 TDE_OBJS = \
 	src/access/pg_tde_tdemap.frontend \

--- a/contrib/pg_tde/Makefile.tools
+++ b/contrib/pg_tde/Makefile.tools
@@ -1,25 +1,24 @@
 TDE_XLOG_OBJS = \
- 	src/access/pg_tde_xlog_encrypt.frontend
+	src/access/pg_tde_xlog_encrypt.frontend
 
 TDE_OBJS = \
- 	src/access/pg_tde_tdemap.frontend \
- 	src/catalog/tde_keyring.frontend \
- 	src/catalog/tde_keyring_parse_opts.frontend \
- 	src/catalog/tde_principal_key.frontend \
- 	src/common/pg_tde_utils.frontend \
- 	src/encryption/enc_aes.frontend \
- 	src/encryption/enc_tde.frontend \
- 	src/keyring/keyring_api.frontend \
- 	src/keyring/keyring_curl.frontend \
- 	src/keyring/keyring_file.frontend \
- 	src/keyring/keyring_vault.frontend \
+	src/access/pg_tde_tdemap.frontend \
+	src/catalog/tde_keyring.frontend \
+	src/catalog/tde_keyring_parse_opts.frontend \
+	src/catalog/tde_principal_key.frontend \
+	src/common/pg_tde_utils.frontend \
+	src/encryption/enc_aes.frontend \
+	src/encryption/enc_tde.frontend \
+	src/keyring/keyring_api.frontend \
+	src/keyring/keyring_curl.frontend \
+	src/keyring/keyring_file.frontend \
+	src/keyring/keyring_vault.frontend \
 	src/libkmip/libkmip/src/kmip.frontend \
 	src/libkmip/libkmip/src/kmip_bio.frontend \
 	src/libkmip/libkmip/src/kmip_locate.frontend \
 	src/libkmip/libkmip/src/kmip_memset.frontend \
 	src/keyring/keyring_kmip.frontend \
 	src/keyring/keyring_kmip_impl.frontend
-
 
 TDE_OBJS2 = $(TDE_OBJS:%=$(top_srcdir)/contrib/pg_tde/%)
 TDE_XLOG_OBJS2 = $(TDE_XLOG_OBJS:%=$(top_srcdir)/contrib/pg_tde/%)
@@ -35,5 +34,4 @@ libtdexlog.a: $(TDE_XLOG_OBJS2)
 	rm -f $@
 	$(AR) $(AROPT) $@ $^
 
-
-tdelibs: libtde.a libtdexlog.a	
+tdelibs: libtde.a libtdexlog.a

--- a/contrib/pg_tde/meson.build
+++ b/contrib/pg_tde/meson.build
@@ -3,7 +3,7 @@ curldep = dependency('libcurl')
 pg_tde_sources = files(
   'src/access/pg_tde_tdemap.c',
   'src/access/pg_tde_xlog.c',
-  'src/access/pg_tde_xlog_encrypt.c',
+  'src/access/pg_tde_xlog_smgr.c',
   'src/catalog/tde_keyring.c',
   'src/catalog/tde_keyring_parse_opts.c',
   'src/catalog/tde_principal_key.c',
@@ -25,7 +25,7 @@ pg_tde_sources = files(
 
 tde_frontend_sources = files(
   'src/access/pg_tde_tdemap.c',
-  'src/access/pg_tde_xlog_encrypt.c',
+  'src/access/pg_tde_xlog_smgr.c',
   'src/catalog/tde_keyring.c',
   'src/catalog/tde_keyring_parse_opts.c',
   'src/catalog/tde_principal_key.c',

--- a/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
@@ -1,11 +1,11 @@
 /*-------------------------------------------------------------------------
  *
- * pg_tde_xlog_encrypt.c
+ * pg_tde_xlog_smgr.c
  *	  Encrypted XLog storage manager
  *
  *
  * IDENTIFICATION
- *	  src/access/pg_tde_xlog_encrypt.c
+ *	  src/access/pg_tde_xlog_smgr.c
  *
  *-------------------------------------------------------------------------
  */
@@ -25,7 +25,7 @@
 #include "utils/memutils.h"
 
 #include "access/pg_tde_tdemap.h"
-#include "access/pg_tde_xlog_encrypt.h"
+#include "access/pg_tde_xlog_smgr.h"
 #include "catalog/tde_global_space.h"
 #include "encryption/enc_tde.h"
 

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_smgr.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_smgr.h
@@ -1,13 +1,13 @@
 /*-------------------------------------------------------------------------
  *
- * pg_tde_xlog_encrypt.h
+ * pg_tde_xlog_smgr.h
  *	   Encrypted XLog storage manager
  *
  *-------------------------------------------------------------------------
  */
 
-#ifndef PG_TDE_XLOGENCRYPT_H
-#define PG_TDE_XLOGENCRYPT_H
+#ifndef PG_TDE_XLOGSMGR_H
+#define PG_TDE_XLOGSMGR_H
 
 #include "postgres.h"
 
@@ -15,4 +15,4 @@ extern Size TDEXLogEncryptStateSize(void);
 extern void TDEXLogShmemInit(void);
 extern void TDEXLogSmgrInit(void);
 
-#endif							/* PG_TDE_XLOGENCRYPT_H */
+#endif							/* PG_TDE_XLOGSMGR_H */

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -18,7 +18,7 @@
 #include "storage/lwlock.h"
 #include "storage/shmem.h"
 #include "access/pg_tde_xlog.h"
-#include "access/pg_tde_xlog_encrypt.h"
+#include "access/pg_tde_xlog_smgr.h"
 #include "encryption/enc_aes.h"
 #include "access/pg_tde_tdemap.h"
 #include "access/xlog.h"

--- a/src/bin/pg_waldump/pg_waldump.c
+++ b/src/bin/pg_waldump/pg_waldump.c
@@ -34,7 +34,7 @@
 
 #ifdef PERCONA_EXT
 #include "access/pg_tde_fe_init.h"
-#include "access/pg_tde_xlog_encrypt.h"
+#include "access/pg_tde_xlog_smgr.h"
 #include "access/xlog_smgr.h"
 #include "catalog/tde_global_space.h"
 #endif


### PR DESCRIPTION
The new name makes it clearer what the files does plus matches our
    naming conventions with the relation data storage manager.
