### PR TITLE
PG-1550 Only let superusers create and modify key providers

### DIFF
--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -4,15 +4,13 @@ The `pg_tde` extension provides functions for managing different aspects of its 
 
 ## Permission management
 
-By default, `pg_tde` is restrictive. It doesn't allow any operations until permissions are granted to the user. Only superusers can run permission management functions to manage user permissions. Operations on the global scope are limited to superusers only.
-
-Permissions are based on the normal `EXECUTE` permission on the functions provided by `pg_tde`. Superusers manage them using the `GRANT EXECUTE` and `REVOKE EXECUTE` commands.
+By default, `pg_tde` is restrictive. It doesn't allow any operations until permissions are granted to the user. Only superusers can create or modify to key providers or modify objects in the global scope. Functions for viewing keys and for setting the principal key in a database local key provider can on the other hand be run by the database owner and be delegated to normal users using the `GRANT EXECUTE` and `REVOKE EXECUTE` commands.
 
 The following functions are also provided for easier management of functionality groups:
 
 ### Database local key management
 
-Use these functions to grant or revoke permissions to manage permissions for the current database. They enable or disable all functions related to the providers and keys on the current database:
+Use these functions to grant or revoke permissions to manage the key of the current database. They enable or disable all functions related to the key of the current database:
 
 * `pg_tde_grant_database_key_management_to_role(role)`
 * `pg_tde_revoke_database_key_management_from_role(role)`
@@ -28,14 +26,12 @@ These functions allow or revoke the use of the permissions management functions:
 * `pg_tde_grant_grant_management_to_role(role)`
 * `pg_tde_revoke_grant_management_from_role(role)`
 
-
 ### Inspections
 
 Use these functions to grant or revoke the use of query functions, which do not modify the encryption settings:
 
 * `pg_tde_grant_key_viewer_to_role(role)`
 * `pg_tde_revoke_key_viewer_from_role(role)`
-
 
 ## Key provider management
 

--- a/contrib/pg_tde/expected/access_control.out
+++ b/contrib/pg_tde/expected/access_control.out
@@ -1,23 +1,15 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
+SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+                                     1
+(1 row)
+
 CREATE USER regress_pg_tde_access_control;
 SET ROLE regress_pg_tde_access_control;
 -- should throw access denied
-SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
-ERROR:  permission denied for function pg_tde_add_database_key_provider_file
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'local-file-provider');
 ERROR:  permission denied for function pg_tde_set_key_using_database_key_provider
-SELECT pg_tde_add_global_key_provider_file('global-file-provider', '/tmp/pg_tde_test_keyring.per');
-ERROR:  must be superuser to modify global key providers
-SELECT pg_tde_set_key_using_global_key_provider('test-db-key', 'global-file-provider');
-ERROR:  must be superuser to access global key providers
-SELECT pg_tde_set_server_key_using_global_key_provider('wal-key','global-file-provider');
-ERROR:  must be superuser to access global key providers
-SELECT pg_tde_set_default_key_using_global_key_provider('def-key', 'global-file-provider');
-ERROR:  must be superuser to access global key providers
-SELECT pg_tde_delete_database_key_provider('local-file-provider');
-ERROR:  permission denied for function pg_tde_delete_database_key_provider
-SELECT pg_tde_delete_global_key_provider('global-file-provider');
-ERROR:  must be superuser to modify global key providers
 SELECT pg_tde_list_all_database_key_providers();
 ERROR:  permission denied for function pg_tde_list_all_database_key_providers
 SELECT pg_tde_list_all_global_key_providers();
@@ -49,12 +41,6 @@ SELECT pg_tde_grant_key_viewer_to_role('regress_pg_tde_access_control');
 
 SET ROLE regress_pg_tde_access_control;
 -- should now be allowed
-SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
- pg_tde_add_database_key_provider_file 
----------------------------------------
-                                     1
-(1 row)
-
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'local-file-provider');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
@@ -73,19 +59,35 @@ SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_key_info();
  test-db-key | local-file-provider |               1
 (1 row)
 
+SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_server_key_info();
+ERROR:  Principal key does not exists for the database
+HINT:  Use set_key interface to set the principal key
+SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_default_key_info();
+ERROR:  Principal key does not exists for the database
+HINT:  Use set_key interface to set the principal key
 SELECT pg_tde_verify_key();
  pg_tde_verify_key 
 -------------------
  
 (1 row)
 
+SELECT pg_tde_verify_server_key();
+ERROR:  principal key not configured for current database
+SELECT pg_tde_verify_default_key();
+ERROR:  principal key not configured for current database
 -- only superuser
+SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
+ERROR:  must be superuser to modify key providers
+SELECT pg_tde_change_global_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
+ERROR:  must be superuser to modify key providers
+SELECT pg_tde_delete_database_key_provider('local-file-provider');
+ERROR:  must be superuser to modify key providers
 SELECT pg_tde_add_global_key_provider_file('global-file-provider', '/tmp/pg_tde_test_keyring.per');
