### PR TITLE
Add missing files to GitHub fail artifacts from make

### DIFF
--- a/.github/workflows/psp-reusable.yml
+++ b/.github/workflows/psp-reusable.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: testlog-ubuntu-${{ inputs.ubuntu_version }}.04-meson-${{ inputs.build_type }}
+          name: log-test-${{ inputs.os }}-${{ inputs.build_script }}-${{ inputs.build_type }}
           path: |
             src/build/testrun/
             src/contrib/*/t/
@@ -111,7 +111,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: testlog-tde-${{ inputs.os }}-${{  inputs.build_script }}-${{ inputs.build_type }}
+          name: log-test-global-tde-${{ inputs.os }}-${{ inputs.build_script }}-${{ inputs.build_type }}
           path: |
             src/build/testrun/
             src/contrib/*/t/

--- a/.github/workflows/psp-reusable.yml
+++ b/.github/workflows/psp-reusable.yml
@@ -76,10 +76,17 @@ jobs:
           name: log-test-${{ inputs.os }}-${{ inputs.build_script }}-${{ inputs.build_type }}
           path: |
             src/build/testrun/
-            src/contrib/*/t/
-            src/contrib/*/results
+            src/contrib/*/log
             src/contrib/*/regression.diffs
             src/contrib/*/regression.out
+            src/contrib/*/results
+            src/contrib/*/tmp_check
+            src/contrib/*/t/results
+            src/src/test/*/log
+            src/src/test/*/regression.diffs
+            src/src/test/*/regression.out
+            src/src/test/*/results
+            src/src/test/*/tmp_check
           retention-days: 3
 
   test_tde:
@@ -114,8 +121,15 @@ jobs:
           name: log-test-global-tde-${{ inputs.os }}-${{ inputs.build_script }}-${{ inputs.build_type }}
           path: |
             src/build/testrun/
-            src/contrib/*/t/
-            src/contrib/*/results
+            src/contrib/*/log
             src/contrib/*/regression.diffs
             src/contrib/*/regression.out
+            src/contrib/*/results
+            src/contrib/*/tmp_check
+            src/contrib/*/t/results
+            src/src/test/*/log
+            src/src/test/*/regression.diffs
+            src/src/test/*/regression.out
+            src/src/test/*/results
+            src/src/test/*/tmp_check
           retention-days: 3


### PR DESCRIPTION
Most of the files, including logs and result files, were missing from the artifact which is uploaded on build failure.