### PR TITLE
Improve function names and signatures for encryption

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
@@ -176,7 +176,7 @@ TDEXLogWriteEncryptedPages(int fd, const void *buf, size_t count, off_t offset,
 #endif
 
 	CalcXLogPageIVPrefix(tli, segno, key->base_iv, iv_prefix);
-	PG_TDE_ENCRYPT_DATA(iv_prefix, offset,
+	pg_tde_stream_crypt(iv_prefix, offset,
 						(char *) buf, count,
 						enc_buff, key, &EncryptionCryptCtx);
 
@@ -348,7 +348,7 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 				elog(DEBUG1, "decrypt WAL, dec_off: %lu [buff_off %lu], sz: %lu | key %X/%X",
 					 dec_off, dec_off - offset, dec_sz, LSN_FORMAT_ARGS(curr_key->key->start_lsn));
 #endif
-				PG_TDE_DECRYPT_DATA(iv_prefix, dec_off, dec_buf, dec_sz, dec_buf,
+				pg_tde_stream_crypt(iv_prefix, dec_off, dec_buf, dec_sz, dec_buf,
 									curr_key->key, &curr_key->crypt_ctx);
 
 				if (dec_off + dec_sz == offset)

--- a/contrib/pg_tde/src/encryption/enc_aes.c
+++ b/contrib/pg_tde/src/encryption/enc_aes.c
@@ -64,7 +64,7 @@ AesInit(void)
 }
 
 static void
-AesRunCtr(EVP_CIPHER_CTX **ctxPtr, int enc, const unsigned char *key, const unsigned char *iv, const unsigned char *in, int in_len, unsigned char *out)
+AesEcbEncrypt(EVP_CIPHER_CTX **ctxPtr, const unsigned char *key, const unsigned char *in, int in_len, unsigned char *out)
 {
 	int			out_len;
 
@@ -73,7 +73,7 @@ AesRunCtr(EVP_CIPHER_CTX **ctxPtr, int enc, const unsigned char *key, const unsi
 		*ctxPtr = EVP_CIPHER_CTX_new();
 		EVP_CIPHER_CTX_init(*ctxPtr);
 
-		if (EVP_CipherInit_ex(*ctxPtr, cipher_ctr_ecb, NULL, key, iv, enc) == 0)
+		if (EVP_CipherInit_ex(*ctxPtr, cipher_ctr_ecb, NULL, key, NULL, 1) == 0)
 			ereport(ERROR,
 					errmsg("EVP_CipherInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
@@ -251,12 +251,12 @@ AesGcmDecrypt(const unsigned char *key, const unsigned char *iv, const unsigned 
 	return true;
 }
 
-/* This function assumes that the out buffer is big enough: at least (blockNumber2 - blockNumber1) * 16 bytes
+/*
+ * This function assumes that the out buffer is big enough: at least (blockNumber2 - blockNumber1) * 16 bytes
  */
 void
-Aes128EncryptedZeroBlocks(void *ctxPtr, const unsigned char *key, const char *iv_prefix, uint64_t blockNumber1, uint64_t blockNumber2, unsigned char *out)
+AesCtrEncryptedZeroBlocks(void *ctxPtr, const unsigned char *key, const char *iv_prefix, uint64_t blockNumber1, uint64_t blockNumber2, unsigned char *out)
 {
-	const unsigned char iv[16] = {0,};
 	unsigned char *p;
 
 	Assert(blockNumber2 >= blockNumber1);
@@ -277,5 +277,5 @@ Aes128EncryptedZeroBlocks(void *ctxPtr, const unsigned char *key, const char *iv
 		p += sizeof(j);
 	}
 
-	AesRunCtr(ctxPtr, 1, key, iv, out, p - out, out);
+	AesEcbEncrypt(ctxPtr, key, out, p - out, out);
 }

--- a/contrib/pg_tde/src/include/encryption/enc_aes.h
+++ b/contrib/pg_tde/src/include/encryption/enc_aes.h
@@ -13,11 +13,10 @@
 #include <stdint.h>
 
 extern void AesInit(void);
-extern void Aes128EncryptedZeroBlocks(void *ctxPtr, const unsigned char *key, const char *iv_prefix, uint64_t blockNumber1, uint64_t blockNumber2, unsigned char *out);
-
 extern void AesEncrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *in, int in_len, unsigned char *out);
 extern void AesDecrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *in, int in_len, unsigned char *out);
 extern void AesGcmEncrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *aad, int aad_len, const unsigned char *in, int in_len, unsigned char *out, unsigned char *tag);
 extern bool AesGcmDecrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *aad, int aad_len, const unsigned char *in, int in_len, unsigned char *out, unsigned char *tag);
+extern void AesCtrEncryptedZeroBlocks(void *ctxPtr, const unsigned char *key, const char *iv_prefix, uint64_t blockNumber1, uint64_t blockNumber2, unsigned char *out);
 
 #endif							/* ENC_AES_H */

--- a/contrib/pg_tde/src/include/encryption/enc_tde.h
+++ b/contrib/pg_tde/src/include/encryption/enc_tde.h
@@ -12,14 +12,6 @@
 
 #include "access/pg_tde_tdemap.h"
 
-extern void pg_tde_crypt(const char *iv_prefix, uint32 start_offset, const char *data, uint32 data_len, char *out, InternalKey *key, void **ctxPtr, const char *context);
-
-/* Function Macros over crypt */
-
-#define PG_TDE_ENCRYPT_DATA(_iv_prefix, _start_offset, _data, _data_len, _out, _key, _ctxptr) \
-	pg_tde_crypt(_iv_prefix, _start_offset, _data, _data_len, _out, _key, _ctxptr, "ENCRYPT")
-
-#define PG_TDE_DECRYPT_DATA(_iv_prefix, _start_offset, _data, _data_len, _out, _key, _ctxptr) \
-	pg_tde_crypt(_iv_prefix, _start_offset, _data, _data_len, _out, _key, _ctxptr, "DECRYPT")
+extern void pg_tde_stream_crypt(const char *iv_prefix, uint32 start_offset, const char *data, uint32 data_len, char *out, InternalKey *key, void **ctxPtr);
 
 #endif							/* ENC_TDE_H */


### PR DESCRIPTION
The naming was quite inconsistent and, in the case of ECB vs CTR, misleading. So let's make it more consistent plus remove the legacy macros for the WAL encryption which were only used to slightly improve debug logging.