### PR TITLE
Make 013_crash_recovery.pl work on repeated runs

### DIFF
--- a/contrib/pg_tde/t/013_crash_recovery.pl
+++ b/contrib/pg_tde/t/013_crash_recovery.pl
@@ -7,6 +7,9 @@ use Test::More;
 use lib 't';
 use pgtde;
 
+# ensure we start with a clean key provider file
+unlink('/tmp/crash_recovery.per');
+
 PGTDE::setup_files_dir(basename($0));
 
 my $node = PostgreSQL::Test::Cluster->new('main');


### PR DESCRIPTION
If the keyring from a previous run is still present, the test fails.