### PR TITLE
PG-1537 Error on required arguments

### DIFF
--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -163,4 +163,22 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 -- Creating a file key provider fails if we can't open or create the file
 SELECT pg_tde_add_database_key_provider_file('will-not-work','/cant-create-file-in-root.per');
 ERROR:  Failed to open keyring file /cant-create-file-in-root.per: Permission denied
+-- Setting principal key fails if key name is NULL
+SELECT pg_tde_set_default_key_using_global_key_provider(NULL, 'file-keyring');
+ERROR:  key name cannot be null
+SELECT pg_tde_set_key_using_database_key_provider(NULL, 'file-keyring');
+ERROR:  key name cannot be null
+SELECT pg_tde_set_key_using_global_key_provider(NULL, 'file-keyring');
+ERROR:  key name cannot be null
+SELECT pg_tde_set_server_key_using_global_key_provider(NULL, 'file-keyring');
+ERROR:  key name cannot be null
+-- Empty string is not allowed for a principal key name
+SELECT pg_tde_set_default_key_using_global_key_provider('', 'file-keyring');
+ERROR:  key name "" is too short
+SELECT pg_tde_set_key_using_database_key_provider('', 'file-keyring');
+ERROR:  key name "" is too short
+SELECT pg_tde_set_key_using_global_key_provider('', 'file-keyring');
+ERROR:  key name "" is too short
+SELECT pg_tde_set_server_key_using_global_key_provider('', 'file-keyring');
+ERROR:  key name "" is too short
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -163,6 +163,37 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 -- Creating a file key provider fails if we can't open or create the file
 SELECT pg_tde_add_database_key_provider_file('will-not-work','/cant-create-file-in-root.per');
 ERROR:  Failed to open keyring file /cant-create-file-in-root.per: Permission denied
+-- Creating key providers fails if any required parameter is NULL
+SELECT pg_tde_add_database_key_provider(NULL, 'name', '{}');
+ERROR:  provider type cannot be null
+SELECT pg_tde_add_database_key_provider('file', NULL, '{}');
+ERROR:  provider name cannot be null
+SELECT pg_tde_add_database_key_provider('file', 'name', NULL);
+ERROR:  provider options cannot be null
+SELECT pg_tde_add_global_key_provider(NULL, 'name', '{}');
+ERROR:  provider type cannot be null
+SELECT pg_tde_add_global_key_provider('file', NULL, '{}');
+ERROR:  provider name cannot be null
+SELECT pg_tde_add_global_key_provider('file', 'name', NULL);
+ERROR:  provider options cannot be null
+-- Modifying key providers fails if any required parameter is NULL
+SELECT pg_tde_change_database_key_provider(NULL, 'file-keyring', '{}');
+ERROR:  provider type cannot be null
+SELECT pg_tde_change_database_key_provider('file', NULL, '{}');
+ERROR:  provider name cannot be null
+SELECT pg_tde_change_database_key_provider('file', 'file-keyring', NULL);
+ERROR:  provider options cannot be null
+SELECT pg_tde_change_global_key_provider(NULL, 'file-keyring', '{}');
+ERROR:  provider type cannot be null
+SELECT pg_tde_change_global_key_provider('file', NULL, '{}');
+ERROR:  provider name cannot be null
+SELECT pg_tde_change_global_key_provider('file', 'file-keyring', NULL);
+ERROR:  provider options cannot be null
+-- Deleting key providers fails if key name is NULL
+SELECT pg_tde_delete_database_key_provider(NULL);
+ERROR:  provider_name cannot be null
+SELECT pg_tde_delete_global_key_provider(NULL);
+ERROR:  provider_name cannot be null
 -- Setting principal key fails if key name is NULL
 SELECT pg_tde_set_default_key_using_global_key_provider(NULL, 'file-keyring');
 ERROR:  key name cannot be null

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -176,6 +176,11 @@ SELECT pg_tde_add_global_key_provider('file', NULL, '{}');
 ERROR:  provider name cannot be null
 SELECT pg_tde_add_global_key_provider('file', 'name', NULL);
 ERROR:  provider options cannot be null
+-- Empty string is not allowed for a key provider name
+SELECT pg_tde_add_database_key_provider('file', '', '{}');
+ERROR:  provider name "" is too short
+SELECT pg_tde_add_global_key_provider('file', '', '{}');
+ERROR:  provider name "" is too short
 -- Modifying key providers fails if any required parameter is NULL
 SELECT pg_tde_change_database_key_provider(NULL, 'file-keyring', '{}');
 ERROR:  provider type cannot be null

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -63,6 +63,10 @@ SELECT pg_tde_add_global_key_provider(NULL, 'name', '{}');
 SELECT pg_tde_add_global_key_provider('file', NULL, '{}');
 SELECT pg_tde_add_global_key_provider('file', 'name', NULL);
 
+-- Empty string is not allowed for a key provider name
+SELECT pg_tde_add_database_key_provider('file', '', '{}');
+SELECT pg_tde_add_global_key_provider('file', '', '{}');
+
 -- Modifying key providers fails if any required parameter is NULL
 SELECT pg_tde_change_database_key_provider(NULL, 'file-keyring', '{}');
 SELECT pg_tde_change_database_key_provider('file', NULL, '{}');

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -55,4 +55,16 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 -- Creating a file key provider fails if we can't open or create the file
 SELECT pg_tde_add_database_key_provider_file('will-not-work','/cant-create-file-in-root.per');
 
