### PR TITLE
Slightly improve TAP test readbaility

### DIFF
--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -47,10 +47,8 @@ $node->restart;
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 
 # Verify that we can't see the data in the file
-my $tablefile = $node->safe_psql('postgres', 'SHOW data_directory;');
-$tablefile .= '/';
-$tablefile .=
-  $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\'test_enc\');');
+my $tablefile = $node->data_dir . '/'
+  . $node->safe_psql('postgres', "SELECT pg_relation_filepath('test_enc');");
 
 my $strings = 'TABLEFILE FOUND: ';
 $strings .= `(ls  $tablefile >/dev/null && echo yes) || echo no`;

--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -17,34 +17,33 @@ $node->start;
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres',
-	'SELECT extname, extversion FROM pg_extension WHERE extname = \'pg_tde\';'
+	"SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_tde';");
+
+PGTDE::psql($node, 'postgres',
+	'CREATE TABLE test_enc (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;'
 );
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;'
+	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');"
 );
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');"
+	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');"
 );
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');"
+	'CREATE TABLE test_enc (id SERIAL, k VARCHAR(32), PRIMARY KEY (id)) USING tde_heap;'
 );
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;'
-);
+	"INSERT INTO test_enc (k) VALUES ('foobar'), ('barfoo');");
 
-PGTDE::psql($node, 'postgres',
-	'INSERT INTO test_enc (k) VALUES (\'foobar\'),(\'barfoo\');');
-
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
 $node->restart;
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 # Verify that we can't see the data in the file
 my $tablefile = $node->data_dir . '/'

--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -50,11 +50,10 @@ PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 my $tablefile = $node->data_dir . '/'
   . $node->safe_psql('postgres', "SELECT pg_relation_filepath('test_enc');");
 
-my $strings = 'TABLEFILE FOUND: ';
-$strings .= `(ls  $tablefile >/dev/null && echo yes) || echo no`;
-PGTDE::append_to_result_file($strings);
+PGTDE::append_to_result_file(
+	'TABLEFILE FOUND: ' . (-f $tablefile ? 'yes' : 'no'));
 
