### PR TITLE
Remove an unrelated query from the `pg_tde_is_encrypted()` test

### DIFF
--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -1,7 +1,4 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT * FROM pg_tde_key_info();
-ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
+++ b/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
@@ -1,7 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-SELECT * FROM pg_tde_key_info();
-
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 


### PR DESCRIPTION
As far as I can tell this query is in no way related to the actual test suite.