### PR TITLE
Clean up `tde_keyring.c` a bit

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -831,7 +831,7 @@ load_keyring_provider_options(ProviderType provider_type, char *keyring_options)
 static FileKeyring *
 load_file_keyring_provider_options(char *keyring_options)
 {
-	FileKeyring *file_keyring = palloc0(sizeof(FileKeyring));
+	FileKeyring *file_keyring = palloc0_object(FileKeyring);
 
 	file_keyring->keyring.type = FILE_KEY_PROVIDER;
 
@@ -855,7 +855,7 @@ load_file_keyring_provider_options(char *keyring_options)
 static VaultV2Keyring *
 load_vaultV2_keyring_provider_options(char *keyring_options)
 {
-	VaultV2Keyring *vaultV2_keyring = palloc0(sizeof(VaultV2Keyring));
+	VaultV2Keyring *vaultV2_keyring = palloc0_object(VaultV2Keyring);
 
 	vaultV2_keyring->keyring.type = VAULT_V2_KEY_PROVIDER;
 
@@ -884,7 +884,7 @@ load_vaultV2_keyring_provider_options(char *keyring_options)
 static KmipKeyring *
 load_kmip_keyring_provider_options(char *keyring_options)
 {
-	KmipKeyring *kmip_keyring = palloc0(sizeof(KmipKeyring));
+	KmipKeyring *kmip_keyring = palloc0_object(KmipKeyring);
 
 	kmip_keyring->keyring.type = KMIP_KEY_PROVIDER;
 

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -915,30 +915,27 @@ load_kmip_keyring_provider_options(char *keyring_options)
 static void
 debug_print_kerying(GenericKeyring *keyring)
 {
-	int			debug_level = DEBUG2;
-
-	elog(debug_level, "Keyring type: %d", keyring->type);
-	elog(debug_level, "Keyring name: %s", keyring->provider_name);
-	elog(debug_level, "Keyring id: %d", keyring->keyring_id);
+	elog(DEBUG2, "Keyring type: %d", keyring->type);
+	elog(DEBUG2, "Keyring name: %s", keyring->provider_name);
+	elog(DEBUG2, "Keyring id: %d", keyring->keyring_id);
 	switch (keyring->type)
 	{
 		case FILE_KEY_PROVIDER:
-			elog(debug_level, "File Keyring Path: %s", ((FileKeyring *) keyring)->file_name);
+			elog(DEBUG2, "File Keyring Path: %s", ((FileKeyring *) keyring)->file_name);
 			break;
 		case VAULT_V2_KEY_PROVIDER:
-			elog(debug_level, "Vault Keyring Token: %s", ((VaultV2Keyring *) keyring)->vault_token);
-			elog(debug_level, "Vault Keyring URL: %s", ((VaultV2Keyring *) keyring)->vault_url);
-			elog(debug_level, "Vault Keyring Mount Path: %s", ((VaultV2Keyring *) keyring)->vault_mount_path);
-			elog(debug_level, "Vault Keyring CA Path: %s", ((VaultV2Keyring *) keyring)->vault_ca_path);
+			elog(DEBUG2, "Vault Keyring Token: %s", ((VaultV2Keyring *) keyring)->vault_token);
+			elog(DEBUG2, "Vault Keyring URL: %s", ((VaultV2Keyring *) keyring)->vault_url);
+			elog(DEBUG2, "Vault Keyring Mount Path: %s", ((VaultV2Keyring *) keyring)->vault_mount_path);
+			elog(DEBUG2, "Vault Keyring CA Path: %s", ((VaultV2Keyring *) keyring)->vault_ca_path);
 			break;
 		case KMIP_KEY_PROVIDER:
-			elog(debug_level, "KMIP Keyring Host: %s", ((KmipKeyring *) keyring)->kmip_host);
-			elog(debug_level, "KMIP Keyring Port: %s", ((KmipKeyring *) keyring)->kmip_port);
-			elog(debug_level, "KMIP Keyring CA Path: %s", ((KmipKeyring *) keyring)->kmip_ca_path);
-			elog(debug_level, "KMIP Keyring Cert Path: %s", ((KmipKeyring *) keyring)->kmip_cert_path);
+			elog(DEBUG2, "KMIP Keyring Host: %s", ((KmipKeyring *) keyring)->kmip_host);
+			elog(DEBUG2, "KMIP Keyring Port: %s", ((KmipKeyring *) keyring)->kmip_port);
+			elog(DEBUG2, "KMIP Keyring CA Path: %s", ((KmipKeyring *) keyring)->kmip_ca_path);
+			elog(DEBUG2, "KMIP Keyring Cert Path: %s", ((KmipKeyring *) keyring)->kmip_cert_path);
 			break;
 		case UNKNOWN_KEY_PROVIDER:
-			elog(debug_level, "Unknown Keyring ");
 			break;
 	}
 }

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -427,6 +427,7 @@ GetKeyProviderByID(int provider_id, Oid dbOid)
 		keyring = (GenericKeyring *) linitial(providers);
 		list_free(providers);
 	}
+
 	return keyring;
 }
 
@@ -435,9 +436,9 @@ GetKeyProviderByID(int provider_id, Oid dbOid)
 static void
 write_key_provider_info(KeyringProviderRecordInFile *record, bool write_xlog)
 {
-	off_t		bytes_written = 0;
+	off_t		bytes_written;
 	int			fd;
-	char		kp_info_path[MAXPGPATH] = {0};
+	char		kp_info_path[MAXPGPATH];
 
 	Assert(record != NULL);
 	Assert(record->offset_in_file >= 0);
@@ -689,15 +690,15 @@ GetKeyProviderByID(int provider_id, Oid dbOid)
 		keyring = (GenericKeyring *) providers->head->ptr;
 		simple_list_free(providers);
 	}
+
 	return keyring;
 }
 
 static void
 simple_list_free(SimplePtrList *list)
 {
-	SimplePtrListCell *cell;
+	SimplePtrListCell *cell = list->head;
 
-	cell = list->head;
 	while (cell != NULL)
 	{
 		SimplePtrListCell *next;
@@ -721,7 +722,7 @@ scan_key_provider_file(ProviderScanType scanType, void *scanKey, Oid dbOid)
 {
 	off_t		curr_pos = 0;
 	int			fd;
-	char		kp_info_path[MAXPGPATH] = {0};
+	char		kp_info_path[MAXPGPATH];
 	KeyringProviderRecord provider;
 #ifndef FRONTEND
 	List	   *providers_list = NIL;
@@ -795,9 +796,10 @@ scan_key_provider_file(ProviderScanType scanType, void *scanKey, Oid dbOid)
 static GenericKeyring *
 load_keyring_provider_from_record(KeyringProviderRecord *provider)
 {
-	GenericKeyring *keyring = NULL;
+	GenericKeyring *keyring;
 
 	keyring = load_keyring_provider_options(provider->provider_type, provider->options);
+
 	if (keyring)
 	{
 		keyring->keyring_id = provider->provider_id;
@@ -806,6 +808,7 @@ load_keyring_provider_from_record(KeyringProviderRecord *provider)
 		memcpy(keyring->options, provider->options, sizeof(keyring->options));
 		debug_print_kerying(keyring);
 	}
+
 	return keyring;
 }
 
@@ -951,7 +954,7 @@ static int
 open_keyring_infofile(Oid database_id, int flags)
 {
 	int			fd;
-	char		kp_info_path[MAXPGPATH] = {0};
+	char		kp_info_path[MAXPGPATH];
 
 	get_keyring_infofile_path(kp_info_path, database_id);
 	fd = BasicOpenFile(kp_info_path, flags | PG_BINARY);
@@ -970,7 +973,7 @@ open_keyring_infofile(Oid database_id, int flags)
 static bool
 fetch_next_key_provider(int fd, off_t *curr_pos, KeyringProviderRecord *provider)
 {
-	off_t		bytes_read = 0;
+	off_t		bytes_read;
 
 	Assert(provider != NULL);
 	Assert(fd >= 0);

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -86,7 +86,7 @@ static Size initialize_shared_state(void *start_address);
 static Datum pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
 static Datum pg_tde_change_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
 static Datum pg_tde_delete_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid);
-static Datum pg_tde_list_all_key_providers_internal(const char *fname, bool global, PG_FUNCTION_ARGS);
+static Datum pg_tde_list_all_key_providers_internal(PG_FUNCTION_ARGS, const char *fname, Oid dbOid);
 static Size required_shared_mem_size(void);
 static List *scan_key_provider_file(ProviderScanType scanType, void *scanKey, Oid dbOid);
 
@@ -350,20 +350,19 @@ pg_tde_delete_key_provider_internal(PG_FUNCTION_ARGS, Oid db_oid)
 Datum
 pg_tde_list_all_database_key_providers(PG_FUNCTION_ARGS)
 {
-	return pg_tde_list_all_key_providers_internal("pg_tde_list_all_database_key_providers_database", false, fcinfo);
+	return pg_tde_list_all_key_providers_internal(fcinfo, "pg_tde_list_all_database_key_providers_database", MyDatabaseId);
 }
 
 Datum
 pg_tde_list_all_global_key_providers(PG_FUNCTION_ARGS)
 {
-	return pg_tde_list_all_key_providers_internal("pg_tde_list_all_database_key_providers_global", true, fcinfo);
+	return pg_tde_list_all_key_providers_internal(fcinfo, "pg_tde_list_all_database_key_providers_global", GLOBAL_DATA_TDE_OID);
 }
 
 static Datum
-pg_tde_list_all_key_providers_internal(const char *fname, bool global, PG_FUNCTION_ARGS)
+pg_tde_list_all_key_providers_internal(PG_FUNCTION_ARGS, const char *fname, Oid dbOid)
 {
-	Oid			database = (global ? GLOBAL_DATA_TDE_OID : MyDatabaseId);
-	List	   *all_providers = GetAllKeyringProviders(database);
+	List	   *all_providers = GetAllKeyringProviders(dbOid);
 	ListCell   *lc;
 	Tuplestorestate *tupstore;
 	TupleDesc	tupdesc;

--- a/contrib/pg_tde/src/keyring/keyring_api.c
+++ b/contrib/pg_tde/src/keyring/keyring_api.c
@@ -129,7 +129,7 @@ KeyringGenerateNewKey(const char *key_name, unsigned key_len)
 
 	Assert(key_len <= 32);
 	/* Struct will be saved to disk so keep clean */
-	key = palloc0(sizeof(KeyInfo));
+	key = palloc0_object(KeyInfo);
 	key->data.len = key_len;
 	if (!RAND_bytes(key->data.data, key_len))
 	{


### PR DESCRIPTION
- Use `palloc0_object()`
- Do not initialize variables unless we have to
- Clean up debug printing
- Make `pg_tde_list_all_key_providers_internal()` more consistent with the rest of the code
