### PR TITLE
Run full test suite when generating coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Setup kmip and vault
         run: ci_scripts/setup-keyring-servers.sh
 
-      - name: Test postgres with TDE to generate coverage
-        run: ci_scripts/make-test.sh --tde-only
+      - name: Test postgres to generate coverage
+        run: ci_scripts/make-test.sh
 
       - name: Collect coverage data
         run: find . -type f -name "*.c" ! -path '*libkmip*' | xargs -t gcov -abcfu


### PR DESCRIPTION
The --tde-only flag seems to make it fail intermittently which is highly annoying.

Let's see if this helps :slightly_smiling_face: 