### PR TITLE
Move all `pg_tde` related tests into `contrib/pg_tde`

### DIFF
--- a/contrib/pg_tde/meson.build
+++ b/contrib/pg_tde/meson.build
@@ -115,6 +115,8 @@ tap_tests = [
   't/011_unlogged_tables.pl',
   't/012_replication.pl',
   't/013_crash_recovery.pl',
+  't/014_pg_waldump_basic.pl',
+  't/015_pg_waldump_fullpage.pl',
 ]
 
 tests += {

--- a/contrib/pg_tde/t/015_pg_waldump_fullpage.pl
+++ b/contrib/pg_tde/t/015_pg_waldump_fullpage.pl
@@ -41,8 +41,12 @@ shared_preload_libraries = 'pg_tde'
 $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
-$node->safe_psql('postgres', "SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');");;
-$node->safe_psql('postgres', "SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-wal');");
+$node->safe_psql('postgres',
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');"
+);
+$node->safe_psql('postgres',
+	"SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-wal');"
+);
 
 $node->append_conf(
 	'postgresql.conf', q{
@@ -84,7 +88,7 @@ ok(-f $walfile, "Got a WAL file");
 $node->command_ok(
 	[
 		'pg_waldump', '--quiet',
-		'-k', $node->data_dir. '/pg_tde',
+		'-k', $node->data_dir . '/pg_tde',
 		'--save-fullpage', "$tmp_folder/raw",
 		'--relation', $relation,
 		$walfile

--- a/src/bin/pg_waldump/meson.build
+++ b/src/bin/pg_waldump/meson.build
@@ -42,8 +42,6 @@ tests += {
     'tests': [
       't/001_basic.pl',
       't/002_save_fullpage.pl',
-      't/003_basic_encrypted.pl',
-      't/004_save_fullpage_encrypted.pl',
     ],
   },
 }


### PR DESCRIPTION
While these tests test our changes to `pg_waldump` they are quite easy to overlook right now and where exactly should we draw the line? These tests are not something we ever want to upstream and in the future when we figure out how we want to make sure `pg_waldump` works with encrypted WAL we likely will want to have the tests for that solution in the same folder as our other tests anyway.