### PR TITLE
Remove type field from key provider configuration

### DIFF
--- a/contrib/pg_tde/expected/access_control.out
+++ b/contrib/pg_tde/expected/access_control.out
@@ -48,9 +48,9 @@ SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'local-file-pro
 (1 row)
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id |    provider_name    | provider_type |                          options                           
-----+---------------------+---------------+------------------------------------------------------------
-  1 | local-file-provider | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
+ id |    provider_name    | provider_type |                  options                  
+----+---------------------+---------------+-------------------------------------------
+  1 | local-file-provider | file          | {"path" : "/tmp/pg_tde_test_keyring.per"}
 (1 row)
 
 SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_key_info();

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -16,9 +16,9 @@ SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_k
 (1 row)
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name | provider_type |                          options                           
-----+---------------+---------------+------------------------------------------------------------
-  1 | file-provider | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
+ id | provider_name | provider_type |                  options                  
+----+---------------+---------------+-------------------------------------------
+  1 | file-provider | file          | {"path" : "/tmp/pg_tde_test_keyring.per"}
 (1 row)
 
 SELECT pg_tde_add_database_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
@@ -28,10 +28,10 @@ SELECT pg_tde_add_database_key_provider_file('file-provider2','/tmp/pg_tde_test_
 (1 row)
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name  | provider_type |                           options                           
-----+----------------+---------------+-------------------------------------------------------------
-  1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
-  2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
+ id | provider_name  | provider_type |                  options                   
+----+----------------+---------------+--------------------------------------------
+  1 | file-provider  | file          | {"path" : "/tmp/pg_tde_test_keyring.per"}
+  2 | file-provider2 | file          | {"path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
 SELECT pg_tde_verify_key();
@@ -52,10 +52,10 @@ SELECT pg_tde_change_database_key_provider_file('not-existent-provider','/tmp/pg
 ERROR:  key provider "not-existent-provider" does not exists
 HINT:  Create the key provider
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name  | provider_type |                           options                           
-----+----------------+---------------+-------------------------------------------------------------
-  1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring.per"}
-  2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
+ id | provider_name  | provider_type |                  options                   
+----+----------------+---------------+--------------------------------------------
+  1 | file-provider  | file          | {"path" : "/tmp/pg_tde_test_keyring.per"}
+  2 | file-provider2 | file          | {"path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
 SELECT pg_tde_change_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_other.per');
@@ -65,10 +65,10 @@ SELECT pg_tde_change_database_key_provider_file('file-provider','/tmp/pg_tde_tes
 (1 row)
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name  | provider_type |                             options                              
-----+----------------+---------------+------------------------------------------------------------------
-  1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring_other.per"}
-  2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
+ id | provider_name  | provider_type |                     options                     
+----+----------------+---------------+-------------------------------------------------
+  1 | file-provider  | file          | {"path" : "/tmp/pg_tde_test_keyring_other.per"}
+  2 | file-provider2 | file          | {"path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
 SELECT pg_tde_verify_key();
@@ -76,10 +76,10 @@ ERROR:  failed to retrieve principal key test-db-key from keyring with ID 1
 SELECT pg_tde_change_database_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  parse json keyring config: unexpected field foo
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name  | provider_type |                             options                              
-----+----------------+---------------+------------------------------------------------------------------
-  1 | file-provider  | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring_other.per"}
-  2 | file-provider2 | file          | {"type" : "file", "path" : "/tmp/pg_tde_test_keyring2.per"}
+ id | provider_name  | provider_type |                     options                     
+----+----------------+---------------+-------------------------------------------------
+  1 | file-provider  | file          | {"path" : "/tmp/pg_tde_test_keyring_other.per"}
+  2 | file-provider2 | file          | {"path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
 SELECT pg_tde_add_global_key_provider_file('file-keyring','/tmp/pg_tde_test_keyring.per');

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -16,7 +16,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_add_database_key_provider('file', provider_name,
-                json_object('type' VALUE 'file', 'path' VALUE COALESCE(file_path, '')));
+                json_object('path' VALUE COALESCE(file_path, '')));
 END;
 
 CREATE FUNCTION pg_tde_add_database_key_provider_file(provider_name TEXT, file_path JSON)
@@ -26,7 +26,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_add_database_key_provider('file', provider_name,
-                json_object('type' VALUE 'file', 'path' VALUE file_path));
+                json_object('path' VALUE file_path));
 END;
 
 CREATE FUNCTION pg_tde_add_database_key_provider_vault_v2(provider_name TEXT,
@@ -40,8 +40,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_add_database_key_provider('vault-v2', provider_name,
-                            json_object('type' VALUE 'vault-v2',
-                            'url' VALUE COALESCE(vault_url, ''),
+                            json_object('url' VALUE COALESCE(vault_url, ''),
                             'token' VALUE COALESCE(vault_token, ''),
                             'mountPath' VALUE COALESCE(vault_mount_path, ''),
                             'caPath' VALUE COALESCE(vault_ca_path, '')));
@@ -58,8 +57,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_add_database_key_provider('vault-v2', provider_name,
-                            json_object('type' VALUE 'vault-v2',
-                            'url' VALUE vault_url,
+                            json_object('url' VALUE vault_url,
                             'token' VALUE vault_token,
                             'mountPath' VALUE vault_mount_path,
                             'caPath' VALUE vault_ca_path));
@@ -76,8 +74,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_add_database_key_provider('kmip', provider_name,
-                            json_object('type' VALUE 'kmip',
-                            'host' VALUE COALESCE(kmip_host, ''),
+                            json_object('host' VALUE COALESCE(kmip_host, ''),
                             'port' VALUE kmip_port,
                             'caPath' VALUE COALESCE(kmip_ca_path, ''),
                             'certPath' VALUE COALESCE(kmip_cert_path, '')));
@@ -94,8 +91,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_add_database_key_provider('kmip', provider_name,
-                            json_object('type' VALUE 'kmip',
-                            'host' VALUE kmip_host,
+                            json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
                             'caPath' VALUE kmip_ca_path,
                             'certPath' VALUE kmip_cert_path));
@@ -133,7 +129,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_add_global_key_provider('file', provider_name,
-                json_object('type' VALUE 'file', 'path' VALUE COALESCE(file_path, '')));
+                json_object('path' VALUE COALESCE(file_path, '')));
 END;
 
 CREATE FUNCTION pg_tde_add_global_key_provider_file(provider_name TEXT, file_path JSON)
@@ -143,7 +139,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_add_global_key_provider('file', provider_name,
-                json_object('type' VALUE 'file', 'path' VALUE file_path));
+                json_object('path' VALUE file_path));
 END;
 
 CREATE FUNCTION pg_tde_add_global_key_provider_vault_v2(provider_name TEXT,
@@ -157,8 +153,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_add_global_key_provider('vault-v2', provider_name,
-                            json_object('type' VALUE 'vault-v2',
-                            'url' VALUE COALESCE(vault_url, ''),
+                            json_object('url' VALUE COALESCE(vault_url, ''),
                             'token' VALUE COALESCE(vault_token, ''),
                             'mountPath' VALUE COALESCE(vault_mount_path, ''),
                             'caPath' VALUE COALESCE(vault_ca_path, '')));
@@ -175,8 +170,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_add_global_key_provider('vault-v2', provider_name,
-                            json_object('type' VALUE 'vault-v2',
-                            'url' VALUE vault_url,
+                            json_object('url' VALUE vault_url,
                             'token' VALUE vault_token,
                             'mountPath' VALUE vault_mount_path,
                             'caPath' VALUE vault_ca_path));
@@ -193,8 +187,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_add_global_key_provider('kmip', provider_name,
-                            json_object('type' VALUE 'kmip',
-                            'host' VALUE COALESCE(kmip_host, ''),
+                            json_object('host' VALUE COALESCE(kmip_host, ''),
                             'port' VALUE kmip_port,
                             'caPath' VALUE COALESCE(kmip_ca_path, ''),
                             'certPath' VALUE COALESCE(kmip_cert_path, '')));
@@ -211,8 +204,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_add_global_key_provider('vault-v2', provider_name,
-                            json_object('type' VALUE 'vault-v2',
-                            'host' VALUE kmip_host,
+                            json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
                             'caPath' VALUE kmip_ca_path,
                             'certPath' VALUE kmip_cert_path));
@@ -231,7 +223,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_change_database_key_provider('file', provider_name,
-                json_object('type' VALUE 'file', 'path' VALUE COALESCE(file_path, '')));
+                json_object('path' VALUE COALESCE(file_path, '')));
 END;
 
 CREATE FUNCTION pg_tde_change_database_key_provider_file(provider_name TEXT, file_path JSON)
@@ -241,7 +233,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_change_database_key_provider('file', provider_name,
-                json_object('type' VALUE 'file', 'path' VALUE file_path));
+                json_object('path' VALUE file_path));
 END;
 
 CREATE FUNCTION pg_tde_change_database_key_provider_vault_v2(provider_name TEXT,
@@ -255,8 +247,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_change_database_key_provider('vault-v2', provider_name,
-                            json_object('type' VALUE 'vault-v2',
-                            'url' VALUE COALESCE(vault_url, ''),
+                            json_object('url' VALUE COALESCE(vault_url, ''),
                             'token' VALUE COALESCE(vault_token, ''),
                             'mountPath' VALUE COALESCE(vault_mount_path, ''),
                             'caPath' VALUE COALESCE(vault_ca_path, '')));
@@ -273,8 +264,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_change_database_key_provider('vault-v2', provider_name,
-                            json_object('type' VALUE 'vault-v2',
-                            'url' VALUE vault_url,
+                            json_object('url' VALUE vault_url,
                             'token' VALUE vault_token,
                             'mountPath' VALUE vault_mount_path,
                             'caPath' VALUE vault_ca_path));
@@ -291,8 +281,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_change_database_key_provider('kmip', provider_name,
-                            json_object('type' VALUE 'kmip',
-                            'host' VALUE COALESCE(kmip_host, ''),
+                            json_object('host' VALUE COALESCE(kmip_host, ''),
                             'port' VALUE kmip_port,
                             'caPath' VALUE COALESCE(kmip_ca_path, ''),
                             'certPath' VALUE COALESCE(kmip_cert_path, '')));
@@ -309,8 +298,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_change_database_key_provider('kmip', provider_name,
-                            json_object('type' VALUE 'kmip',
-                            'host' VALUE kmip_host,
+                            json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
                             'caPath' VALUE kmip_ca_path,
                             'certPath' VALUE kmip_cert_path));
@@ -329,7 +317,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_change_global_key_provider('file', provider_name,
-                json_object('type' VALUE 'file', 'path' VALUE COALESCE(file_path, '')));
+                json_object('path' VALUE COALESCE(file_path, '')));
 END;
 
 CREATE FUNCTION pg_tde_change_global_key_provider_file(provider_name TEXT, file_path JSON)
@@ -339,7 +327,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_change_global_key_provider('file', provider_name,
-                json_object('type' VALUE 'file', 'path' VALUE file_path));
+                json_object('path' VALUE file_path));
 END;
 
 CREATE FUNCTION pg_tde_change_global_key_provider_vault_v2(provider_name TEXT,
@@ -353,8 +341,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_change_global_key_provider('vault-v2', provider_name,
-                            json_object('type' VALUE 'vault-v2',
-                            'url' VALUE COALESCE(vault_url, ''),
+                            json_object('url' VALUE COALESCE(vault_url, ''),
                             'token' VALUE COALESCE(vault_token, ''),
                             'mountPath' VALUE COALESCE(vault_mount_path, ''),
                             'caPath' VALUE COALESCE(vault_ca_path, '')));
@@ -371,8 +358,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_change_global_key_provider('vault-v2', provider_name,
-                            json_object('type' VALUE 'vault-v2',
-                            'url' VALUE vault_url,
+                            json_object('url' VALUE vault_url,
                             'token' VALUE vault_token,
                             'mountPath' VALUE vault_mount_path,
                             'caPath' VALUE vault_ca_path));
@@ -389,8 +375,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_change_global_key_provider('kmip', provider_name,
-                            json_object('type' VALUE 'kmip',
-                            'host' VALUE COALESCE(kmip_host, ''),
+                            json_object('host' VALUE COALESCE(kmip_host, ''),
                             'port' VALUE kmip_port,
                             'caPath' VALUE COALESCE(kmip_ca_path, ''),
                             'certPath' VALUE COALESCE(kmip_cert_path, '')));
@@ -407,8 +392,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_change_global_key_provider('vault-v2', provider_name,
-                            json_object('type' VALUE 'vault-v2',
-                            'host' VALUE kmip_host,
+                            json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
                             'caPath' VALUE kmip_ca_path,
                             'certPath' VALUE kmip_cert_path));
@@ -473,7 +457,7 @@ AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_default_key_info()
 RETURNS TABLE ( key_name text,
-                key_provider_name text,     
+                key_provider_name text,
                 key_provider_id integer,
                 key_creation_time timestamp with time zone)
 LANGUAGE C

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -24,10 +24,10 @@ SELECT pg_tde_add_global_key_provider_file('file-3', '/tmp/pg_tde_test_keyring_3
 (1 row)
 
 SELECT pg_tde_list_all_database_key_providers();
-                          pg_tde_list_all_database_key_providers                          
-------------------------------------------------------------------------------------------
- (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring.per""}")
- (2,file-2,file,"{""type"" : ""file"", ""path"" : ""/tmp/pg_tde_test_keyring_2.per""}")
+               pg_tde_list_all_database_key_providers                
+---------------------------------------------------------------------
+ (1,file-vault,file,"{""path"" : ""/tmp/pg_tde_test_keyring.per""}")
+ (2,file-2,file,"{""path"" : ""/tmp/pg_tde_test_keyring_2.per""}")
 (2 rows)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -6,9 +6,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_prov
 (1 row)
 
 SELECT pg_tde_list_all_database_key_providers();
-                           pg_tde_list_all_database_key_providers                           
---------------------------------------------------------------------------------------------
- (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_1.per""}")
+                pg_tde_list_all_database_key_providers                 
+-----------------------------------------------------------------------
+ (1,file-vault,file,"{""path"" : ""/tmp/change_key_provider_1.per""}")
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');
@@ -46,9 +46,9 @@ SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_p
 (1 row)
 
 SELECT pg_tde_list_all_database_key_providers();
-                           pg_tde_list_all_database_key_providers                           
---------------------------------------------------------------------------------------------
- (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_2.per""}")
+                pg_tde_list_all_database_key_providers                 
+-----------------------------------------------------------------------
+ (1,file-vault,file,"{""path"" : ""/tmp/change_key_provider_2.per""}")
 (1 row)
 
 SELECT pg_tde_verify_key();
@@ -97,9 +97,9 @@ SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_p
 (1 row)
 
 SELECT pg_tde_list_all_database_key_providers();
-                           pg_tde_list_all_database_key_providers                           
---------------------------------------------------------------------------------------------
- (1,file-vault,file,"{""type"" : ""file"", ""path"" : ""/tmp/change_key_provider_3.per""}")
+                pg_tde_list_all_database_key_providers                 
+-----------------------------------------------------------------------
+ (1,file-vault,file,"{""path"" : ""/tmp/change_key_provider_3.per""}")
 (1 row)
 
 SELECT pg_tde_verify_key();


### PR DESCRIPTION
This field in the JSON was not used by anything, it wasn't even verified to match the actual key provider type so the risk of weird data was unnecessary.