### PR TITLE
Make local variable no longer static

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -979,11 +979,10 @@ GenericKeyring *
 GetKeyProviderByName(const char *provider_name, Oid dbOid)
 {
 	GenericKeyring *keyring = NULL;
-
 #ifndef FRONTEND
-	static List *providers;
+	List	   *providers;
 #else
-	static SimplePtrList *providers;
+	SimplePtrList *providers;
 #endif
 
 	providers = scan_key_provider_file(PROVIDER_SCAN_BY_NAME, (void *) provider_name, dbOid);


### PR DESCRIPTION
Presumably this variable used to actually be used as a static variable at some point in time but that is no longer the case.