-$strings = 'CONTAINS FOO (should be empty): ';
+my $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile | grep foo`;
 PGTDE::append_to_result_file($strings);
 

--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -24,9 +24,6 @@ PGTDE::psql($node, 'postgres',
 	'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;'
 );
 
-PGTDE::append_to_result_file("-- server restart");
-$node->restart;
-
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');"
 );

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -17,37 +17,37 @@ $node->start;
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');"
+	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');"
+	"SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2g.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2g.per');"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-3','/tmp/pg_tde_test_keyring_3.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-3', '/tmp/pg_tde_test_keyring_3.per');"
 );
 
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_list_all_database_key_providers();");
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');"
+	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');"
 );
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;'
+	'CREATE TABLE test_enc (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;'
 );
 
-PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc (k) VALUES (5),(6);');
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc (k) VALUES (5), (6);');
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 # Rotate key
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');");
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
 $node->restart;
@@ -58,13 +58,13 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres',
 	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();"
 );
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 # Again rotate key
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');"
+	"SELECT pg_tde_set_key_using_database_key_provider('rotated-key2', 'file-2');"
 );
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
 $node->restart;
@@ -75,13 +75,13 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres',
 	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();"
 );
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 # Again rotate key
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_set_key_using_global_key_provider('rotated-key', 'file-3', false);"
 );
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
 $node->restart;
@@ -92,7 +92,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres',
 	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();"
 );
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 # TODO: add method to query current info
 # And maybe debug tools to show what's in a file keyring?
@@ -101,7 +101,7 @@ PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX', 'file-2', false);"
 );
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
 $node->restart;
@@ -112,10 +112,10 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres',
 	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();"
 );
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::psql($node, 'postgres',
-	'ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;');
+	'ALTER SYSTEM SET pg_tde.inherit_global_providers = off;');
 
 # Things still work after a restart
 PGTDE::append_to_result_file("-- server restart");
@@ -133,7 +133,7 @@ PGTDE::psql($node, 'postgres',
 );
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');"
+	"SELECT pg_tde_set_key_using_database_key_provider('rotated-key2', 'file-2');"
 );
 PGTDE::psql($node, 'postgres',
 	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -17,13 +17,6 @@ $node->start;
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;'
-);
-
-PGTDE::append_to_result_file("-- server restart");
-$node->restart;
-
-PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');"
 );
 PGTDE::psql($node, 'postgres',

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -60,24 +60,24 @@ $node->start;
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello' ));"
+	"SELECT pg_tde_add_database_key_provider_file('file-provider', json_object('type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello'));"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');"
+	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-provider');"
 );
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;'
+	'CREATE TABLE test_enc2 (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;'
 );
 
-PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (5),(6);');
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (5), (6);');
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
 $node->restart;
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id;');
 
 PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');
 

--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -85,7 +85,7 @@ PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
 $node->stop;
 
-system("kill $pid");
+kill('TERM', $pid);
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/contrib/pg_tde/t/004_file_config.pl
+++ b/contrib/pg_tde/t/004_file_config.pl
@@ -21,24 +21,24 @@ $node->start;
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));"
+	"SELECT pg_tde_add_database_key_provider_file('file-provider', json_object('type' VALUE 'file', 'path' VALUE '/tmp/datafile-location'));"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');"
+	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-provider');"
 );
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;'
+	'CREATE TABLE test_enc1 (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;'
 );
 
-PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc1 (k) VALUES (5),(6);');
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc1 (k) VALUES (5), (6);');
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc1 ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
 $node->restart;
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc1 ORDER BY id;');
 
 PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc1;');
 

--- a/contrib/pg_tde/t/005_multiple_extensions.pl
+++ b/contrib/pg_tde/t/005_multiple_extensions.pl
@@ -119,28 +119,28 @@ PGTDE::append_to_debug_file($stdout);
 
 $node->psql(
 	'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));",
+	"SELECT pg_tde_add_database_key_provider_file('file-provider', json_object('type' VALUE 'file', 'path' VALUE '/tmp/datafile-location'));",
 	extra_params => ['-a']);
 $node->psql(
 	'postgres',
-	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');",
+	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-provider');",
 	extra_params => ['-a']);
 
 $stdout = $node->safe_psql(
 	'postgres',
-	'CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;',
-	extra_params => ['-a']);
-PGTDE::append_to_result_file($stdout);
-
-$stdout = $node->safe_psql(
-	'postgres',
-	'INSERT INTO test_enc1 (k) VALUES (5),(6);',
+	'CREATE TABLE test_enc1 (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;',
 	extra_params => ['-a']);
 PGTDE::append_to_result_file($stdout);
 
 $stdout = $node->safe_psql(
 	'postgres',
-	'SELECT * FROM test_enc1 ORDER BY id ASC;',
+	'INSERT INTO test_enc1 (k) VALUES (5), (6);',
+	extra_params => ['-a']);
+PGTDE::append_to_result_file($stdout);
+
+$stdout = $node->safe_psql(
+	'postgres',
+	'SELECT * FROM test_enc1 ORDER BY id;',
 	extra_params => ['-a']);
 PGTDE::append_to_result_file($stdout);
 
@@ -149,7 +149,7 @@ $node->restart;
 
 $stdout = $node->safe_psql(
 	'postgres',
-	'SELECT * FROM test_enc1 ORDER BY id ASC;',
+	'SELECT * FROM test_enc1 ORDER BY id;',
 	extra_params => ['-a']);
 PGTDE::append_to_result_file($stdout);
 
@@ -162,7 +162,7 @@ PGTDE::append_to_result_file($stdout);
 # Print PGSM settings
 ($cmdret, $stdout, $stderr) = $node->psql(
 	'postgres',
-	"SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name='pg_stat_monitor.pgsm_query_shared_buffer';",
+	"SELECT name, setting, unit, context, vartype, source, min_val, max_val, enumvals, boot_val, reset_val, pending_restart FROM pg_settings WHERE name = 'pg_stat_monitor.pgsm_query_shared_buffer';",
 	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
 ok($cmdret == 0, "Print PGTDE EXTENSION Settings");
 PGTDE::append_to_debug_file($stdout);
@@ -187,7 +187,7 @@ ok($cmdret == 0, "Run pgbench");
 
 ($cmdret, $stdout, $stderr) = $node->psql(
 	'postgres',
-	'SELECT datname, substr(query,0,150) AS query, SUM(calls) AS calls FROM pg_stat_monitor GROUP BY datname, query ORDER BY datname, query, calls;',
+	'SELECT datname, substr(query, 0, 150) AS query, SUM(calls) AS calls FROM pg_stat_monitor GROUP BY datname, query ORDER BY datname, query, calls;',
 	extra_params => [ '-a', '-Pformat=aligned', '-Ptuples_only=off' ]);
 ok($cmdret == 0, "SELECT XXX FROM pg_stat_monitor");
 PGTDE::append_to_debug_file($stdout);

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -69,24 +69,24 @@ $node->start;
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url' ), to_json('secret'::text), NULL);"
+	"SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object('type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token'), json_object('type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url'), to_json('secret'::text), NULL);"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key','vault-provider');"
+	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'vault-provider');"
 );
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;'
+	'CREATE TABLE test_enc2 (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;'
 );
 
-PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (5),(6);');
+PGTDE::psql($node, 'postgres', 'INSERT INTO test_enc2 (k) VALUES (5), (6);');
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
 $node->restart;
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id;');
 
 PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');
 

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -94,7 +94,7 @@ PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
 $node->stop;
 
-system("kill -9 $pid");
+kill('TERM', $pid);
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -100,9 +100,9 @@ sub verify_table
 
 	my ($table) = @_;
 
-	my $tablefile = $node->safe_psql('postgres', 'SHOW data_directory;');
-	$tablefile .= '/';
-	$tablefile .= $node->safe_psql('postgres',
+	my $tablefile =
+	  $node->data_dir . '/'
+	  . $node->safe_psql('postgres',
 		'SELECT pg_relation_filepath(\'' . $table . '\');');
 
 	PGTDE::psql($node, 'postgres',

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -17,13 +17,6 @@ $node->start;
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;'
-);
-
-PGTDE::append_to_result_file("-- server restart");
-$node->restart;
-
-PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');"
 );
 PGTDE::psql($node, 'postgres',
@@ -129,48 +122,6 @@ verify_table('test_enc2');
 verify_table('test_enc3');
 verify_table('test_enc4');
 verify_table('test_enc5');
-
-# Verify that we can't see the data in the file
-my $tablefile2 = $node->safe_psql('postgres', 'SHOW data_directory;');
-$tablefile2 .= '/';
-$tablefile2 .=
-  $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\'test_enc2\');');
-
-my $strings = 'TABLEFILE2 FOUND: ';
-$strings .= `(ls  $tablefile2 >/dev/null && echo yes) || echo no`;
-PGTDE::append_to_result_file($strings);
-
-$strings = 'CONTAINS FOO (should be empty): ';
-$strings .= `strings $tablefile2 | grep foo`;
-PGTDE::append_to_result_file($strings);
-
-# Verify that we can't see the data in the file
-my $tablefile3 = $node->safe_psql('postgres', 'SHOW data_directory;');
-$tablefile3 .= '/';
-$tablefile3 .=
-  $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\'test_enc3\');');
-
-$strings = 'TABLEFILE3 FOUND: ';
-$strings .= `(ls  $tablefile3 >/dev/null && echo yes) || echo no`;
-PGTDE::append_to_result_file($strings);
-
-$strings = 'CONTAINS FOO (should be empty): ';
-$strings .= `strings $tablefile3 | grep foo`;
-PGTDE::append_to_result_file($strings);
-
-# Verify that we can't see the data in the file
-my $tablefile4 = $node->safe_psql('postgres', 'SHOW data_directory;');
-$tablefile4 .= '/';
-$tablefile4 .=
-  $node->safe_psql('postgres', 'SELECT pg_relation_filepath(\'test_enc4\');');
-
-$strings = 'TABLEFILE4 FOUND: ';
-$strings .= `(ls  $tablefile4 >/dev/null && echo yes) || echo no`;
-PGTDE::append_to_result_file($strings);
-
-$strings = 'CONTAINS FOO (should be empty): ';
-$strings .= `strings $tablefile4 | grep foo`;
-PGTDE::append_to_result_file($strings);
 
 PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc1;');
 PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -108,15 +108,17 @@ sub verify_table
 	PGTDE::psql($node, 'postgres',
 		'SELECT * FROM ' . $table . ' ORDER BY id ASC;');
 
-	my $strings = 'TABLEFILE FOR ' . $table . ' FOUND: ';
-	$strings .= `(ls  $tablefile >/dev/null && echo -n yes) || echo -n no`;
-	PGTDE::append_to_result_file($strings);
+	PGTDE::append_to_result_file('TABLEFILE FOR '
+		  . $table
+		  . ' FOUND: '
+		  . (-f $tablefile ? 'yes' : 'no'));
 
-	$strings = 'CONTAINS FOO (should be empty): ';
+	my $strings = 'CONTAINS FOO (should be empty): ';
 	$strings .= `strings $tablefile | grep foo`;
 	PGTDE::append_to_result_file($strings);
 }
 
+# Verify that we can't see the data in the files
 verify_table('test_enc1');
 verify_table('test_enc2');
 verify_table('test_enc3');

--- a/contrib/pg_tde/t/007_tde_heap.pl
+++ b/contrib/pg_tde/t/007_tde_heap.pl
@@ -17,79 +17,79 @@ $node->start;
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');"
+	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');"
+	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');"
 );
 
 ######################### test_enc1 (simple create table w tde_heap)
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc1(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;'
+	'CREATE TABLE test_enc1 (id SERIAL, k VARCHAR(32), PRIMARY KEY (id)) USING tde_heap;'
 );
 
 PGTDE::psql($node, 'postgres',
-	'INSERT INTO test_enc1 (k) VALUES (\'foobar\'),(\'barfoo\');');
+	"INSERT INTO test_enc1 (k) VALUES ('foobar'), ('barfoo');");
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc1 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc1 ORDER BY id;');
 
 ######################### test_enc2 (create heap + alter to tde_heap)
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc2(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));');
+	'CREATE TABLE test_enc2 (id SERIAL, k VARCHAR(32), PRIMARY KEY (id));');
 
 PGTDE::psql($node, 'postgres',
-	'INSERT INTO test_enc2 (k) VALUES (\'foobar\'),(\'barfoo\');');
+	"INSERT INTO test_enc2 (k) VALUES ('foobar'), ('barfoo');");
 
 PGTDE::psql($node, 'postgres',
 	'ALTER TABLE test_enc2 SET ACCESS METHOD tde_heap;');
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc2 ORDER BY id;');
 
 ######################### test_enc3 (default_table_access_method)
 
 PGTDE::psql($node, 'postgres',
-	'SET default_table_access_method = "tde_heap"; CREATE TABLE test_enc3(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));'
+	'SET default_table_access_method = "tde_heap"; CREATE TABLE test_enc3 (id SERIAL, k VARCHAR(32), PRIMARY KEY (id));'
 );
 
 PGTDE::psql($node, 'postgres',
-	'INSERT INTO test_enc3 (k) VALUES (\'foobar\'),(\'barfoo\');');
+	"INSERT INTO test_enc3 (k) VALUES ('foobar'), ('barfoo');");
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc3 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc3 ORDER BY id;');
 
 ######################### test_enc4 (create heap + alter default)
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc4(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING heap;'
+	'CREATE TABLE test_enc4 (id SERIAL, k VARCHAR(32), PRIMARY KEY (id)) USING heap;'
 );
 
 PGTDE::psql($node, 'postgres',
-	'INSERT INTO test_enc4 (k) VALUES (\'foobar\'),(\'barfoo\');');
+	"INSERT INTO test_enc4 (k) VALUES ('foobar'), ('barfoo');");
 
 PGTDE::psql($node, 'postgres',
 	'SET default_table_access_method = "tde_heap"; ALTER TABLE test_enc4 SET ACCESS METHOD DEFAULT;'
 );
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc4 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc4 ORDER BY id;');
 
 ######################### test_enc5 (create tde_heap + truncate)
 
 PGTDE::psql($node, 'postgres',
-	'CREATE TABLE test_enc5(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;'
+	'CREATE TABLE test_enc5 (id SERIAL, k VARCHAR(32), PRIMARY KEY (id)) USING tde_heap;'
 );
 
 PGTDE::psql($node, 'postgres',
-	'INSERT INTO test_enc5 (k) VALUES (\'foobar\'),(\'barfoo\');');
+	"INSERT INTO test_enc5 (k) VALUES ('foobar'), ('barfoo');");
 
 PGTDE::psql($node, 'postgres', 'CHECKPOINT;');
 
 PGTDE::psql($node, 'postgres', 'TRUNCATE test_enc5;');
 
 PGTDE::psql($node, 'postgres',
-	'INSERT INTO test_enc5 (k) VALUES (\'foobar\'),(\'barfoo\');');
+	"INSERT INTO test_enc5 (k) VALUES ('foobar'), ('barfoo');");
 
-PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc5 ORDER BY id ASC;');
+PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc5 ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");
 $node->restart;
@@ -103,10 +103,10 @@ sub verify_table
 	my $tablefile =
 	  $node->data_dir . '/'
 	  . $node->safe_psql('postgres',
-		'SELECT pg_relation_filepath(\'' . $table . '\');');
+		"SELECT pg_relation_filepath('" . $table . "');");
 
 	PGTDE::psql($node, 'postgres',
-		'SELECT * FROM ' . $table . ' ORDER BY id ASC;');
+		'SELECT * FROM ' . $table . ' ORDER BY id;');
 
 	PGTDE::append_to_result_file('TABLEFILE FOR '
 		  . $table

--- a/contrib/pg_tde/t/008_key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/008_key_rotate_tablespace.pl
@@ -22,18 +22,18 @@ PGTDE::psql($node, 'postgres',
 
 PGTDE::psql($node, 'tbc', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 PGTDE::psql($node, 'tbc',
-	"SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');"
+	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');"
 );
 PGTDE::psql($node, 'tbc',
-	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');"
+	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');"
 );
 
 PGTDE::psql(
 	$node, 'tbc', "
 CREATE TABLE country_table (
-     country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
+     country_id   serial primary key,
+     country_name text unique not null,
+     continent    text not null
 ) USING tde_heap;
 ");
 

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -20,7 +20,7 @@ $node->start;
 PGTDE::psql($node, 'postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/pg_tde_test_keyring010.per');"
 );
 
 PGTDE::psql($node, 'postgres',

--- a/contrib/pg_tde/t/014_pg_waldump_basic.pl
+++ b/contrib/pg_tde/t/014_pg_waldump_basic.pl
@@ -28,7 +28,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_tde_test_keyring-wal.per');"
 );
 $node->safe_psql('postgres',
 	"SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-wal');"

--- a/contrib/pg_tde/t/015_pg_waldump_fullpage.pl
+++ b/contrib/pg_tde/t/015_pg_waldump_fullpage.pl
@@ -42,7 +42,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal','/tmp/pg_tde_test_keyring-wal.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_tde_test_keyring-wal.per');"
 );
 $node->safe_psql('postgres',
 	"SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-wal');"

--- a/contrib/pg_tde/t/expected/001_basic.out
+++ b/contrib/pg_tde/t/expected/001_basic.out
@@ -38,7 +38,6 @@ SELECT * FROM test_enc ORDER BY id ASC;
 (2 rows)
 
 TABLEFILE FOUND: yes
-
 CONTAINS FOO (should be empty): 
 DROP TABLE test_enc;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/t/expected/001_basic.out
+++ b/contrib/pg_tde/t/expected/001_basic.out
@@ -8,7 +8,6 @@ SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_tde';
 CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
 psql:<stdin>:1: ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_key before using encrypted tables
--- server restart
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/t/expected/001_basic.out
+++ b/contrib/pg_tde/t/expected/001_basic.out
@@ -5,24 +5,24 @@ SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_tde';
  pg_tde  | 1.0-rc
 (1 row)
 
-CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
+CREATE TABLE test_enc (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;
 psql:<stdin>:1: ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_key before using encrypted tables
-SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
                                      1
 (1 row)
 
-SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  
 (1 row)
 
-CREATE TABLE test_enc(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
-INSERT INTO test_enc (k) VALUES ('foobar'),('barfoo');
-SELECT * FROM test_enc ORDER BY id ASC;
+CREATE TABLE test_enc (id SERIAL, k VARCHAR(32), PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc (k) VALUES ('foobar'), ('barfoo');
+SELECT * FROM test_enc ORDER BY id;
  id |   k    
 ----+--------
   1 | foobar
@@ -30,7 +30,7 @@ SELECT * FROM test_enc ORDER BY id ASC;
 (2 rows)
 
 -- server restart
-SELECT * FROM test_enc ORDER BY id ASC;
+SELECT * FROM test_enc ORDER BY id;
  id |   k    
 ----+--------
   1 | foobar

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -1,23 +1,23 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
                                      1
 (1 row)
 
-SELECT pg_tde_add_database_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');
+SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
                                      2
 (1 row)
 
-SELECT pg_tde_add_global_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2g.per');
+SELECT pg_tde_add_global_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2g.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
                                   -1
 (1 row)
 
-SELECT pg_tde_add_global_key_provider_file('file-3','/tmp/pg_tde_test_keyring_3.per');
+SELECT pg_tde_add_global_key_provider_file('file-3', '/tmp/pg_tde_test_keyring_3.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
                                   -2
@@ -30,15 +30,15 @@ SELECT pg_tde_list_all_database_key_providers();
  (2,file-2,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring_2.per""}")
 (2 rows)
 
-SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  
 (1 row)
 
-CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
-INSERT INTO test_enc (k) VALUES (5),(6);
-SELECT * FROM test_enc ORDER BY id ASC;
+CREATE TABLE test_enc (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc (k) VALUES (5), (6);
+SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
   1 | 5
@@ -51,7 +51,7 @@ SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');
  
 (1 row)
 
-SELECT * FROM test_enc ORDER BY id ASC;
+SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
   1 | 5
@@ -68,20 +68,20 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
-SELECT * FROM test_enc ORDER BY id ASC;
+SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
   1 | 5
   2 | 6
 (2 rows)
 
-SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');
+SELECT pg_tde_set_key_using_database_key_provider('rotated-key2', 'file-2');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  
 (1 row)
 
-SELECT * FROM test_enc ORDER BY id ASC;
+SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
   1 | 5
@@ -98,7 +98,7 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
-SELECT * FROM test_enc ORDER BY id ASC;
+SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
   1 | 5
@@ -111,7 +111,7 @@ SELECT pg_tde_set_key_using_global_key_provider('rotated-key', 'file-3', false);
  
 (1 row)
 
-SELECT * FROM test_enc ORDER BY id ASC;
+SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
   1 | 5
@@ -128,7 +128,7 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
-SELECT * FROM test_enc ORDER BY id ASC;
+SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
   1 | 5
@@ -141,7 +141,7 @@ SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX', 'file-2', false)
  
 (1 row)
 
-SELECT * FROM test_enc ORDER BY id ASC;
+SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
   1 | 5
@@ -158,14 +158,14 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
-SELECT * FROM test_enc ORDER BY id ASC;
+SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
   1 | 5
   2 | 6
 (2 rows)
 
-ALTER SYSTEM SET pg_tde.inherit_global_providers = OFF;
+ALTER SYSTEM SET pg_tde.inherit_global_providers = off;
 -- server restart
 SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX2', 'file-2', false);
 psql:<stdin>:1: ERROR:  Usage of global key providers is disabled. Enable it with pg_tde.inherit_global_providers = ON
@@ -178,7 +178,7 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
 psql:<stdin>:1: ERROR:  Principal key does not exists for the database
 HINT:  Use set_key interface to set the principal key
-SELECT pg_tde_set_key_using_database_key_provider('rotated-key2','file-2');
+SELECT pg_tde_set_key_using_database_key_provider('rotated-key2', 'file-2');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -1,8 +1,4 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
-psql:<stdin>:1: ERROR:  principal key not configured
-HINT:  create one using pg_tde_set_key before using encrypted tables
--- server restart
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/t/expected/003_remote_config.out
+++ b/contrib/pg_tde/t/expected/003_remote_config.out
@@ -1,19 +1,19 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello' ));
+SELECT pg_tde_add_database_key_provider_file('file-provider', json_object('type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello'));
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
                                      1
 (1 row)
 
-SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-provider');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  
 (1 row)
 
-CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
-INSERT INTO test_enc2 (k) VALUES (5),(6);
-SELECT * FROM test_enc2 ORDER BY id ASC;
+CREATE TABLE test_enc2 (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc2 (k) VALUES (5), (6);
+SELECT * FROM test_enc2 ORDER BY id;
  id | k 
 ----+---
   1 | 5
@@ -21,7 +21,7 @@ SELECT * FROM test_enc2 ORDER BY id ASC;
 (2 rows)
 
 -- server restart
-SELECT * FROM test_enc2 ORDER BY id ASC;
+SELECT * FROM test_enc2 ORDER BY id;
  id | k 
 ----+---
   1 | 5

--- a/contrib/pg_tde/t/expected/004_file_config.out
+++ b/contrib/pg_tde/t/expected/004_file_config.out
@@ -1,19 +1,19 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-provider', json_object( 'type' VALUE 'file', 'path' VALUE '/tmp/datafile-location' ));
+SELECT pg_tde_add_database_key_provider_file('file-provider', json_object('type' VALUE 'file', 'path' VALUE '/tmp/datafile-location'));
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
                                      1
 (1 row)
 
-SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-provider');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-provider');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  
 (1 row)
 
-CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
-INSERT INTO test_enc1 (k) VALUES (5),(6);
-SELECT * FROM test_enc1 ORDER BY id ASC;
+CREATE TABLE test_enc1 (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc1 (k) VALUES (5), (6);
+SELECT * FROM test_enc1 ORDER BY id;
  id | k 
 ----+---
   1 | 5
@@ -21,7 +21,7 @@ SELECT * FROM test_enc1 ORDER BY id ASC;
 (2 rows)
 
 -- server restart
-SELECT * FROM test_enc1 ORDER BY id ASC;
+SELECT * FROM test_enc1 ORDER BY id;
  id | k 
 ----+---
   1 | 5

--- a/contrib/pg_tde/t/expected/005_multiple_extensions.out
+++ b/contrib/pg_tde/t/expected/005_multiple_extensions.out
@@ -1,11 +1,11 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-CREATE TABLE test_enc1(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
-INSERT INTO test_enc1 (k) VALUES (5),(6);
-SELECT * FROM test_enc1 ORDER BY id ASC;
+CREATE TABLE test_enc1 (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc1 (k) VALUES (5), (6);
+SELECT * FROM test_enc1 ORDER BY id;
 1|5
 2|6
 -- server restart
-SELECT * FROM test_enc1 ORDER BY id ASC;
+SELECT * FROM test_enc1 ORDER BY id;
 1|5
 2|6
 DROP TABLE test_enc1;

--- a/contrib/pg_tde/t/expected/006_remote_vault_config.out
+++ b/contrib/pg_tde/t/expected/006_remote_vault_config.out
@@ -1,19 +1,19 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token' ), json_object( 'type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url' ), to_json('secret'::text), NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object('type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token'), json_object('type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url'), to_json('secret'::text), NULL);
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
                                          1
 (1 row)
 
-SELECT pg_tde_set_key_using_database_key_provider('test-db-key','vault-provider');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'vault-provider');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  
 (1 row)
 
-CREATE TABLE test_enc2(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
-INSERT INTO test_enc2 (k) VALUES (5),(6);
-SELECT * FROM test_enc2 ORDER BY id ASC;
+CREATE TABLE test_enc2 (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc2 (k) VALUES (5), (6);
+SELECT * FROM test_enc2 ORDER BY id;
  id | k 
 ----+---
   1 | 5
@@ -21,7 +21,7 @@ SELECT * FROM test_enc2 ORDER BY id ASC;
 (2 rows)
 
 -- server restart
-SELECT * FROM test_enc2 ORDER BY id ASC;
+SELECT * FROM test_enc2 ORDER BY id;
  id | k 
 ----+---
   1 | 5

--- a/contrib/pg_tde/t/expected/007_tde_heap.out
+++ b/contrib/pg_tde/t/expected/007_tde_heap.out
@@ -1,8 +1,4 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING tde_heap;
-psql:<stdin>:1: ERROR:  principal key not configured
-HINT:  create one using pg_tde_set_key before using encrypted tables
--- server restart
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
@@ -115,15 +111,6 @@ SELECT * FROM test_enc5 ORDER BY id ASC;
 (2 rows)
 
 TABLEFILE FOR test_enc5 FOUND: yes
-CONTAINS FOO (should be empty): 
-TABLEFILE2 FOUND: yes
-
-CONTAINS FOO (should be empty): 
-TABLEFILE3 FOUND: yes
-
-CONTAINS FOO (should be empty): 
-TABLEFILE4 FOUND: yes
-
 CONTAINS FOO (should be empty): 
 DROP TABLE test_enc1;
 DROP TABLE test_enc2;

--- a/contrib/pg_tde/t/expected/007_tde_heap.out
+++ b/contrib/pg_tde/t/expected/007_tde_heap.out
@@ -1,60 +1,60 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
                                      1
 (1 row)
 
-SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  
 (1 row)
 
-CREATE TABLE test_enc1(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
-INSERT INTO test_enc1 (k) VALUES ('foobar'),('barfoo');
-SELECT * FROM test_enc1 ORDER BY id ASC;
+CREATE TABLE test_enc1 (id SERIAL, k VARCHAR(32), PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc1 (k) VALUES ('foobar'), ('barfoo');
+SELECT * FROM test_enc1 ORDER BY id;
  id |   k    
 ----+--------
   1 | foobar
   2 | barfoo
 (2 rows)
 
-CREATE TABLE test_enc2(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));
-INSERT INTO test_enc2 (k) VALUES ('foobar'),('barfoo');
+CREATE TABLE test_enc2 (id SERIAL, k VARCHAR(32), PRIMARY KEY (id));
+INSERT INTO test_enc2 (k) VALUES ('foobar'), ('barfoo');
 ALTER TABLE test_enc2 SET ACCESS METHOD tde_heap;
-SELECT * FROM test_enc2 ORDER BY id ASC;
+SELECT * FROM test_enc2 ORDER BY id;
  id |   k    
 ----+--------
   1 | foobar
   2 | barfoo
 (2 rows)
 
-SET default_table_access_method = "tde_heap"; CREATE TABLE test_enc3(id SERIAL,k VARCHAR(32),PRIMARY KEY (id));
-INSERT INTO test_enc3 (k) VALUES ('foobar'),('barfoo');
-SELECT * FROM test_enc3 ORDER BY id ASC;
+SET default_table_access_method = "tde_heap"; CREATE TABLE test_enc3 (id SERIAL, k VARCHAR(32), PRIMARY KEY (id));
+INSERT INTO test_enc3 (k) VALUES ('foobar'), ('barfoo');
+SELECT * FROM test_enc3 ORDER BY id;
  id |   k    
 ----+--------
   1 | foobar
   2 | barfoo
 (2 rows)
 
-CREATE TABLE test_enc4(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING heap;
-INSERT INTO test_enc4 (k) VALUES ('foobar'),('barfoo');
+CREATE TABLE test_enc4 (id SERIAL, k VARCHAR(32), PRIMARY KEY (id)) USING heap;
+INSERT INTO test_enc4 (k) VALUES ('foobar'), ('barfoo');
 SET default_table_access_method = "tde_heap"; ALTER TABLE test_enc4 SET ACCESS METHOD DEFAULT;
-SELECT * FROM test_enc4 ORDER BY id ASC;
+SELECT * FROM test_enc4 ORDER BY id;
  id |   k    
 ----+--------
   1 | foobar
   2 | barfoo
 (2 rows)
 
-CREATE TABLE test_enc5(id SERIAL,k VARCHAR(32),PRIMARY KEY (id)) USING tde_heap;
-INSERT INTO test_enc5 (k) VALUES ('foobar'),('barfoo');
+CREATE TABLE test_enc5 (id SERIAL, k VARCHAR(32), PRIMARY KEY (id)) USING tde_heap;
+INSERT INTO test_enc5 (k) VALUES ('foobar'), ('barfoo');
 CHECKPOINT;
 TRUNCATE test_enc5;
-INSERT INTO test_enc5 (k) VALUES ('foobar'),('barfoo');
-SELECT * FROM test_enc5 ORDER BY id ASC;
+INSERT INTO test_enc5 (k) VALUES ('foobar'), ('barfoo');
+SELECT * FROM test_enc5 ORDER BY id;
  id |   k    
 ----+--------
   3 | foobar
@@ -63,7 +63,7 @@ SELECT * FROM test_enc5 ORDER BY id ASC;
 
 -- server restart
 ###########################
-SELECT * FROM test_enc1 ORDER BY id ASC;
+SELECT * FROM test_enc1 ORDER BY id;
  id |   k    
 ----+--------
   1 | foobar
@@ -73,7 +73,7 @@ SELECT * FROM test_enc1 ORDER BY id ASC;
 TABLEFILE FOR test_enc1 FOUND: yes
 CONTAINS FOO (should be empty): 
 ###########################
-SELECT * FROM test_enc2 ORDER BY id ASC;
+SELECT * FROM test_enc2 ORDER BY id;
  id |   k    
 ----+--------
   1 | foobar
@@ -83,7 +83,7 @@ SELECT * FROM test_enc2 ORDER BY id ASC;
 TABLEFILE FOR test_enc2 FOUND: yes
 CONTAINS FOO (should be empty): 
 ###########################
-SELECT * FROM test_enc3 ORDER BY id ASC;
+SELECT * FROM test_enc3 ORDER BY id;
  id |   k    
 ----+--------
   1 | foobar
@@ -93,7 +93,7 @@ SELECT * FROM test_enc3 ORDER BY id ASC;
 TABLEFILE FOR test_enc3 FOUND: yes
 CONTAINS FOO (should be empty): 
 ###########################
-SELECT * FROM test_enc4 ORDER BY id ASC;
+SELECT * FROM test_enc4 ORDER BY id;
  id |   k    
 ----+--------
   1 | foobar
@@ -103,7 +103,7 @@ SELECT * FROM test_enc4 ORDER BY id ASC;
 TABLEFILE FOR test_enc4 FOUND: yes
 CONTAINS FOO (should be empty): 
 ###########################
-SELECT * FROM test_enc5 ORDER BY id ASC;
+SELECT * FROM test_enc5 ORDER BY id;
  id |   k    
 ----+--------
   3 | foobar

--- a/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
+++ b/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
@@ -1,22 +1,22 @@
 SET allow_in_place_tablespaces = true; CREATE TABLESPACE test_tblspace LOCATION '';
 CREATE DATABASE tbc TABLESPACE = test_tblspace;
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
                                      1
 (1 row)
 
-SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
+SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  
 (1 row)
 
 CREATE TABLE country_table (
-     country_id        serial primary key,
-     country_name    text unique not null,
-     continent        text not null
+     country_id   serial primary key,
+     country_name text unique not null,
+     continent    text not null
 ) USING tde_heap;
 INSERT INTO country_table (country_name, continent)
      VALUES ('Japan', 'Asia'),

--- a/contrib/pg_tde/t/expected/009_wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/009_wal_encrypt.out
@@ -1,5 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');
+SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/pg_tde_test_keyring010.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
                                   -1


### PR DESCRIPTION
Various improvements to make the TAP tests a bit easier to read.

- Make white space in queries more consistent
- Use Perl's `kill()` over shell
- Use Perl's `-f` over `ls`
- Remove some useless queries which did not do anything interesting to test
- Use `data_dir()` over doing SQL queries
