### PR TITLE
PG-1540 Add support for `CREATE` and `ALTER SEQUENCE` plus refactor event trigger to use a stack

### DIFF
--- a/contrib/pg_tde/expected/recreate_storage.out
+++ b/contrib/pg_tde/expected/recreate_storage.out
@@ -104,6 +104,7 @@ SELECT pg_tde_is_encrypted('rewritemetoo2');
 
 CREATE TABLE encrypted_table (
     id SERIAL,
+    id2 INT,
     data TEXT,
     created_at DATE NOT NULL,
     PRIMARY KEY (id, created_at)
@@ -135,6 +136,100 @@ SELECT pg_tde_is_encrypted('encrypted_table_id_seq');
  t
 (1 row)
 
+CREATE TABLE plain_table (
+    id2 INT
+) USING heap;
+-- Starts independent and becomes encrypted
+CREATE SEQUENCE independent_seq;
+SELECT pg_tde_is_encrypted('independent_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+ALTER SEQUENCE independent_seq OWNED BY encrypted_table.id2;
+SELECT pg_tde_is_encrypted('independent_seq');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+-- Starts independent and stays plain
+CREATE SEQUENCE independent_seq2 OWNED BY NONE;
+SELECT pg_tde_is_encrypted('independent_seq2');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+ALTER SEQUENCE independent_seq2 OWNED BY plain_table.id2;
+SELECT pg_tde_is_encrypted('independent_seq2');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+-- Starts owned by an encrypted table and becomes owned by a plain table
+CREATE SEQUENCE encrypted_table_id2_seq OWNED BY encrypted_table.id2;
+SELECT pg_tde_is_encrypted('encrypted_table_id2_seq');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+ALTER SEQUENCE encrypted_table_id2_seq OWNED BY plain_table.id2;
+SELECT pg_tde_is_encrypted('encrypted_table_id2_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+-- Starts owned by an encrypted table and becomes independent
+CREATE SEQUENCE encrypted_table_id2_seq2 OWNED BY encrypted_table.id2;
+SELECT pg_tde_is_encrypted('encrypted_table_id2_seq2');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+ALTER SEQUENCE encrypted_table_id2_seq2 OWNED BY NONE;
+SELECT pg_tde_is_encrypted('encrypted_table_id2_seq2');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+-- Starts owned by a plain table and becomes owned by an encrypted table
+CREATE SEQUENCE plain_table_id2_seq OWNED BY plain_table.id2;
+SELECT pg_tde_is_encrypted('plain_table_id2_seq');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+ALTER SEQUENCE plain_table_id2_seq OWNED BY encrypted_table.id2;
+SELECT pg_tde_is_encrypted('plain_table_id2_seq');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+-- Starts owned by a plain table and becomes independent
+CREATE SEQUENCE plain_table_id2_seq2 OWNED BY plain_table.id2;
+SELECT pg_tde_is_encrypted('plain_table_id2_seq2');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+ALTER SEQUENCE plain_table_id2_seq2 OWNED BY NONE;
+SELECT pg_tde_is_encrypted('plain_table_id2_seq2');
+ pg_tde_is_encrypted 
+---------------------
+ f
+(1 row)
+
+DROP TABLE plain_table;
 DROP EXTENSION pg_tde CASCADE;
 NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to table t1

--- a/contrib/pg_tde/src/include/pg_tde_event_capture.h
+++ b/contrib/pg_tde/src/include/pg_tde_event_capture.h
@@ -11,23 +11,14 @@
 #include "nodes/parsenodes.h"
 #include "access/transam.h"
 
-typedef struct TdeCreateEvent
+typedef enum
 {
-	FullTransactionId tid;		/* transaction id of the last event trigger,
-								 * or 0 */
-	bool		encryptMode;	/* true when the table uses encryption */
-	Oid			baseTableOid;	/* Oid of table on which index is being
-								 * created on. For create table statement this
-								 * contains InvalidOid */
-	RangeVar   *relation;		/* Reference to the parsed relation from
-								 * create statement */
-	bool		alterAccessMethodMode;	/* during ALTER ... SET ACCESS METHOD,
-										 * new file permissions shouldn't be
-										 * based on earlier encryption status. */
-} TdeCreateEvent;
+	TDE_ENCRYPT_MODE_RETAIN = 0,
+	TDE_ENCRYPT_MODE_ENCRYPT,
+	TDE_ENCRYPT_MODE_PLAIN,
+} TDEEncryptMode;
 
 extern void TdeEventCaptureInit(void);
-extern TdeCreateEvent *GetCurrentTdeCreateEvent(void);
-extern void validateCurrentEventTriggerState(bool mightStartTransaction);
+extern TDEEncryptMode currentTdeEncryptModeValidated(void);
 
 #endif


### PR DESCRIPTION
While trying to figure out how to fix the trigger with table inheritance I ended up sidetracked into this, but at least the end result was cleaner code and fixing the support for sequences. How to solve table inheritance and `ALTER TYPE` is still very unclear.

When creating a table with a serial/identity column the sequence will get the same encryption status as the owning table but when doing the same using `CREATE SEQUENCE` and `ALTER SEQUENCE` the sequence ended up not encrypted so this add support for those.

A design choice is that sequences not owned by any table are never encrypted which is unclear if it is a good choice or not.

And to fix the sequence support without making the code even harder to read I decided to refactor the event trigger to use a command stack so we can cleanly register that we need to recreate sequences at the end. Plus we also simplify the API between the event trigger and the SMGR code.