### PR TITLE
PG-1543 Always cache server principal key

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -261,9 +261,9 @@ pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocat
 {
 	TDEPrincipalKey *principal_key;
 
-	LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
+	LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
 
-	principal_key = GetPrincipalKey(newrlocator->dbOid, LW_SHARED);
+	principal_key = GetPrincipalKey(newrlocator->dbOid, LW_EXCLUSIVE);
 	if (principal_key == NULL)
 	{
 		ereport(ERROR,

--- a/contrib/pg_tde/src/include/catalog/tde_global_space.h
+++ b/contrib/pg_tde/src/include/catalog/tde_global_space.h
@@ -33,6 +33,4 @@
 	_obj_oid \
 }
 
-#define TDEisInGlobalSpace(dbOid) 	(dbOid == GLOBAL_DATA_TDE_OID)
-
 #endif							/* TDE_GLOBAL_CATALOG_H */

--- a/contrib/pg_tde/t/009_wal_encrypt.pl
+++ b/contrib/pg_tde/t/009_wal_encrypt.pl
@@ -23,9 +23,13 @@ PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_keyring010.per');"
 );
 
+PGTDE::psql($node, 'postgres', 'SELECT pg_tde_verify_server_key();');
+
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-010');"
 );
+
+PGTDE::psql($node, 'postgres', 'SELECT pg_tde_verify_server_key();');
 
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;');
 

--- a/contrib/pg_tde/t/expected/009_wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/009_wal_encrypt.out
@@ -5,9 +5,17 @@ SELECT pg_tde_add_global_key_provider_file('file-keyring-010','/tmp/pg_tde_test_
                                   -1
 (1 row)
 
+SELECT pg_tde_verify_server_key();
+psql:<stdin>:1: ERROR:  principal key not configured for current database
 SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-010');
  pg_tde_set_server_key_using_global_key_provider 
 -------------------------------------------------
+ 
+(1 row)
+
+SELECT pg_tde_verify_server_key();
+ pg_tde_verify_server_key 
+--------------------------
  
 (1 row)
 


### PR DESCRIPTION
This fixes a bug when `pg_tde_verify_server_key()` was broken if the server key was rotated in the same server lifetime as it was originally created since we wrote to the cache when we created to key the first time but not when we rotated it.

An alternative would be to fix that bug and never cache the server key but by always caching it like we do with all other keys, including the default key, we simplify the code paths and make this kind of bug less likely in the future.

This also discovered a previously harmless mistake where we grabbed the wrong lock level when trying to write a new WAL key.