### PR TITLE
Remove unhelpful hint on key provider not found

### DIFF
--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -50,7 +50,6 @@ SELECT pg_tde_verify_key();
 
 SELECT pg_tde_change_database_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
 ERROR:  key provider "not-existent-provider" does not exists
-HINT:  Create the key provider
 SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                           options                           
 ----+----------------+---------------+-------------------------------------------------------------

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -1030,8 +1030,7 @@ GetKeyProviderByName(const char *provider_name, Oid dbOid)
 	{
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				errmsg("key provider \"%s\" does not exists", provider_name),
-				errhint("Create the key provider"));
+				errmsg("key provider \"%s\" does not exists", provider_name));
 	}
 	return keyring;
 }


### PR DESCRIPTION
The hint added nothing and while we could hint about what function they should use to create a key provider this error happens also when alternating or deleting an existing key provider making any hint pretty much useless.