+-- Setting principal key fails if key name is NULL
+SELECT pg_tde_set_default_key_using_global_key_provider(NULL, 'file-keyring');
+SELECT pg_tde_set_key_using_database_key_provider(NULL, 'file-keyring');
+SELECT pg_tde_set_key_using_global_key_provider(NULL, 'file-keyring');
+SELECT pg_tde_set_server_key_using_global_key_provider(NULL, 'file-keyring');
+
+-- Empty string is not allowed for a principal key name
+SELECT pg_tde_set_default_key_using_global_key_provider('', 'file-keyring');
+SELECT pg_tde_set_key_using_database_key_provider('', 'file-keyring');
+SELECT pg_tde_set_key_using_global_key_provider('', 'file-keyring');
+SELECT pg_tde_set_server_key_using_global_key_provider('', 'file-keyring');
+
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -55,6 +55,26 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 -- Creating a file key provider fails if we can't open or create the file
 SELECT pg_tde_add_database_key_provider_file('will-not-work','/cant-create-file-in-root.per');
 
+-- Creating key providers fails if any required parameter is NULL
+SELECT pg_tde_add_database_key_provider(NULL, 'name', '{}');
+SELECT pg_tde_add_database_key_provider('file', NULL, '{}');
+SELECT pg_tde_add_database_key_provider('file', 'name', NULL);
+SELECT pg_tde_add_global_key_provider(NULL, 'name', '{}');
+SELECT pg_tde_add_global_key_provider('file', NULL, '{}');
+SELECT pg_tde_add_global_key_provider('file', 'name', NULL);
+
+-- Modifying key providers fails if any required parameter is NULL
+SELECT pg_tde_change_database_key_provider(NULL, 'file-keyring', '{}');
+SELECT pg_tde_change_database_key_provider('file', NULL, '{}');
+SELECT pg_tde_change_database_key_provider('file', 'file-keyring', NULL);
+SELECT pg_tde_change_global_key_provider(NULL, 'file-keyring', '{}');
+SELECT pg_tde_change_global_key_provider('file', NULL, '{}');
+SELECT pg_tde_change_global_key_provider('file', 'file-keyring', NULL);
+
+-- Deleting key providers fails if key name is NULL
+SELECT pg_tde_delete_database_key_provider(NULL);
+SELECT pg_tde_delete_global_key_provider(NULL);
+
 -- Setting principal key fails if key name is NULL
 SELECT pg_tde_set_default_key_using_global_key_provider(NULL, 'file-keyring');
 SELECT pg_tde_set_key_using_database_key_provider(NULL, 'file-keyring');

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -287,10 +287,15 @@ pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 	options = required_text_argument(fcinfo->args[2], "provider options");
 
 	nlen = strlen(provider_name);
+	if (nlen == 0)
+		ereport(ERROR,
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("provider name \"\" is too short"));
 	if (nlen >= sizeof(provider.provider_name) - 1)
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				errmsg("too long provider name, maximum length is %ld bytes", sizeof(provider.provider_name) - 1));
+				errmsg("provider name \"%s\" is too long", provider_name),
+				errhint("Maximum length is %ld bytes.", sizeof(provider.provider_name) - 1));
 
 	olen = strlen(options);
 	if (olen >= sizeof(provider.options))

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -508,7 +508,7 @@ clear_principal_key_cache(Oid databaseId)
 Datum
 pg_tde_set_default_key_using_global_key_provider(PG_FUNCTION_ARGS)
 {
-	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *principal_key_name = PG_ARGISNULL(0) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
 	bool		ensure_new_key = PG_GETARG_BOOL(2);
 
@@ -521,7 +521,7 @@ pg_tde_set_default_key_using_global_key_provider(PG_FUNCTION_ARGS)
 Datum
 pg_tde_set_key_using_database_key_provider(PG_FUNCTION_ARGS)
 {
-	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *principal_key_name = PG_ARGISNULL(0) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
 	bool		ensure_new_key = PG_GETARG_BOOL(2);
 
@@ -534,7 +534,7 @@ pg_tde_set_key_using_database_key_provider(PG_FUNCTION_ARGS)
 Datum
 pg_tde_set_key_using_global_key_provider(PG_FUNCTION_ARGS)
 {
-	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *principal_key_name = PG_ARGISNULL(0) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
 	bool		ensure_new_key = PG_GETARG_BOOL(2);
 
@@ -547,7 +547,7 @@ pg_tde_set_key_using_global_key_provider(PG_FUNCTION_ARGS)
 Datum
 pg_tde_set_server_key_using_global_key_provider(PG_FUNCTION_ARGS)
 {
-	char	   *principal_key_name = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	char	   *principal_key_name = PG_ARGISNULL(0) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
 	bool		ensure_new_key = PG_GETARG_BOOL(2);
 
@@ -567,6 +567,15 @@ pg_tde_set_principal_key_internal(Oid providerOid, Oid dbOid, const char *key_na
 		ereport(ERROR,
 				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				errmsg("must be superuser to access global key providers"));
+
+	if (key_name == NULL)
+		ereport(ERROR,
+				errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+				errmsg("key name cannot be null"));
+	if (strlen(key_name) == 0)
+		ereport(ERROR,
+				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("key name \"\" is too short"));
 
 	ereport(LOG, errmsg("Setting principal key [%s : %s] for the database", key_name, provider_name));
 


### PR DESCRIPTION
Do not accept NULL or the empty string for required arguments in our user facing functions.

I'm a bit unsure of where the helper `required_text_argument()` belongs, any input is appreciated.