-ERROR:  must be superuser to modify global key providers
+ERROR:  must be superuser to modify key providers
 SELECT pg_tde_change_global_key_provider_file('global-file-provider', '/tmp/pg_tde_test_keyring.per');
-ERROR:  must be superuser to modify global key providers
+ERROR:  must be superuser to modify key providers
 SELECT pg_tde_delete_global_key_provider('global-file-provider');
-ERROR:  must be superuser to modify global key providers
+ERROR:  must be superuser to modify key providers
 SELECT pg_tde_set_key_using_global_key_provider('key1', 'global-file-provider');
 ERROR:  must be superuser to access global key providers
 SELECT pg_tde_set_default_key_using_global_key_provider('key1', 'global-file-provider');
@@ -101,16 +103,18 @@ SELECT pg_tde_revoke_key_viewer_from_role('regress_pg_tde_access_control');
 
 SET ROLE regress_pg_tde_access_control;
 -- verify the view access is revoked
-SELECT * FROM pg_tde_list_all_database_key_providers();
+SELECT pg_tde_list_all_database_key_providers();
 ERROR:  permission denied for function pg_tde_list_all_database_key_providers
-SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_key_info();
+SELECT pg_tde_list_all_global_key_providers();
+ERROR:  permission denied for function pg_tde_list_all_global_key_providers
+SELECT pg_tde_key_info();
 ERROR:  permission denied for function pg_tde_key_info
-SELECT pg_tde_verify_key();
-ERROR:  permission denied for function pg_tde_verify_key
 SELECT pg_tde_server_key_info();
 ERROR:  permission denied for function pg_tde_server_key_info
 SELECT pg_tde_default_key_info();
 ERROR:  permission denied for function pg_tde_default_key_info
