### PR TITLE
Redo of the key provider info now needs a lock

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -190,7 +190,9 @@ GetAllKeyringProviders(Oid dbOid)
 void
 redo_key_provider_info(KeyringProviderRecordInFile *xlrec)
 {
+	LWLockAcquire(tde_provider_info_lock(), LW_EXCLUSIVE);
 	write_key_provider_info(xlrec, false);
+	LWLockRelease(tde_provider_info_lock());
 }
 
 static void


### PR DESCRIPTION
Although it may be technically omitted during redo, write_key_provider_info() now checks if there is a lock held.

I'll add tests covering this to https://github.com/percona/postgres/pull/217 _(I found this issue writing test for that PR)_