### PR TITLE
Remove unused return value from `check_percona_api_version()`

### DIFF
--- a/src/include/utils/percona.h
+++ b/src/include/utils/percona.h
@@ -14,16 +14,13 @@
 
 extern const PGDLLIMPORT int percona_api_version;
 
-static inline bool
+static inline void
 check_percona_api_version(void)
 {
 	if (PERCONA_API_VERSION != percona_api_version)
 	{
 		elog(FATAL, "Percona API version mismatch, the extension was built against a different PostgreSQL version!");
-		return false;
 	}
-
-	return true;
 }
 
 #endif


### PR DESCRIPTION
There is no user of this return value and furthermore the function can only ever return `true`.