### PR TITLE
PG-1447 Test and fix support for template databases

### DIFF
--- a/contrib/pg_tde/Makefile
+++ b/contrib/pg_tde/Makefile
@@ -8,7 +8,8 @@ DATA = pg_tde--1.0-rc.sql
 # Since meson supports skipping test suites this is a make only feature
 ifndef TDE_MODE
 REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/pg_tde/pg_tde.conf
-# default_principal_key needs to run after key_provider.
+# create_database must run after default_principal_key which must run after
+# key_provider.
 REGRESS = access_control \
 alter_index \
 cache_alloc \
@@ -24,7 +25,8 @@ tablespace \
 toast_decrypt \
 vault_v2_test \
 version \
-default_principal_key
+default_principal_key \
+create_database
 TAP_TESTS = 1
 endif
 

--- a/contrib/pg_tde/expected/create_database.out
+++ b/contrib/pg_tde/expected/create_database.out
@@ -92,6 +92,14 @@ SELECT pg_tde_is_encrypted('test_plain_id_seq');
 (1 row)
 
 \c :regress_database
+CREATE DATABASE new_db_file_copy TEMPLATE template_db STRATEGY FILE_COPY;
+ERROR:  The FILE_COPY strategy cannot be used when there are encrypted objects in the template database: 3 objects found
+HINT:  Use the WAL_LOG strategy instead.
+\c template_db
+DROP TABLE test_enc;
+\c :regress_database
+CREATE DATABASE new_db_file_copy TEMPLATE template_db STRATEGY FILE_COPY;
+DROP DATABASE new_db_file_copy;
 DROP DATABASE new_db;
 DROP DATABASE template_db;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/create_database.out
+++ b/contrib/pg_tde/expected/create_database.out
@@ -1,0 +1,97 @@
+CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE DATABASE template_db;
+SELECT current_database() AS regress_database
+\gset
+\c template_db
+CREATE EXTENSION pg_tde;
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/template_provider.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
+ pg_tde_set_key_using_database_key_provider 
+--------------------------------------------
+ 
+(1 row)
+
+CREATE TABLE test_enc (id serial PRIMARY KEY, x int) USING tde_heap;
+CREATE TABLE test_plain (id serial PRIMARY KEY, x int) USING heap;
+INSERT INTO test_enc (x) VALUES (10), (20);
+INSERT INTO test_plain (x) VALUES (30), (40);
+\c :regress_database
+-- TODO: Test the case where we have no default key once we can delete default keys
+--CREATE DATABASE new_db TEMPLATE template_db;
+SELECT pg_tde_add_global_key_provider_file('global-file-vault','/tmp/template_provider_global.per');
+ pg_tde_add_global_key_provider_file 
+-------------------------------------
+                                  -4
+(1 row)
+
+SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'global-file-vault');
+ pg_tde_set_default_key_using_global_key_provider 
+--------------------------------------------------
+ 
+(1 row)
+
+CREATE DATABASE new_db TEMPLATE template_db;
+\c new_db
+INSERT INTO test_enc (x) VALUES (25);
+SELECT * FROM test_enc;
+ id | x  
+----+----
+  1 | 10
+  2 | 20
+  3 | 25
+(3 rows)
+
+SELECT pg_tde_is_encrypted('test_enc');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_enc_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_enc_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+INSERT INTO test_plain (x) VALUES (45);
+SELECT * FROM test_plain;
+ id | x  
+----+----
+  1 | 30
+  2 | 40
+  3 | 45
+(3 rows)
+
+SELECT pg_tde_is_encrypted('test_plain');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_plain_pkey');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_plain_id_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+\c :regress_database
+DROP DATABASE new_db;
+DROP DATABASE template_db;
+DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/meson.build
+++ b/contrib/pg_tde/meson.build
@@ -80,7 +80,8 @@ install_data(
   kwargs: contrib_data_args,
 )
 
