### PR TITLE
Clean up AES initialization code

### DIFF
--- a/contrib/pg_tde/src/encryption/enc_aes.c
+++ b/contrib/pg_tde/src/encryption/enc_aes.c
@@ -41,9 +41,9 @@
  * 16 byte blocks.
  */
 
-static const EVP_CIPHER *cipher_cbc;
-static const EVP_CIPHER *cipher_gcm;
-static const EVP_CIPHER *cipher_ctr_ecb;
+static const EVP_CIPHER *cipher_cbc = NULL;
+static const EVP_CIPHER *cipher_gcm = NULL;
+static const EVP_CIPHER *cipher_ctr_ecb = NULL;
 
 void
 AesInit(void)
@@ -69,6 +69,8 @@ AesRunCtr(EVP_CIPHER_CTX **ctxPtr, int enc, const unsigned char *key, const unsi
 
 	if (*ctxPtr == NULL)
 	{
+		Assert(cipher_ctr_ecb != NULL);
+
 		*ctxPtr = EVP_CIPHER_CTX_new();
 		EVP_CIPHER_CTX_init(*ctxPtr);
 
@@ -93,6 +95,7 @@ AesRunCbc(int enc, const unsigned char *key, const unsigned char *iv, const unsi
 	int			out_len_final;
 	EVP_CIPHER_CTX *ctx = NULL;
 
+	Assert(cipher_cbc != NULL);
 	Assert(in_len % EVP_CIPHER_block_size(cipher_cbc) == 0);
 
 	ctx = EVP_CIPHER_CTX_new();
@@ -142,6 +145,7 @@ AesGcmEncrypt(const unsigned char *key, const unsigned char *iv, const unsigned 
 	int			out_len_final;
 	EVP_CIPHER_CTX *ctx;
 
+	Assert(cipher_gcm != NULL);
 	Assert(in_len % EVP_CIPHER_block_size(cipher_gcm) == 0);
 
 	ctx = EVP_CIPHER_CTX_new();

--- a/contrib/pg_tde/src/encryption/enc_aes.c
+++ b/contrib/pg_tde/src/encryption/enc_aes.c
@@ -48,7 +48,7 @@ static const EVP_CIPHER *cipher_ctr_ecb;
 void
 AesInit(void)
 {
-	static int	initialized = 0;
+	static bool initialized = false;
 
 	if (!initialized)
 	{
@@ -59,7 +59,7 @@ AesInit(void)
 		cipher_gcm = EVP_aes_128_gcm();
 		cipher_ctr_ecb = EVP_aes_128_ecb();
 
-		initialized = 1;
+		initialized = true;
 	}
 }
 

--- a/contrib/pg_tde/src/encryption/enc_aes.c
+++ b/contrib/pg_tde/src/encryption/enc_aes.c
@@ -50,17 +50,16 @@ AesInit(void)
 {
 	static bool initialized = false;
 
-	if (!initialized)
-	{
-		OpenSSL_add_all_algorithms();
-		ERR_load_crypto_strings();
+	Assert(!initialized);
 
-		cipher_cbc = EVP_aes_128_cbc();
-		cipher_gcm = EVP_aes_128_gcm();
-		cipher_ctr_ecb = EVP_aes_128_ecb();
+	OpenSSL_add_all_algorithms();
+	ERR_load_crypto_strings();
 
-		initialized = true;
-	}
+	cipher_cbc = EVP_aes_128_cbc();
+	cipher_gcm = EVP_aes_128_gcm();
+	cipher_ctr_ecb = EVP_aes_128_ecb();
+
+	initialized = true;
 }
 
 static void

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -73,8 +73,6 @@ tde_shmem_startup(void)
 		prev_shmem_startup_hook();
 
 	TdeShmemInit();
-	AesInit();
-
 	TDEXLogShmemInit();
 	TDEXLogSmgrInit();
 }
@@ -96,23 +94,21 @@ _PG_init(void)
 
 	check_percona_api_version();
 
+	AesInit();
 	TdeGucInit();
 	TdeEventCaptureInit();
-
 	InitializePrincipalKeyInfo();
 	InitializeKeyProviderInfo();
+	InstallFileKeyring();
+	InstallVaultV2Keyring();
+	InstallKmipKeyring();
+	RegisterTdeRmgr();
+	RegisterStorageMgr();
 
 	prev_shmem_request_hook = shmem_request_hook;
 	shmem_request_hook = tde_shmem_request;
 	prev_shmem_startup_hook = shmem_startup_hook;
 	shmem_startup_hook = tde_shmem_startup;
-
-	InstallFileKeyring();
-	InstallVaultV2Keyring();
-	InstallKmipKeyring();
-	RegisterTdeRmgr();
-
-	RegisterStorageMgr();
 }
 
 static void

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -83,8 +83,6 @@ tde_mdwritev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 		unsigned char *local_blocks_aligned = (unsigned char *) TYPEALIGN(PG_IO_ALIGN_SIZE, local_blocks);
 		void	  **local_buffers = palloc_array(void *, nblocks);
 
-		AesInit();
-
 		for (int i = 0; i < nblocks; ++i)
 		{
 			BlockNumber bn = blocknum + i;
@@ -144,8 +142,6 @@ tde_mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 		unsigned char *local_blocks_aligned = (unsigned char *) TYPEALIGN(PG_IO_ALIGN_SIZE, local_blocks);
 		unsigned char iv[16];
 
-		AesInit();
-
 		CalcBlockIv(forknum, blocknum, int_key->base_iv, iv);
 
 		AesEncrypt(int_key->key, iv, ((unsigned char *) buffer), BLCKSZ, local_blocks_aligned);
@@ -167,8 +163,6 @@ tde_mdreadv(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 
 	if (!tdereln->encrypted_relation)
 		return;
-
-	AesInit();
 
 	for (int i = 0; i < nblocks; ++i)
 	{


### PR DESCRIPTION
This tries to call `AesInit()` only when necessary. An alternative would be to always call it before we use AES but having the SMGR call initialize when the WAL SMGR and the tdemap code do not is confusing for the user.

~Another question is if we even need the `initialized` check as it is now or if we maybe should convert it into an assertion.~