### PR TITLE
Do not keep function for clearing out old files around

### DIFF
--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -440,11 +440,6 @@ RETURNS VOID
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
-CREATE FUNCTION pg_tde_extension_initialize()
-RETURNS VOID
-LANGUAGE C
-AS 'MODULE_PATHNAME';
-
 CREATE FUNCTION pg_tde_verify_key()
 RETURNS VOID
 LANGUAGE C
@@ -526,7 +521,12 @@ EXECUTE FUNCTION pg_tde_ddl_command_end_capture();
 ALTER EVENT TRIGGER pg_tde_ddl_end ENABLE ALWAYS;
 
 -- Per database extension initialization
+CREATE FUNCTION pg_tde_extension_initialize()
+RETURNS VOID
+LANGUAGE C
+AS 'MODULE_PATHNAME';
 SELECT pg_tde_extension_initialize();
+DROP FUNCTION pg_tde_extension_initialize();
 
 CREATE FUNCTION pg_tde_grant_database_key_management_to_role(
     target_role TEXT)

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -142,7 +142,7 @@ pg_tde_extension_initialize(PG_FUNCTION_ARGS)
 	XLogRegisterData((char *) &xlrec, sizeof(XLogExtensionInstall));
 	XLogInsert(RM_TDERMGR_ID, XLOG_TDE_INSTALL_EXTENSION);
 
-	PG_RETURN_NULL();
+	PG_RETURN_VOID();
 }
 void
 extension_install_redo(XLogExtensionInstall *xlrec)


### PR DESCRIPTION
The `pg_tde_extension_initialize(`) function remained after `CREATE EXTENSION` and was executable by any user allowing any use to delete all keys and break the server. This function is so dangerous that we should not leave it around at all and instead drop it after having used it.