### PR TITLE
Remove checking for leftover tables on extension install

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -28,7 +28,6 @@
 #include "catalog/tde_principal_key.h"
 #include "encryption/enc_aes.h"
 #include "keyring/keyring_api.h"
-#include "common/pg_tde_utils.h"
 
 #include <openssl/rand.h>
 #include <openssl/err.h>

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -84,7 +84,7 @@ static void cleanup_key_provider_info(Oid databaseId);
 static const char *get_keyring_provider_typename(ProviderType p_type);
 static List *GetAllKeyringProviders(Oid dbOid);
 static Size initialize_shared_state(void *start_address);
-static void key_provider_startup_cleanup(int tde_tbl_count, XLogExtensionInstall *ext_info, bool redo, void *arg);
+static void key_provider_startup_cleanup(XLogExtensionInstall *ext_info, bool redo, void *arg);
 static Datum pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
 static Datum pg_tde_change_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
 static Datum pg_tde_delete_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
@@ -137,16 +137,11 @@ InitializeKeyProviderInfo(void)
 	RegisterShmemRequest(&key_provider_info_shmem_routine);
 	on_ext_install(key_provider_startup_cleanup, NULL);
 }
+
 static void
-key_provider_startup_cleanup(int tde_tbl_count, XLogExtensionInstall *ext_info, bool redo, void *arg)
+key_provider_startup_cleanup(XLogExtensionInstall *ext_info, bool redo, void *arg)
 {
 
-	if (tde_tbl_count > 0)
-	{
-		ereport(WARNING,
-				errmsg("failed to perform initialization. database already has %d TDE tables", tde_tbl_count));
-		return;
-	}
 	cleanup_key_provider_info(ext_info->database_id);
 }
 

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -84,7 +84,7 @@ static void cleanup_key_provider_info(Oid databaseId);
 static const char *get_keyring_provider_typename(ProviderType p_type);
 static List *GetAllKeyringProviders(Oid dbOid);
 static Size initialize_shared_state(void *start_address);
-static void key_provider_startup_cleanup(XLogExtensionInstall *ext_info, bool redo, void *arg);
+static void key_provider_startup_cleanup(XLogExtensionInstall *ext_info, bool redo);
 static Datum pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
 static Datum pg_tde_change_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
 static Datum pg_tde_delete_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
@@ -135,11 +135,11 @@ InitializeKeyProviderInfo(void)
 {
 	ereport(LOG, errmsg("initializing TDE key provider info"));
 	RegisterShmemRequest(&key_provider_info_shmem_routine);
-	on_ext_install(key_provider_startup_cleanup, NULL);
+	on_ext_install(key_provider_startup_cleanup);
 }
 
 static void
