### PR TITLE
Increase `pg_ctl` timeout when running with code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - TDE_REL_17_STABLE
 
+env:
+  PGCTLTIMEOUT: 120 # Avoid failures on slow recovery
+
 jobs:
   collect:
     name: Collect and upload


### PR DESCRIPTION
We get random timeouts from `pg_ctl` in the coverage build only so let's increase the timeout from 60 to 120 seconds. These timeouts might indicate that we have some issue with recovery being too slow in general but for now let's just increase the timeout to avoid random test failures.