### PR TITLE
Rename the files under `$PGDATA/pg_tde`

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -47,7 +47,7 @@ typedef enum ProviderScanType
 	PROVIDER_SCAN_ALL
 } ProviderScanType;
 
-#define PG_TDE_KEYRING_FILENAME "pg_tde_%d_keyring"
+#define PG_TDE_KEYRING_FILENAME "%d_providers"
 
 #define FILE_KEYRING_TYPE "file"
 #define VAULTV2_KEYRING_TYPE "vault-v2"

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -102,7 +102,7 @@ extern void pg_tde_create_smgr_key_perm_redo(const RelFileLocator *newrlocator);
 extern void pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocator, uint32 flags);
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator);
 
-#define PG_TDE_MAP_FILENAME			"pg_tde_%d_map"
+#define PG_TDE_MAP_FILENAME			"%d_keys"
 
 static inline void
 pg_tde_set_db_file_path(Oid dbOid, char *path)


### PR DESCRIPTION
The name `pg_tde_<OID>_keyring` was confusing to users due to making it sound like it would contain keys. And the name `pg_tde_<OID>_map` did not tell a user anything. The new names are `<OID>_providers` for the key providers and `<OID>_keys` for the relation/WAL keys.

While changing the suffixes to be more descriptive I also dropped the pg_tde_ prefix since it is just noise when they all are in the `pg_tde` directory.