### PR TITLE
PG-1507 PG-1508 Disallow `ALTER TABLE` when there is a mix of encrypted and unencrypted

### DIFF
--- a/contrib/pg_tde/expected/partition_table.out
+++ b/contrib/pg_tde/expected/partition_table.out
@@ -52,6 +52,7 @@ SELECT pg_tde_is_encrypted('partition_q4_2024');
 (1 row)
 
 ALTER TABLE partitioned_table SET ACCESS METHOD heap;
+ERROR:  Recursive ALTER TABLE on a mix of encrypted and unencrypted relations is not supported
 ALTER TABLE partition_q1_2024 SET ACCESS METHOD heap;
 ALTER TABLE partition_q2_2024 SET ACCESS METHOD tde_heap;
 ALTER TABLE partition_q3_2024 SET ACCESS METHOD heap;
@@ -86,6 +87,12 @@ SELECT pg_tde_is_encrypted('partition_q4_2024');
  t
 (1 row)
 
+-- Does not care about parent AM as long as all children with storage use the same
+ALTER TABLE partition_q1_2024 SET ACCESS METHOD tde_heap;
+ALTER TABLE partition_q2_2024 SET ACCESS METHOD tde_heap;
+ALTER TABLE partition_q3_2024 SET ACCESS METHOD tde_heap;
+ALTER TABLE partition_q4_2024 SET ACCESS METHOD tde_heap;
+ALTER TABLE partitioned_table SET ACCESS METHOD heap;
 DROP TABLE partitioned_table;
 -- Partition inherits encryption status from parent table if default is heap and parent is tde_heap
 SET default_table_access_method = "heap";

--- a/contrib/pg_tde/expected/recreate_storage.out
+++ b/contrib/pg_tde/expected/recreate_storage.out
@@ -229,6 +229,49 @@ SELECT pg_tde_is_encrypted('plain_table_id2_seq2');
  f
 (1 row)
 
+-- Enforce that we do not mess up encryption status for toast table
+CREATE TABLE cities (
+  name       varchar(8),
+  population real,
+  elevation  int
+) USING tde_heap;
+CREATE TABLE state_capitals (
+  state      char(2) UNIQUE NOT NULL
+) INHERITS (cities) USING heap;
+CREATE TABLE capitals (
+  country      char(2) UNIQUE NOT NULL
+) INHERITS (cities) USING tde_heap;
+ALTER TABLE cities ALTER COLUMN name TYPE TEXT;
+ERROR:  Recursive ALTER TABLE on a mix of encrypted and unencrypted relations is not supported
+-- Enforce the same for typed tables
+CREATE TYPE people_type AS (age int, name varchar(8), dob date);
+CREATE TABLE sales_staff OF people_type USING tde_heap;
+CREATE TABLE other_staff OF people_type USING heap;
+ALTER TYPE people_type ALTER ATTRIBUTE name TYPE text CASCADE;
+ERROR:  Recursive ALTER TABLE on a mix of encrypted and unencrypted relations is not supported
+-- If all tpyed tables are encrypted everything should work as usual
+ALTER TABLE other_staff SET ACCESS METHOD tde_heap;
+ALTER TYPE people_type ALTER ATTRIBUTE name TYPE text CASCADE;
+SELECT pg_tde_is_encrypted('pg_toast.pg_toast_' || 'sales_staff'::regclass::oid);
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+SELECT pg_tde_is_encrypted('pg_toast.pg_toast_' || 'other_staff'::regclass::oid);
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+DROP TYPE people_type CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table sales_staff
+drop cascades to table other_staff
+DROP TABLE cities CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table state_capitals
+drop cascades to table capitals
 DROP TABLE plain_table;
 DROP EXTENSION pg_tde CASCADE;
 NOTICE:  drop cascades to 7 other objects

--- a/contrib/pg_tde/sql/partition_table.sql
+++ b/contrib/pg_tde/sql/partition_table.sql
@@ -31,6 +31,13 @@ SELECT pg_tde_is_encrypted('partition_q2_2024');
 SELECT pg_tde_is_encrypted('partition_q3_2024');
 SELECT pg_tde_is_encrypted('partition_q4_2024');
 
+-- Does not care about parent AM as long as all children with storage use the same
+ALTER TABLE partition_q1_2024 SET ACCESS METHOD tde_heap;
+ALTER TABLE partition_q2_2024 SET ACCESS METHOD tde_heap;
+ALTER TABLE partition_q3_2024 SET ACCESS METHOD tde_heap;
+ALTER TABLE partition_q4_2024 SET ACCESS METHOD tde_heap;
+ALTER TABLE partitioned_table SET ACCESS METHOD heap;
+
 DROP TABLE partitioned_table;
 
 -- Partition inherits encryption status from parent table if default is heap and parent is tde_heap

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -260,13 +260,14 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 	else if (IsA(parsetree, AlterTableStmt))
 	{
 		AlterTableStmt *stmt = castNode(AlterTableStmt, parsetree);
-		ListCell   *lcmd;
-		AlterTableCmd *setAccessMethod = NULL;
-		TdeDdlEvent event = {.parsetree = parsetree};
 		Oid			relid = RangeVarGetRelid(stmt->relation, AccessShareLock, true);
 
 		if (relid != InvalidOid)
 		{
+			AlterTableCmd *setAccessMethod = NULL;
+			ListCell   *lcmd;
+			TdeDdlEvent event = {.parsetree = parsetree};
+
 			foreach(lcmd, stmt->cmds)
 			{
 				AlterTableCmd *cmd = lfirst_node(AlterTableCmd, lcmd);


### PR DESCRIPTION
Since `ALTER TABLE` can modify multiple due to inheritance or typed tables which can for example result in TOAST tables being created for some or all of the modified tables while the event trigger is only fired once we cannot rely on the event stack to make sure we get the correct encryption status.
    
Our solution is to be cautious and only modify tables when all tables with storage are either encrypt or not encrypted. If there is a mix we will throw an error. The result of this is also used to properly inform the SMGR of the current encryption status. We apply the same logic to `ALTER TYPE` for typed tables.

A possibility for future improvement would be to limit this check only to commands which recurse down to child tables and/or can create new relfilenodes.
