### PR TITLE
Adding helper functions that reduce code duplications in TAP tests

### DIFF
--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -87,7 +87,8 @@ sub compare_results
 sub check_encryption_status
 {
 	my ($node, $table_name, $expected) = @_;
-	my $result = safe_psql('postgres', "SELECT pg_tde_is_encrypted('$table_name')");
+	my $result =
+	  safe_psql('postgres', "SELECT pg_tde_is_encrypted('$table_name')");
 	append_to_result_file($node->name . ": encryption check result for $table_name = $result");
 	is($result, $expected, "Check encryption status for '$table_name' on " . $node->name);
 }

--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -84,7 +84,8 @@ sub compare_results
 # Common TDE helpers
 
 # Check if the encryption status of a table is as expected and return 't' or 'f'
-sub check_encryption_status {
+sub check_encryption_status
+{
 	my ($node, $table_name, $expected) = @_;
 	my $result = safe_psql('postgres', "SELECT pg_tde_is_encrypted('$table_name')");
 	append_to_result_file($node->name . ": encryption check result for $table_name = $result");
@@ -92,7 +93,8 @@ sub check_encryption_status {
 }
 
 # Set up pg_tde extension and add a global key provider and set the server key
-sub setup_pg_tde_global_environment {
+sub setup_pg_tde_global_environment
+{
 	my ($node, $key_name, $provider_name, $provider_path) = @_;
 	psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 	psql($node, 'postgres',
@@ -102,7 +104,8 @@ sub setup_pg_tde_global_environment {
 }
 
 # Set up pg_tde extension and add a database key provider and set the database key
-sub setup_pg_tde_db_environment {
+sub setup_pg_tde_db_environment
+{
 	my ($node, $key_name, $provider_name, $provider_path) = @_;
 	psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 	psql($node, 'postgres',
@@ -112,19 +115,22 @@ sub setup_pg_tde_db_environment {
 }
 
 # Set up pg_tde in postgresql.conf
-sub enable_pg_tde_in_conf {
+sub enable_pg_tde_in_conf
+{
 	my ($node) = @_;
 	$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 }
 
 # Set default table access method to tde_heap
-sub set_default_table_am_tde_heap {
+sub set_default_table_am_tde_heap
+{
 	my ($node) = @_;
 	$node->append_conf('postgresql.conf', "default_table_access_method = 'tde_heap'");
 }
 
 # Set pg_tde.wal_encrypt and restart the server
-sub set_wal_encryption_and_restart {
+sub set_wal_encryption_and_restart
+{
 	my ($node, $value) = @_;
 
 	die "Invalid value for wal_encrypt: must be 'on' or 'off'\n"

--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -81,4 +81,58 @@ sub compare_results
 	return compare($expected_filename_with_path, $out_filename_with_path);
 }
 
+# Common TDE helpers
+
+# Check if the encryption status of a table is as expected and return 't' or 'f'
+sub check_encryption_status {
+	my ($node, $table_name, $expected) = @_;
+	my $result = safe_psql('postgres', "SELECT pg_tde_is_encrypted('$table_name')");
+	append_to_result_file($node->name . ": encryption check result for $table_name = $result");
+	is($result, $expected, "Check encryption status for '$table_name' on " . $node->name);
+}
+
+# Set up pg_tde extension and add a global key provider and set the server key
+sub setup_pg_tde_global_environment {
+	my ($node, $key_name, $provider_name, $provider_path) = @_;
+	psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+	psql($node, 'postgres',
+		"SELECT pg_tde_add_global_key_provider_file('$provider_name', '$provider_path');");
+	psql($node, 'postgres',
+		"SELECT pg_tde_set_server_key_using_global_key_provider('$key_name', '$provider_name');");
+}
+
+# Set up pg_tde extension and add a database key provider and set the database key
+sub setup_pg_tde_db_environment {
+	my ($node, $key_name, $provider_name, $provider_path) = @_;
+	psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+	psql($node, 'postgres',
+		"SELECT pg_tde_add_database_key_provider_file('$provider_name', '$provider_path');");
+	psql($node, 'postgres',
+		"SELECT pg_tde_set_key_using_database_key_provider('$key_name', '$provider_name');");
+}
+
+# Set up pg_tde in postgresql.conf
+sub enable_pg_tde_in_conf {
+	my ($node) = @_;
+	$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
+}
+
+# Set default table access method to tde_heap
+sub set_default_table_am_tde_heap {
+	my ($node) = @_;
+	$node->append_conf('postgresql.conf', "default_table_access_method = 'tde_heap'");
+}
+
+# Set pg_tde.wal_encrypt and restart the server
+sub set_wal_encryption_and_restart {
+	my ($node, $value) = @_;
+
+	die "Invalid value for wal_encrypt: must be 'on' or 'off'\n"
+		unless $value eq 'on' || $value eq 'off';
+
+	psql($node, 'postgres', "ALTER SYSTEM SET pg_tde.wal_encrypt = $value;");
+	append_to_result_file("-- server restart with wal encryption = $value");
+	$node->restart;
+}
+
 1;


### PR DESCRIPTION
I have added few helper functions that will reduce code duplication in TAP tests. like

- create pg_tde extension and then adding provider and key.
- Enable pg_tde in conf file
- enable/disable WAL encryption and restart server.
- Setting default access method to tde_heap
- Check status of encrypted object using pg_tde_is_encrypted() function

Go through these functions if you think these will be useful then will merge it. 
