### PR TITLE
Fix typo in error messages

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -227,7 +227,7 @@ pg_tde_change_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 	if (nlen >= sizeof(provider.provider_name))
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				errmsg("too long provider name, maximum lenght is %ld bytes", sizeof(provider.provider_name) - 1));
+				errmsg("too long provider name, maximum length is %ld bytes", sizeof(provider.provider_name) - 1));
 
 	olen = strlen(options);
 	if (olen >= sizeof(provider.options))
@@ -280,7 +280,7 @@ pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 	if (nlen >= sizeof(provider.provider_name) - 1)
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				errmsg("too long provider name, maximum lenght is %ld bytes", sizeof(provider.provider_name) - 1));
+				errmsg("too long provider name, maximum length is %ld bytes", sizeof(provider.provider_name) - 1));
 
 	olen = strlen(options);
 	if (olen >= sizeof(provider.options))

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -306,7 +306,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 	if (strlen(key_name) >= sizeof(keyInfo->name))
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				errmsg("too long principal key name, maximum lenght is %ld bytes", sizeof(keyInfo->name) - 1));
+				errmsg("too long principal key name, maximum length is %ld bytes", sizeof(keyInfo->name) - 1));
 
 	if (keyInfo == NULL)
 		keyInfo = KeyringGenerateNewKeyAndStore(new_keyring, key_name, PRINCIPAL_KEY_LEN);


### PR DESCRIPTION
Multiple error messages spelled "length" as "lenght"