### PR TITLE
Rename event triggers to something more expressive

### DIFF
--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -515,15 +515,15 @@ RETURNS event_trigger
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE EVENT TRIGGER pg_tde_trigger_create_index
+CREATE EVENT TRIGGER pg_tde_ddl_start
 ON ddl_command_start
 EXECUTE FUNCTION pg_tde_ddl_command_start_capture();
-ALTER EVENT TRIGGER pg_tde_trigger_create_index ENABLE ALWAYS;
+ALTER EVENT TRIGGER pg_tde_ddl_start ENABLE ALWAYS;
 
-CREATE EVENT TRIGGER pg_tde_trigger_create_index_2
+CREATE EVENT TRIGGER pg_tde_ddl_end
 ON ddl_command_end
 EXECUTE FUNCTION pg_tde_ddl_command_end_capture();
-ALTER EVENT TRIGGER pg_tde_trigger_create_index_2 ENABLE ALWAYS;
+ALTER EVENT TRIGGER pg_tde_ddl_end ENABLE ALWAYS;
 
 -- Per database extension initialization
 SELECT pg_tde_extension_initialize();

--- a/src/test/regress/expected/event_trigger_1.out
+++ b/src/test/regress/expected/event_trigger_1.out
@@ -708,13 +708,13 @@ SELECT
     LATERAL pg_identify_object_as_address('pg_event_trigger'::regclass, e.oid, 0) as b,
     LATERAL pg_get_object_address(b.type, b.object_names, b.object_args) as a
   ORDER BY e.evtname;
-            evtname            |                    descr                    |     type      |          object_names           | object_args |                                     ident                                      
--------------------------------+---------------------------------------------+---------------+---------------------------------+-------------+--------------------------------------------------------------------------------
- end_rls_command               | event trigger end_rls_command               | event trigger | {end_rls_command}               | {}          | ("event trigger",,end_rls_command,end_rls_command)
- pg_tde_trigger_create_index   | event trigger pg_tde_trigger_create_index   | event trigger | {pg_tde_trigger_create_index}   | {}          | ("event trigger",,pg_tde_trigger_create_index,pg_tde_trigger_create_index)
- pg_tde_trigger_create_index_2 | event trigger pg_tde_trigger_create_index_2 | event trigger | {pg_tde_trigger_create_index_2} | {}          | ("event trigger",,pg_tde_trigger_create_index_2,pg_tde_trigger_create_index_2)
- sql_drop_command              | event trigger sql_drop_command              | event trigger | {sql_drop_command}              | {}          | ("event trigger",,sql_drop_command,sql_drop_command)
- start_rls_command             | event trigger start_rls_command             | event trigger | {start_rls_command}             | {}          | ("event trigger",,start_rls_command,start_rls_command)
+      evtname      |              descr              |     type      |    object_names     | object_args |                         ident                          
+-------------------+---------------------------------+---------------+---------------------+-------------+--------------------------------------------------------
+ end_rls_command   | event trigger end_rls_command   | event trigger | {end_rls_command}   | {}          | ("event trigger",,end_rls_command,end_rls_command)
+ pg_tde_ddl_end    | event trigger pg_tde_ddl_end    | event trigger | {pg_tde_ddl_end}    | {}          | ("event trigger",,pg_tde_ddl_end,pg_tde_ddl_end)
+ pg_tde_ddl_start  | event trigger pg_tde_ddl_start  | event trigger | {pg_tde_ddl_start}  | {}          | ("event trigger",,pg_tde_ddl_start,pg_tde_ddl_start)
+ sql_drop_command  | event trigger sql_drop_command  | event trigger | {sql_drop_command}  | {}          | ("event trigger",,sql_drop_command,sql_drop_command)
+ start_rls_command | event trigger start_rls_command | event trigger | {start_rls_command} | {}          | ("event trigger",,start_rls_command,start_rls_command)
 (5 rows)
 
 DROP EVENT TRIGGER start_rls_command;


### PR DESCRIPTION
Instead of giving them numbers we call them `pg_tde_ddl_start` and `pg_tde_ddl_end`. Since the triggers are not on the same event the names do not matter for the order they are executed in.