-key_provider_startup_cleanup(XLogExtensionInstall *ext_info, bool redo, void *arg)
+key_provider_startup_cleanup(XLogExtensionInstall *ext_info, bool redo)
 {
 
 	cleanup_key_provider_info(ext_info->database_id);

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -88,7 +88,7 @@ static Size initialize_shared_state(void *start_address);
 static void initialize_objects_in_dsa_area(dsa_area *dsa, void *raw_dsa_area);
 static Size required_shared_mem_size(void);
 static void shared_memory_shutdown(int code, Datum arg);
-static void principal_key_startup_cleanup(XLogExtensionInstall *ext_info, bool redo, void *arg);
+static void principal_key_startup_cleanup(XLogExtensionInstall *ext_info, bool redo);
 static void clear_principal_key_cache(Oid databaseId);
 static inline dshash_table *get_principal_key_Hash(void);
 static TDEPrincipalKey *get_principal_key_from_cache(Oid dbOid);
@@ -124,7 +124,7 @@ InitializePrincipalKeyInfo(void)
 {
 	ereport(LOG, errmsg("Initializing TDE principal key info"));
 	RegisterShmemRequest(&principal_key_info_shmem_routine);
-	on_ext_install(principal_key_startup_cleanup, NULL);
+	on_ext_install(principal_key_startup_cleanup);
 }
 
 /*
@@ -472,7 +472,7 @@ push_principal_key_to_cache(TDEPrincipalKey *principalKey)
  * but unfortunately we do not have any such mechanism in PG.
 */
 static void
-principal_key_startup_cleanup(XLogExtensionInstall *ext_info, bool redo, void *arg)
+principal_key_startup_cleanup(XLogExtensionInstall *ext_info, bool redo)
 {
 	clear_principal_key_cache(ext_info->database_id);
 

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -88,7 +88,7 @@ static Size initialize_shared_state(void *start_address);
 static void initialize_objects_in_dsa_area(dsa_area *dsa, void *raw_dsa_area);
 static Size required_shared_mem_size(void);
 static void shared_memory_shutdown(int code, Datum arg);
-static void principal_key_startup_cleanup(int tde_tbl_count, XLogExtensionInstall *ext_info, bool redo, void *arg);
+static void principal_key_startup_cleanup(XLogExtensionInstall *ext_info, bool redo, void *arg);
 static void clear_principal_key_cache(Oid databaseId);
 static inline dshash_table *get_principal_key_Hash(void);
 static TDEPrincipalKey *get_principal_key_from_cache(Oid dbOid);
@@ -472,15 +472,8 @@ push_principal_key_to_cache(TDEPrincipalKey *principalKey)
  * but unfortunately we do not have any such mechanism in PG.
 */
 static void
-principal_key_startup_cleanup(int tde_tbl_count, XLogExtensionInstall *ext_info, bool redo, void *arg)
+principal_key_startup_cleanup(XLogExtensionInstall *ext_info, bool redo, void *arg)
 {
-	if (tde_tbl_count > 0)
-	{
-		ereport(WARNING,
-				errmsg("Failed to perform initialization. database already has %d TDE tables", tde_tbl_count));
-		return;
-	}
-
 	clear_principal_key_cache(ext_info->database_id);
 
 	/* Remove the tde files */

--- a/contrib/pg_tde/src/include/common/pg_tde_utils.h
+++ b/contrib/pg_tde/src/include/common/pg_tde_utils.h
@@ -8,10 +8,6 @@
 #ifndef PG_TDE_UTILS_H
 #define PG_TDE_UTILS_H
 
-#ifndef FRONTEND
-extern int	get_tde_tables_count(void);
-#endif							/* !FRONTEND */
-
 extern void pg_tde_set_data_dir(const char *dir);
 extern const char *pg_tde_get_data_dir(void);
 

--- a/contrib/pg_tde/src/include/pg_tde.h
+++ b/contrib/pg_tde/src/include/pg_tde.h
@@ -19,10 +19,9 @@ typedef struct XLogExtensionInstall
 	Oid			database_id;
 } XLogExtensionInstall;
 
-typedef void (*pg_tde_on_ext_install_callback) (XLogExtensionInstall *ext_info, bool redo, void *arg);
+typedef void (*pg_tde_on_ext_install_callback) (XLogExtensionInstall *ext_info, bool redo);
 
-extern void on_ext_install(pg_tde_on_ext_install_callback function, void *arg);
-
+extern void on_ext_install(pg_tde_on_ext_install_callback function);
 extern void extension_install_redo(XLogExtensionInstall *xlrec);
 
 #endif							/* PG_TDE_H */

--- a/contrib/pg_tde/src/include/pg_tde.h
+++ b/contrib/pg_tde/src/include/pg_tde.h
@@ -19,7 +19,7 @@ typedef struct XLogExtensionInstall
 	Oid			database_id;
 } XLogExtensionInstall;
 
-typedef void (*pg_tde_on_ext_install_callback) (int tde_tbl_count, XLogExtensionInstall *ext_info, bool redo, void *arg);
+typedef void (*pg_tde_on_ext_install_callback) (XLogExtensionInstall *ext_info, bool redo, void *arg);
 
 extern void on_ext_install(pg_tde_on_ext_install_callback function, void *arg);
 

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -25,7 +25,6 @@
 #include "access/xloginsert.h"
 #include "keyring/keyring_api.h"
 #include "common/pg_tde_shmem.h"
-#include "common/pg_tde_utils.h"
 #include "catalog/tde_principal_key.h"
 #include "keyring/keyring_file.h"
 #include "keyring/keyring_vault.h"
@@ -202,19 +201,9 @@ pg_tde_init_data_dir(void)
 static void
 run_extension_install_callbacks(XLogExtensionInstall *xlrec, bool redo)
 {
-	int			i;
-	int			tde_table_count = 0;
-
-	/*
-	 * Get the number of tde tables in this database should always be zero.
-	 * But still, it prevents the cleanup if someone explicitly calls this
-	 * function.
-	 */
-	if (!redo)
-		tde_table_count = get_tde_tables_count();
-	for (i = 0; i < on_ext_install_index; i++)
+	for (int i = 0; i < on_ext_install_index; i++)
 		on_ext_install_list[i]
-			.function(tde_table_count, xlrec, redo, on_ext_install_list[i].arg);
+			.function(xlrec, redo, on_ext_install_list[i].arg);
 }
 
 /* Returns package version */


### PR DESCRIPTION
This check makes no sense since `tde_heap` will get a new oid every time  we install it so if there are any leftovers from last time we will not  find them anyway.
    
Additionally for this to happen something would need to be broken with `pg_depend` which I do not see why we should expend this much effort with trying to assert against.

This PR also removed the unused extra arguments to the hook since for an internal API such extensibility seems very wasteful.