### PR TITLE
PG-1551 Handle errors and short reads while reading WAL

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
@@ -270,10 +270,10 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 		 count, offset, offset, LSN_FORMAT_ARGS(segno));
 #endif
 
-	/*
-	 * Read data from disk
-	 */
 	readsz = pg_pread(fd, buf, count, offset);
+
+	if (readsz <= 0)
+		return readsz;
 
 	if (!keys)
 	{
@@ -302,7 +302,7 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 #endif
 
 	XLogSegNoOffsetToRecPtr(segno, offset, segSize, data_start);
-	XLogSegNoOffsetToRecPtr(segno, offset + count, segSize, data_end);
+	XLogSegNoOffsetToRecPtr(segno, offset + readsz, segSize, data_end);
 
 	/*
 	 * TODO: this is higly ineffective. We should get rid of linked list and
@@ -339,7 +339,7 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 				/* We have reached the end of the segment */
 				if (dec_end == 0)
 				{
-					dec_end = offset + count;
+					dec_end = offset + readsz;
 				}
 
 				dec_sz = dec_end - dec_off;


### PR DESCRIPTION
Do not try to decrypt data not actually read by returning directly if we reached the end of file or got an error. If we get a short read we also return directly which is safe since `pg_tde_crypt()` supports any offset, not just multiples of the AES block size. This likely makes it a bit trickier to move to OpenSSL's built-in CTR which we probably want to do in the future but let's cross that bridge when we get to it.