-# default_principal_key needs to run after key_provider.
+# create_database must run after default_principal_key which must run after
+# key_provider.
 sql_tests = [
   'access_control',
   'alter_index',
@@ -98,6 +99,7 @@ sql_tests = [
   'vault_v2_test',
   'version',
   'default_principal_key',
+  'create_database',
 ]
 
 tap_tests = [

--- a/contrib/pg_tde/sql/create_database.sql
+++ b/contrib/pg_tde/sql/create_database.sql
@@ -1,0 +1,51 @@
+CREATE EXTENSION IF NOT EXISTS pg_tde;
+
+CREATE DATABASE template_db;
+
+SELECT current_database() AS regress_database
+\gset
+
+\c template_db
+
+CREATE EXTENSION pg_tde;
+
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/template_provider.per');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
+
+CREATE TABLE test_enc (id serial PRIMARY KEY, x int) USING tde_heap;
+CREATE TABLE test_plain (id serial PRIMARY KEY, x int) USING heap;
+
+INSERT INTO test_enc (x) VALUES (10), (20);
+INSERT INTO test_plain (x) VALUES (30), (40);
+
+\c :regress_database
+
+-- TODO: Test the case where we have no default key once we can delete default keys
+--CREATE DATABASE new_db TEMPLATE template_db;
+
+SELECT pg_tde_add_global_key_provider_file('global-file-vault','/tmp/template_provider_global.per');
+
+SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'global-file-vault');
+
+CREATE DATABASE new_db TEMPLATE template_db;
+
+\c new_db
+
+INSERT INTO test_enc (x) VALUES (25);
+SELECT * FROM test_enc;
+SELECT pg_tde_is_encrypted('test_enc');
+SELECT pg_tde_is_encrypted('test_enc_pkey');
+SELECT pg_tde_is_encrypted('test_enc_id_seq');
+
+INSERT INTO test_plain (x) VALUES (45);
+SELECT * FROM test_plain;
+SELECT pg_tde_is_encrypted('test_plain');
+SELECT pg_tde_is_encrypted('test_plain_pkey');
+SELECT pg_tde_is_encrypted('test_plain_id_seq');
+
+\c :regress_database
+
+DROP DATABASE new_db;
+DROP DATABASE template_db;
+
+DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/create_database.sql
+++ b/contrib/pg_tde/sql/create_database.sql
@@ -45,6 +45,17 @@ SELECT pg_tde_is_encrypted('test_plain_id_seq');
 
 \c :regress_database
 
+CREATE DATABASE new_db_file_copy TEMPLATE template_db STRATEGY FILE_COPY;
+
+\c template_db
+
+DROP TABLE test_enc;
+
+\c :regress_database
+
+CREATE DATABASE new_db_file_copy TEMPLATE template_db STRATEGY FILE_COPY;
+
+DROP DATABASE new_db_file_copy;
 DROP DATABASE new_db;
 DROP DATABASE template_db;
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -111,6 +111,7 @@ pg_tde_set_db_file_path(Oid dbOid, char *path)
 }
 
 extern InternalKey *GetSMGRRelationKey(RelFileLocatorBackend rel);
+extern int	pg_tde_count_relations(Oid dbOid);
 
 extern void pg_tde_delete_tde_files(Oid dbOid);
 

--- a/contrib/pg_tde/src/include/pg_tde_event_capture.h
+++ b/contrib/pg_tde/src/include/pg_tde_event_capture.h
@@ -26,8 +26,8 @@ typedef struct TdeCreateEvent
 										 * based on earlier encryption status. */
 } TdeCreateEvent;
 
+extern void TdeEventCaptureInit(void);
 extern TdeCreateEvent *GetCurrentTdeCreateEvent(void);
-
 extern void validateCurrentEventTriggerState(bool mightStartTransaction);
 
 #endif

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -33,6 +33,7 @@
 #include "utils/builtins.h"
 #include "smgr/pg_tde_smgr.h"
 #include "catalog/tde_global_space.h"
+#include "pg_tde_event_capture.h"
 #include "utils/percona.h"
 #include "pg_tde_guc.h"
 #include "access/tableam.h"
@@ -111,6 +112,7 @@ _PG_init(void)
 	check_percona_api_version();
 
 	TdeGucInit();
+	TdeEventCaptureInit();
 
 	InitializePrincipalKeyInfo();
 	InitializeKeyProviderInfo();


### PR DESCRIPTION
Using a database with encrypted relations as template works with the `WAL_LOG` strategy as long as you have configured a default principal key. It is a bit hackish but works and  since encrypted objects in a template database is likely to be an uncommon use case this is fine for now.
    
The test file is put last in the test run order since there is still no good way to clean up default principal keys.

Additionally we assert there are no encrypted relations when using `FILE_COPY`.

The `FILE_COPY` strategy of `CREATE DATABASE` does not use the SMGR so it cannot properly copy and re-encrypt encrypted relations. So we check for  such relations and error out if any are found.
    
We look for encrypted relations simply by counting the number of keys in the key map file of the database. This simple approach is fine even with  the risk of a left-over key from a crash or a bug due to the `FILE_COPY` strategy being rare and that we therefore want to keep this code minimal.
