### PR TITLE
Remove double declarations

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -75,24 +75,13 @@ static void simple_list_free(SimplePtrList *list);
 static List *scan_key_provider_file(ProviderScanType scanType, void *scanKey, Oid dbOid);
 
 PG_FUNCTION_INFO_V1(pg_tde_add_database_key_provider);
-Datum		pg_tde_add_database_key_provider(PG_FUNCTION_ARGS);
-
 PG_FUNCTION_INFO_V1(pg_tde_add_global_key_provider);
-Datum		pg_tde_add_global_key_provider(PG_FUNCTION_ARGS);
-
 PG_FUNCTION_INFO_V1(pg_tde_change_database_key_provider);
-Datum		pg_tde_change_database_key_provider(PG_FUNCTION_ARGS);
-
 PG_FUNCTION_INFO_V1(pg_tde_change_global_key_provider);
-Datum		pg_tde_change_global_key_provider(PG_FUNCTION_ARGS);
-
 static Datum pg_tde_list_all_key_providers_internal(const char *fname, bool global, PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(pg_tde_list_all_database_key_providers);
-Datum		pg_tde_list_all_database_key_providers(PG_FUNCTION_ARGS);
-
 PG_FUNCTION_INFO_V1(pg_tde_list_all_global_key_providers);
-Datum		pg_tde_list_all_global_key_providers(PG_FUNCTION_ARGS);
 
 static Datum pg_tde_change_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
 

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -112,16 +112,9 @@ static bool pg_tde_verify_principal_key_internal(Oid databaseOid);
 static Datum pg_tde_delete_key_provider_internal(PG_FUNCTION_ARGS, int is_global);
 
 PG_FUNCTION_INFO_V1(pg_tde_set_default_key_using_global_key_provider);
-Datum		pg_tde_set_default_key_using_global_key_provider(PG_FUNCTION_ARGS);
-
 PG_FUNCTION_INFO_V1(pg_tde_set_key_using_database_key_provider);
-Datum		pg_tde_set_key_using_database_key_provider(PG_FUNCTION_ARGS);
-
 PG_FUNCTION_INFO_V1(pg_tde_set_key_using_global_key_provider);
-Datum		pg_tde_set_key_using_global_key_provider(PG_FUNCTION_ARGS);
-
 PG_FUNCTION_INFO_V1(pg_tde_set_server_key_using_global_key_provider);
-Datum		pg_tde_set_server_key_using_global_key_provider(PG_FUNCTION_ARGS);
 
 enum global_status
 {


### PR DESCRIPTION
For some reason these functions were declared twice, once using the macro and once without it.