### PR TITLE
PG-1546 Remove grant managment functions

### DIFF
--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -19,13 +19,6 @@ Use these functions to grant or revoke permissions to manage the key of the curr
 
 Managment of the global scope is restricted to superusers only.
 
-### Permission management
-
-These functions allow or revoke the use of the permissions management functions:
-
-* `pg_tde_grant_grant_management_to_role(role)`
-* `pg_tde_revoke_grant_management_from_role(role)`
-
 ### Inspections
 
 Use these functions to grant or revoke the use of query functions, which do not modify the encryption settings:

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -590,41 +590,6 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION pg_tde_grant_grant_management_to_role(
-    target_role TEXT)
-RETURNS VOID
-LANGUAGE plpgsql
-SET search_path = @extschema@
-AS $$
-BEGIN
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_grant_database_key_management_to_role(TEXT) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_grant_grant_management_to_role(TEXT) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_grant_key_viewer_to_role(TEXT) TO %I', target_role);
-
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_revoke_database_key_management_from_role(TEXT) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_revoke_grant_management_from_role(TEXT) TO %I', target_role);
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_revoke_key_viewer_from_role(TEXT) TO %I', target_role);
-END;
-$$;
-
-CREATE FUNCTION pg_tde_revoke_grant_management_from_role(
-    target_role TEXT)
-RETURNS VOID
-LANGUAGE plpgsql
-SET search_path = @extschema@
-AS $$
-BEGIN
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_grant_database_key_management_to_role(TEXT) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_grant_grant_management_to_role(TEXT) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_grant_key_viewer_to_role(TEXT) FROM %I', target_role);
-
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_revoke_database_key_management_from_role(TEXT) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_revoke_grant_management_from_role(TEXT) FROM %I', target_role);
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_revoke_key_viewer_from_role(TEXT) FROM %I', target_role);
-END;
-$$;
-
 -- Revoking all the privileges from the public role
 SELECT pg_tde_revoke_database_key_management_from_role('public');
-SELECT pg_tde_revoke_grant_management_from_role('public');
 SELECT pg_tde_revoke_key_viewer_from_role('public');


### PR DESCRIPTION
These functions did never really do anything since they added no extra permissions since you would need to be allowed to grant and revoke access anyway to call them since they did not use `SECURITY DEFINER`.