+SELECT pg_tde_verify_key();
+ERROR:  permission denied for function pg_tde_verify_key
 SELECT pg_tde_verify_server_key();
 ERROR:  permission denied for function pg_tde_verify_server_key
 SELECT pg_tde_verify_default_key();

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -535,26 +535,6 @@ LANGUAGE plpgsql
 SET search_path = @extschema@
 AS $$
 BEGIN
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider(text, text, JSON) TO %I', target_role);
-
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_file(text, json) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_file(text, text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_vault_v2(text, text, text, text, text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_vault_v2(text, JSON, JSON, JSON, JSON) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_kmip(text, text, int, text, text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_add_database_key_provider_kmip(text, JSON, JSON, JSON, JSON) TO %I', target_role);
-
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider(text, text, JSON) TO %I', target_role);
-
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_file(text, json) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_file(text, text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_vault_v2(text, text, text,text,text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_vault_v2(text, JSON, JSON,JSON,JSON) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_kmip(text, text, int, text, text) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_change_database_key_provider_kmip(text, JSON, JSON, JSON, JSON) TO %I', target_role);
-
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_delete_database_key_provider(text) TO %I', target_role);
-
     EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_key_using_database_key_provider(text, text, BOOLEAN) TO %I', target_role);
 END;
 $$;
@@ -586,26 +566,6 @@ LANGUAGE plpgsql
 SET search_path = @extschema@
 AS $$
 BEGIN
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider(text, text, JSON) FROM %I', target_role);
-
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_file(text, json) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_file(text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_vault_v2(text, text, text, text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_vault_v2(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_kmip(text, text, int, text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_add_database_key_provider_kmip(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
-
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider(text, text, JSON) FROM %I', target_role);
-
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_file(text, json) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_file(text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_vault_v2(text, text, text, text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_vault_v2(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_kmip(text, text, int, text, text) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_change_database_key_provider_kmip(text, JSON, JSON, JSON, JSON) FROM %I', target_role);
-
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_delete_database_key_provider(text) FROM %I', target_role);
-
     EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_key_using_database_key_provider(text, text, BOOLEAN) FROM %I', target_role);
 END;
 $$;

--- a/contrib/pg_tde/sql/access_control.sql
+++ b/contrib/pg_tde/sql/access_control.sql
@@ -1,18 +1,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
+SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
+
 CREATE USER regress_pg_tde_access_control;
 
 SET ROLE regress_pg_tde_access_control;
 
 -- should throw access denied
-SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'local-file-provider');
-SELECT pg_tde_add_global_key_provider_file('global-file-provider', '/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_set_key_using_global_key_provider('test-db-key', 'global-file-provider');
-SELECT pg_tde_set_server_key_using_global_key_provider('wal-key','global-file-provider');
-SELECT pg_tde_set_default_key_using_global_key_provider('def-key', 'global-file-provider');
-SELECT pg_tde_delete_database_key_provider('local-file-provider');
-SELECT pg_tde_delete_global_key_provider('global-file-provider');
 SELECT pg_tde_list_all_database_key_providers();
 SELECT pg_tde_list_all_global_key_providers();
 SELECT pg_tde_key_info();
@@ -30,13 +25,19 @@ SELECT pg_tde_grant_key_viewer_to_role('regress_pg_tde_access_control');
 SET ROLE regress_pg_tde_access_control;
 
 -- should now be allowed
-SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'local-file-provider');
 SELECT * FROM pg_tde_list_all_database_key_providers();
 SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_key_info();
+SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_server_key_info();
+SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_default_key_info();
 SELECT pg_tde_verify_key();
+SELECT pg_tde_verify_server_key();
+SELECT pg_tde_verify_default_key();
 
 -- only superuser
+SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_change_global_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_delete_database_key_provider('local-file-provider');
 SELECT pg_tde_add_global_key_provider_file('global-file-provider', '/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_change_global_key_provider_file('global-file-provider', '/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_delete_global_key_provider('global-file-provider');
@@ -51,11 +52,12 @@ SELECT pg_tde_revoke_key_viewer_from_role('regress_pg_tde_access_control');
 SET ROLE regress_pg_tde_access_control;
 
 -- verify the view access is revoked
-SELECT * FROM pg_tde_list_all_database_key_providers();
-SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_key_info();
-SELECT pg_tde_verify_key();
+SELECT pg_tde_list_all_database_key_providers();
+SELECT pg_tde_list_all_global_key_providers();
+SELECT pg_tde_key_info();
 SELECT pg_tde_server_key_info();
 SELECT pg_tde_default_key_info();
+SELECT pg_tde_verify_key();
 SELECT pg_tde_verify_server_key();
 SELECT pg_tde_verify_default_key();
 

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -205,11 +205,6 @@ pg_tde_change_database_key_provider(PG_FUNCTION_ARGS)
 Datum
 pg_tde_change_global_key_provider(PG_FUNCTION_ARGS)
 {
-	if (!superuser())
-		ereport(ERROR,
-				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				errmsg("must be superuser to modify global key providers"));
-
 	return pg_tde_change_key_provider_internal(fcinfo, GLOBAL_DATA_TDE_OID);
 }
 
@@ -222,6 +217,11 @@ pg_tde_change_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 	int			olen;
 	KeyringProviderRecord provider;
 	GenericKeyring *keyring;
+
+	if (!superuser())
+		ereport(ERROR,
+				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("must be superuser to modify key providers"));
 
 	provider_type = required_text_argument(fcinfo->args[0], "provider type");
 	provider_name = required_text_argument(fcinfo->args[1], "provider name");
@@ -259,11 +259,6 @@ pg_tde_add_database_key_provider(PG_FUNCTION_ARGS)
 Datum
 pg_tde_add_global_key_provider(PG_FUNCTION_ARGS)
 {
-	if (!superuser())
-		ereport(ERROR,
-				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				errmsg("must be superuser to modify global key providers"));
-
 	return pg_tde_add_key_provider_internal(fcinfo, GLOBAL_DATA_TDE_OID);
 }
 
@@ -276,6 +271,11 @@ pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 	int			nlen,
 				olen;
 	KeyringProviderRecord provider;
+
+	if (!superuser())
+		ereport(ERROR,
+				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("must be superuser to modify key providers"));
 
 	provider_type = required_text_argument(fcinfo->args[0], "provider type");
 	provider_name = required_text_argument(fcinfo->args[1], "provider name");
@@ -318,13 +318,7 @@ pg_tde_delete_database_key_provider(PG_FUNCTION_ARGS)
 Datum
 pg_tde_delete_global_key_provider(PG_FUNCTION_ARGS)
 {
-	if (!superuser())
-		ereport(ERROR,
-				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				errmsg("must be superuser to modify global key providers"));
-
 	return pg_tde_delete_key_provider_internal(fcinfo, GLOBAL_DATA_TDE_OID);
-
 }
 
 Datum
@@ -334,6 +328,11 @@ pg_tde_delete_key_provider_internal(PG_FUNCTION_ARGS, Oid db_oid)
 	GenericKeyring *provider;
 	int			provider_id;
 	bool		provider_used;
+
+	if (!superuser())
+		ereport(ERROR,
+				errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				errmsg("must be superuser to modify key providers"));
 
 	provider_name = required_text_argument(fcinfo->args[0], "provider_name");
 


### PR DESCRIPTION
When creating a key provider you can point its configuration towards any path or network address that PostgreSQL can reach which can be used to attack the environment of PostgreSQL in way normally only restricted to superusers (compare trusted vs untrusted languages). So make the administration of key providers also follow this convention.

This limits the powers of our multitenancy but since we are not sure yet about how users want to use our mutlitenancy it is better to start off restrictive and build a complex solution later.