### PR TITLE
PG-1465 Add ASAN and UBSAN sanitizers

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
         run: ci_scripts/setup-keyring-servers.sh
 
       - name: Test postgres with TDE to generate coverage
-        run: ci_scripts/make-test.sh --tde-only
+        run: ci_scripts/make-test.sh tde
 
       - name: Collect coverage data
         run: find . -type f -name "*.c" ! -path '*libkmip*' | xargs -t gcov -abcfu

--- a/.github/workflows/psp-reusable.yml
+++ b/.github/workflows/psp-reusable.yml
@@ -71,7 +71,7 @@ jobs:
         run: src/ci_scripts/setup-keyring-servers.sh
 
       - name: Test postgres
-        run: src/ci_scripts/${{ inputs.build_script }}-test.sh
+        run: src/ci_scripts/${{ inputs.build_script }}-test.sh all
 
       - name: Report on test fail
         uses: actions/upload-artifact@v4

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,69 @@
+name: Sanitizers
+on:
+  pull_request:
+  push:
+    branches:
+      - TDE_REL_17_STABLE
+
+env:
+  CC: clang
+  LD: clang
+  UBSAN_OPTIONS: log_path=${{ github.workspace }}/sanitize.log print_suppressions=0 print_stacktrace=1 print_summary=1 halt_on_error=1
+  ASAN_OPTIONS: log_path=${{ github.workspace }}/sanitize.log print_suppressions=0 abort_on_error=1
+  LSAN_OPTIONS: log_path=${{ github.workspace }}/sanitize.log print_suppressions=0 suppressions=${{ github.workspace }}/ci_scripts/suppressions/lsan.supp
+  ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer-14
+  EXTRA_REGRESS_OPTS: "--temp-config=${{ github.workspace }}/test_postgresql.conf"
+  PGCTLTIMEOUT: 120
+
+jobs:
+  run:
+    name: Run
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: ci_scripts/ubuntu-deps.sh
+
+      - name: Build postgres
+        run: ci_scripts/make-build.sh sanitize
+
+      - name: Setup kmip and vault
+        run: ci_scripts/setup-keyring-servers.sh
+
+      - name: Configure test postgres
+        run: echo 'max_stack_depth=8MB' > test_postgresql.conf
+
+      - name: Run tests pg_tde tests
+        run: ci_scripts/make-test.sh tde
+
+      - name: Run PG regression tests
+        run: ci_scripts/make-test.sh server
+
+      - name: Print sanitize logs
+        if: ${{ !cancelled() }}
+        run: cat sanitize.log.*
+
+      - name: Report on test fail
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: sanitizers-testlog
+          path: |
+            build/testrun
+            contrib/**/log
+            contrib/**/regression.diffs
+            contrib/**/regression.out
+            contrib/**/results
+            contrib/**/tmp_check
+            contrib/**/t/results
+            src/test/**/log
+            src/test/**/regression.diffs
+            src/test/**/regression.out
+            src/test/**/results
+            src/test/**/tmp_check
+            sanitize.log.*
+          retention-days: 3

--- a/ci_scripts/make-build.sh
+++ b/ci_scripts/make-build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-ENABLE_COVERAGE=
+ARGS=
 
 for arg in "$@"
 do
     case "$arg" in
         --enable-coverage)
-            ENABLE_COVERAGE="--enable-coverage"
-            shift;;
+            ARGS +=" --enable-coverage"
+            ;;
     esac
 done
 
@@ -17,10 +17,29 @@ source "$SCRIPT_DIR/env.sh"
 
 cd "$SCRIPT_DIR/.."
 
-if [ "$1" = "debugoptimized" ]; then
-    export CFLAGS="-O2"
-    export CXXFLAGS="-O2"
-fi
+case "$1" in
+    debug)
+        echo "Building with debug option"
+        ARGS+=" --enable-cassert"
+        ;;
 
-./configure --prefix="$INSTALL_DIR" --enable-debug --enable-cassert --enable-tap-tests $ENABLE_COVERAGE
+    debugoptimized)
+        echo "Building with debugoptimized option"
+        export CFLAGS="-O2"
+        ARGS+=" --enable-cassert"
+        ;;
+
+    sanitize)
+        echo "Building with sanitize option"
+        export CFLAGS="-fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -fno-inline-functions"
+        ;;
+
+    *)
+        echo "Unknown build type: $1"
+        echo "Please use one of the following: debug, debugoptimized, sanitize"
+        exit 1
+        ;;
+esac
+
+./configure --prefix="$INSTALL_DIR" --enable-debug --enable-tap-tests $ARGS 
 make install-world -j

--- a/ci_scripts/make-test.sh
+++ b/ci_scripts/make-test.sh
@@ -1,25 +1,33 @@
 #!/bin/bash
 
 set -e
-TDE_ONLY=0
-
-for arg in "$@"
-do
-    case "$arg" in
-        --tde-only)
-            TDE_ONLY=1
-            shift;;
-    esac
-done
 
 SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 source "$SCRIPT_DIR/env.sh"
 
-if [ "$TDE_ONLY" -eq 1 ];
-then
-    cd "$SCRIPT_DIR/../contrib/pg_tde"
-    make -s check
-else
-    cd "$SCRIPT_DIR/.."
-    make -s check-world
-fi
+
+case "$1" in
+    server)
+        echo "Run server regression tests"
+        cd "$SCRIPT_DIR/.."
+        make -s check
+        ;;
+
+    tde)
+        echo "Run tde tests"
+        cd "$SCRIPT_DIR/../contrib/pg_tde"
+        make -s check
+        ;;
+
+    all)
+        echo "Run all tests"
+        cd "$SCRIPT_DIR/.."
+        make -s check-world
+        ;;
+
+    *)
+        echo "Unknown test suite: $1"
+        echo "Please use one of the following: server, tde, all"
+        exit 1
+        ;;
+esac

