### PR TITLE
Clean up shared memory code

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -81,7 +81,7 @@ static dshash_parameters principal_key_dsh_params = {
 	.hash_function = dshash_memhash,
 };
 
-TdePrincipalKeylocalState principalKeyLocalState;
+static TdePrincipalKeylocalState principalKeyLocalState;
 
 static void principal_key_info_attach_shmem(void);
 static Size initialize_shared_state(void *start_address);
@@ -176,7 +176,7 @@ initialize_shared_state(void *start_address)
 	return sizeof(TdePrincipalKeySharedState);
 }
 
-void
+static void
 initialize_objects_in_dsa_area(dsa_area *dsa, void *raw_dsa_area)
 {
 	dshash_table *dsh;

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -79,6 +79,9 @@ static dshash_parameters principal_key_dsh_params = {
 	.entry_size = sizeof(TDEPrincipalKey),
 	.compare_function = dshash_memcmp,
 	.hash_function = dshash_memhash,
+#if PG_VERSION_NUM >= 170000
+	.copy_function = dshash_memcpy,
+#endif
 };
 
 static TdePrincipalKeylocalState principalKeyLocalState;
@@ -189,9 +192,6 @@ initialize_objects_in_dsa_area(dsa_area *dsa, void *raw_dsa_area)
 	sharedState->rawDsaArea = raw_dsa_area;
 	sharedState->hashTrancheId = LWLockNewTrancheId();
 	principal_key_dsh_params.tranche_id = sharedState->hashTrancheId;
-#if PG_VERSION_NUM >= 170000
-	principal_key_dsh_params.copy_function = dshash_memcpy;
-#endif
 	dsh = dshash_create(dsa, &principal_key_dsh_params, 0);
 	sharedState->hashHandle = dshash_get_hash_table_handle(dsh);
 	dshash_detach(dsh);

--- a/contrib/pg_tde/src/common/pg_tde_shmem.c
+++ b/contrib/pg_tde/src/common/pg_tde_shmem.c
@@ -19,19 +19,8 @@
 
 typedef struct TdeSharedState
 {
-	LWLock	   *principalKeyLock;
-	int			principalKeyHashTrancheId;
 	void	   *rawDsaArea;		/* DSA area pointer to store cache hashes */
-	dshash_table_handle principalKeyHashHandle;
 } TdeSharedState;
-
-typedef struct TDELocalState
-{
-	TdeSharedState *sharedTdeState;
-	dsa_area  **dsa;			/* local dsa area for backend attached to the
-								 * dsa area created by postmaster at startup. */
-	dshash_table *principalKeySharedHash;
-}			TDELocalState;
 
 static void tde_shmem_shutdown(int code, Datum arg);
 


### PR DESCRIPTION
This cleanup changes none of the fundamental issues of the shmem code, e.g. the totally pointless own layer we implemented, but it removes dead code and turns struct fields in global variables into local variables and other such changes.