### PR TITLE
Make `ALTER TABLE ... SET ACCESS METHOD` logic easier to read

### DIFF
--- a/contrib/pg_tde/expected/change_access_method.out
+++ b/contrib/pg_tde/expected/change_access_method.out
@@ -121,6 +121,24 @@ SELECT pg_tde_is_encrypted('country_table_pkey');
  t
 (1 row)
 
+-- Test that we honor the default value
+SET default_table_access_method = 'heap';
+ALTER TABLE country_table SET ACCESS METHOD DEFAULT;
+SELECT pg_tde_is_encrypted('country_table');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SET default_table_access_method = 'tde_heap';
+ALTER TABLE country_table SET ACCESS METHOD DEFAULT;
+SELECT pg_tde_is_encrypted('country_table');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+RESET default_table_access_method;
 ALTER TABLE country_table ADD y text;
 SELECT pg_tde_is_encrypted('pg_toast.pg_toast_' || 'country_table'::regclass::oid);
  pg_tde_is_encrypted 

--- a/contrib/pg_tde/expected/change_access_method.out
+++ b/contrib/pg_tde/expected/change_access_method.out
@@ -1,21 +1,21 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
                                      1
 (1 row)
 
-SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  
 (1 row)
 
 CREATE TABLE country_table (
-     country_id        serial primary key,
-     country_name    varchar(32) unique not null,
-     continent        varchar(32) not null
-) using tde_heap;
+     country_id   serial primary key,
+     country_name varchar(32) unique not null,
+     continent    varchar(32) not null
+) USING tde_heap;
  
 INSERT INTO country_table (country_name, continent)
      VALUES ('Japan', 'Asia'),
@@ -48,19 +48,7 @@ SELECT pg_tde_is_encrypted('country_table_pkey');
 (1 row)
 
 -- Try changing the encrypted table to an unencrypted table
-ALTER TABLE country_table SET access method  heap;
-SELECT pg_tde_is_encrypted('country_table_country_id_seq');
- pg_tde_is_encrypted 
----------------------
- f
-(1 row)
-
-SELECT pg_tde_is_encrypted('country_table_pkey');
- pg_tde_is_encrypted 
----------------------
- f
-(1 row)
-
+ALTER TABLE country_table SET ACCESS METHOD heap;
 -- Insert some more data 
 INSERT INTO country_table (country_name, continent)
      VALUES ('France', 'Europe'),
@@ -96,7 +84,7 @@ SELECT pg_tde_is_encrypted('country_table_pkey');
 (1 row)
 
 -- Change it back to encrypted
-ALTER TABLE country_table SET access method  tde_heap;
+ALTER TABLE country_table SET ACCESS METHOD tde_heap;
 INSERT INTO country_table (country_name, continent)
      VALUES ('China', 'Asia'),
             ('Brazil', 'South America'),
@@ -134,35 +122,35 @@ SELECT pg_tde_is_encrypted('country_table_pkey');
 (1 row)
 
 ALTER TABLE country_table ADD y text;
-SELECT pg_tde_is_encrypted(('pg_toast.pg_toast_' || 'country_table'::regclass::oid)::regclass);
+SELECT pg_tde_is_encrypted('pg_toast.pg_toast_' || 'country_table'::regclass::oid);
  pg_tde_is_encrypted 
 ---------------------
  t
 (1 row)
 
 CREATE TABLE country_table2 (
-     country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
+     country_id   serial primary key,
+     country_name text unique not null,
+     continent    text not null
 );
-SET pg_tde.enforce_encryption = ON;
+SET pg_tde.enforce_encryption = on;
 CREATE TABLE country_table3 (
-     country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
+     country_id   serial primary key,
+     country_name text unique not null,
+     continent    text not null
 ) USING heap;
 ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
  
-ALTER TABLE country_table SET access method  heap;
+ALTER TABLE country_table SET ACCESS METHOD heap;
 ERROR:  pg_tde.enforce_encryption is ON, only the tde_heap access method is allowed.
-ALTER TABLE country_table2 SET access method  tde_heap;
+ALTER TABLE country_table2 SET ACCESS METHOD tde_heap;
 CREATE TABLE country_table3 (
-     country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
-) using tde_heap;
+     country_id   serial primary key,
+     country_name text unique not null,
+     continent    text not null
+) USING tde_heap;
 DROP TABLE country_table;
 DROP TABLE country_table2;
 DROP TABLE country_table3;