--- a/ci_scripts/meson-build.sh
+++ b/ci_scripts/meson-build.sh
@@ -17,5 +17,31 @@ source "$SCRIPT_DIR/env.sh"
 
 cd "$SCRIPT_DIR/.."
 
-meson setup build --prefix "$INSTALL_DIR" --buildtype="$1" -Dcassert=true -Dtap_tests=enabled $ENABLE_COVERAGE
+BUILD_TYPE=
+
+case "$1" in
+    debug)
+        echo "Building with debug option"
+        BUILD_TYPE=$1
+        ;;
+
+    debugoptimized)
+        echo "Building with debugoptimized option"
+        BUILD_TYPE=$1
+        ;;
+
+    sanitize)
+        echo "Building with sanitize option"
+        export CFLAGS="-fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -fno-inline-functions"
+        BUILD_TYPE=debug
+        ;;
+
+    *)
+        echo "Unknown build type: $1"
+        echo "Please use one of the following: debug, debugoptimized, sanitize"
+        exit 1
+        ;;
+esac
+
+meson setup build --prefix "$INSTALL_DIR" --buildtype="$BUILD_TYPE" -Dcassert=true -Dtap_tests=enabled $ENABLE_COVERAGE
 cd build && ninja && ninja install

--- a/ci_scripts/meson-test.sh
+++ b/ci_scripts/meson-test.sh
@@ -1,25 +1,32 @@
 #!/bin/bash
 
 set -e
-TDE_ONLY=0
-
-for arg in "$@"
-do
-    case "$arg" in
-        --tde-only)
-            TDE_ONLY=1
-            shift;;
-    esac
-done
 
 SCRIPT_DIR="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 source "$SCRIPT_DIR/env.sh"
 
 cd "$SCRIPT_DIR/../build"
 
-if [ "$TDE_ONLY" -eq 1 ];
-then
-    meson test --suite setup --suite pg_tde
-else
-    meson test
-fi
+
+case "$1" in
+    server)
+        echo "Run server regression tests"
+        meson test --suite setup --suite regress
+        ;;
+
+    tde)
+        echo "Run tde tests"
+        meson test --suite setup --suite pg_tde
+        ;;
+
+    all)
+        echo "Run all tests"
+        meson test
+        ;;
+
+    *)
+        echo "Unknown test suite: $1"
+        echo "Please use one of the following: server, tde, all"
+        exit 1
+        ;;
+esac

--- a/ci_scripts/suppressions/lsan.supp
+++ b/ci_scripts/suppressions/lsan.supp
@@ -1,0 +1,15 @@
+leak:save_ps_display_args
+leak:initdb.c
+leak:fe_memutils.c
+leak:fe-exec.c
+leak:fe-connect.c
+leak:pqexpbuffer.c
+leak:strdup
+leak:preproc.y
+leak:pgtypeslib/common.c
+leak:ecpglib/memory.c
+leak:kmip.c
+
+#pg_dump
+leak:getSchemaData
+leak:dumpDumpableObject

--- a/contrib/pg_tde/documentation/CONTRIBUTING.md
+++ b/contrib/pg_tde/documentation/CONTRIBUTING.md
@@ -56,7 +56,7 @@ To run the tests, use the following command:
 
 ```
 source ci_scripts/setup-keyring-servers.sh
-ci_scripts/make-test.sh
+ci_scripts/make-test.sh all
 ```
 
 You can run tests on your local machine with whatever operating system you have. After you submit the pull request, we will check your patch on multiple operating systems.

--- a/contrib/pg_tde/documentation/docs/contribute.md
+++ b/contrib/pg_tde/documentation/docs/contribute.md
@@ -56,7 +56,7 @@ To run the tests, use the following command:
 
 ```
 source ci_scripts/setup-keyring-servers.sh
-ci_scripts/make-test.sh
+ci_scripts/make-test.sh all
 ```
 
 You can run tests on your local machine with whatever operating system you have. After you submit the pull request, we will check your patch on multiple operating systems.

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -780,7 +780,7 @@ scan_key_provider_file(ProviderScanType scanType, void *scanKey, Oid dbOid)
 				providers_list = lappend(providers_list, keyring);
 #else
 				if (providers_list == NULL)
-					providers_list = palloc_object(SimplePtrList);
+					providers_list = palloc0_object(SimplePtrList);
 				simple_ptr_list_append(providers_list, keyring);
 #endif
 			}

--- a/src/test/recovery/t/012_subtransactions.pl
+++ b/src/test/recovery/t/012_subtransactions.pl
@@ -16,6 +16,10 @@ $node_primary->append_conf(
 	'postgresql.conf', qq(
 	max_prepared_transactions = 10
 	log_checkpoints = true
+
+	## Workaround to make tests pass with enabled UBSAN
+	## https://www.postgresql.org/message-id/flat/1775221.1658699459%40sss.pgh.pa.us#18ac2074d2383f232a20bf8b7b32c526
+	max_stack_depth = 8MB
 ));
 $node_primary->start;
 $node_primary->backup('primary_backup');


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PG-1465

This PR adds CI workflow with ASAN(including LSAN) and UBSAN sanitizers. To make this workflow pass it required to modify couple tests that were affected by sanitizers influence. Running `check-world` takes 46 minutes, so it looks like overkill for workflow that we will run for every PR. Because of that I ended with `pg_tde` tests + PG regression tests.

One real issue were found with sanitizers in `tde_keyring.c` file (access uninitialized pointer)