### PR TITLE
Remove extension install hook system

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -88,7 +88,6 @@ static Size initialize_shared_state(void *start_address);
 static void initialize_objects_in_dsa_area(dsa_area *dsa, void *raw_dsa_area);
 static Size required_shared_mem_size(void);
 static void shared_memory_shutdown(int code, Datum arg);
-static void principal_key_startup_cleanup(XLogExtensionInstall *ext_info, bool redo);
 static void clear_principal_key_cache(Oid databaseId);
 static inline dshash_table *get_principal_key_Hash(void);
 static TDEPrincipalKey *get_principal_key_from_cache(Oid dbOid);
@@ -124,7 +123,6 @@ InitializePrincipalKeyInfo(void)
 {
 	ereport(LOG, errmsg("Initializing TDE principal key info"));
 	RegisterShmemRequest(&principal_key_info_shmem_routine);
-	on_ext_install(principal_key_startup_cleanup);
 }
 
 /*
@@ -470,14 +468,13 @@ push_principal_key_to_cache(TDEPrincipalKey *principalKey)
  * at the time of extension creation to start fresh again.
  * Idelly we should have a mechanism to remove these when the extension
  * but unfortunately we do not have any such mechanism in PG.
-*/
-static void
-principal_key_startup_cleanup(XLogExtensionInstall *ext_info, bool redo)
+ */
+void
+principal_key_startup_cleanup(Oid databaseId)
 {
-	clear_principal_key_cache(ext_info->database_id);
+	clear_principal_key_cache(databaseId);
 
-	/* Remove the tde files */
-	pg_tde_delete_tde_files(ext_info->database_id);
+	pg_tde_delete_tde_files(databaseId);
 }
 
 static void

--- a/contrib/pg_tde/src/include/catalog/tde_keyring.h
+++ b/contrib/pg_tde/src/include/catalog/tde_keyring.h
@@ -34,6 +34,7 @@ extern GenericKeyring *GetKeyProviderByName(const char *provider_name, Oid dbOid
 extern GenericKeyring *GetKeyProviderByID(int provider_id, Oid dbOid);
 extern ProviderType get_keyring_provider_from_typename(char *provider_type);
 extern void InitializeKeyProviderInfo(void);
+extern void key_provider_startup_cleanup(Oid databaseId);
 extern void save_new_key_provider_info(KeyringProviderRecord *provider,
 									   Oid databaseId, bool write_xlog);
 extern void modify_key_provider_info(KeyringProviderRecord *provider,

--- a/contrib/pg_tde/src/include/catalog/tde_principal_key.h
+++ b/contrib/pg_tde/src/include/catalog/tde_principal_key.h
@@ -46,6 +46,7 @@ typedef struct XLogPrincipalKeyRotate
 extern void InitializePrincipalKeyInfo(void);
 
 #ifndef FRONTEND
+extern void principal_key_startup_cleanup(Oid databaseId);
 extern LWLock *tde_lwlock_enc_keys(void);
 extern bool pg_tde_principal_key_configured(Oid databaseId);
 extern TDEPrincipalKey *GetPrincipalKey(Oid dbOid, LWLockMode lockMode);


### PR DESCRIPTION
Since we only have two hooks it is much easier for the reader to just hardcode the two callbacks.

Additionally I wonder why we do not do this on `DROP` with an event trigger but that is a bigger task to investigate. Yes, the end event trigger on the extension itself will not fire but what about have the even trigger do the cleanup when some other object owned by the extension is dropped. Maybe too hacky?