-SET pg_tde.enforce_encryption = OFF;
+SET pg_tde.enforce_encryption = off;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/change_access_method.sql
+++ b/contrib/pg_tde/sql/change_access_method.sql
@@ -1,13 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
 
 CREATE TABLE country_table (
-     country_id        serial primary key,
-     country_name    varchar(32) unique not null,
-     continent        varchar(32) not null
-) using tde_heap;
+     country_id   serial primary key,
+     country_name varchar(32) unique not null,
+     continent    varchar(32) not null
+) USING tde_heap;
  
 INSERT INTO country_table (country_name, continent)
      VALUES ('Japan', 'Asia'),
@@ -15,19 +15,12 @@ INSERT INTO country_table (country_name, continent)
             ('USA', 'North America');
 
 SELECT * FROM country_table;
-
 SELECT pg_tde_is_encrypted('country_table');
-
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
-
 SELECT pg_tde_is_encrypted('country_table_pkey');
 
 -- Try changing the encrypted table to an unencrypted table
-ALTER TABLE country_table SET access method  heap;
-
-SELECT pg_tde_is_encrypted('country_table_country_id_seq');
-
-SELECT pg_tde_is_encrypted('country_table_pkey');
+ALTER TABLE country_table SET ACCESS METHOD heap;
 
 -- Insert some more data 
 INSERT INTO country_table (country_name, continent)
@@ -37,57 +30,53 @@ INSERT INTO country_table (country_name, continent)
 
 SELECT * FROM country_table;
 SELECT pg_tde_is_encrypted('country_table');
-
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
-
 SELECT pg_tde_is_encrypted('country_table_pkey');
 
 -- Change it back to encrypted
-ALTER TABLE country_table SET access method  tde_heap;
+ALTER TABLE country_table SET ACCESS METHOD tde_heap;
 
 INSERT INTO country_table (country_name, continent)
      VALUES ('China', 'Asia'),
             ('Brazil', 'South America'),
             ('Australia', 'Oceania');
+
 SELECT * FROM country_table;
 SELECT pg_tde_is_encrypted('country_table');
-
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
-
 SELECT pg_tde_is_encrypted('country_table_pkey');
 
 ALTER TABLE country_table ADD y text;
 
-SELECT pg_tde_is_encrypted(('pg_toast.pg_toast_' || 'country_table'::regclass::oid)::regclass);
+SELECT pg_tde_is_encrypted('pg_toast.pg_toast_' || 'country_table'::regclass::oid);
 
 CREATE TABLE country_table2 (
-     country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
+     country_id   serial primary key,
+     country_name text unique not null,
+     continent    text not null
 );
 
-SET pg_tde.enforce_encryption = ON;
+SET pg_tde.enforce_encryption = on;
 
 CREATE TABLE country_table3 (
-     country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
+     country_id   serial primary key,
+     country_name text unique not null,
+     continent    text not null
 ) USING heap;
  
-ALTER TABLE country_table SET access method  heap;
-
-ALTER TABLE country_table2 SET access method  tde_heap;
+ALTER TABLE country_table SET ACCESS METHOD heap;
+ALTER TABLE country_table2 SET ACCESS METHOD tde_heap;
 
 CREATE TABLE country_table3 (
-     country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
-) using tde_heap;
+     country_id   serial primary key,
+     country_name text unique not null,
+     continent    text not null
+) USING tde_heap;
 
 DROP TABLE country_table;
 DROP TABLE country_table2;
 DROP TABLE country_table3;
 
-SET pg_tde.enforce_encryption = OFF;
+SET pg_tde.enforce_encryption = off;
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/change_access_method.sql
+++ b/contrib/pg_tde/sql/change_access_method.sql
@@ -46,6 +46,21 @@ SELECT pg_tde_is_encrypted('country_table');
 SELECT pg_tde_is_encrypted('country_table_country_id_seq');
 SELECT pg_tde_is_encrypted('country_table_pkey');
 
+-- Test that we honor the default value
+SET default_table_access_method = 'heap';
+
+ALTER TABLE country_table SET ACCESS METHOD DEFAULT;
+
+SELECT pg_tde_is_encrypted('country_table');
+
+SET default_table_access_method = 'tde_heap';
+
+ALTER TABLE country_table SET ACCESS METHOD DEFAULT;
+
+SELECT pg_tde_is_encrypted('country_table');
+
+RESET default_table_access_method;
+
 ALTER TABLE country_table ADD y text;
 
 SELECT pg_tde_is_encrypted('pg_toast.pg_toast_' || 'country_table'::regclass::oid);


### PR DESCRIPTION
This also cleans up the tests and adds a couple of tests for the `DEFAULT` which I wanted myself to avoid regressions when doing this refactor.