### PR TITLE
Consistently refer to SQL types

### DIFF
--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -103,7 +103,7 @@ CREATE FUNCTION pg_tde_list_all_database_key_providers
     OUT provider_name TEXT,
     OUT provider_type TEXT,
     OUT options JSON)
-RETURNS SETOF record
+RETURNS SETOF RECORD
 LANGUAGE C STRICT
 AS 'MODULE_PATHNAME';
 
@@ -112,7 +112,7 @@ CREATE FUNCTION pg_tde_list_all_global_key_providers
     OUT provider_name TEXT,
     OUT provider_type TEXT,
     OUT options JSON)
-RETURNS SETOF record
+RETURNS SETOF RECORD
 LANGUAGE C STRICT
 AS 'MODULE_PATHNAME';
 
@@ -398,8 +398,8 @@ BEGIN ATOMIC
                             'certPath' VALUE kmip_cert_path));
 END;
 
-CREATE FUNCTION pg_tde_is_encrypted(relation regclass)
-RETURNS boolean
+CREATE FUNCTION pg_tde_is_encrypted(relation REGCLASS)
+RETURNS BOOLEAN
 STRICT
 LANGUAGE C
 AS 'MODULE_PATHNAME';
@@ -440,26 +440,26 @@ LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_key_info()
-RETURNS TABLE ( key_name text,
-                key_provider_name text,
-                key_provider_id integer,
-                key_creation_time timestamp with time zone)
+RETURNS TABLE ( key_name TEXT,
+                key_provider_name TEXT,
+                key_provider_id INT,
+                key_creation_time TIMESTAMP WITH TIME ZONE)
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_server_key_info()
-RETURNS TABLE ( key_name text,
-                key_provider_name text,
-                key_provider_id integer,
-                key_creation_time timestamp with time zone)
+RETURNS TABLE ( key_name TEXT,
+                key_provider_name TEXT,
+                key_provider_id INT,
+                key_creation_time TIMESTAMP WITH TIME ZONE)
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_default_key_info()
-RETURNS TABLE ( key_name text,
-                key_provider_name text,
-                key_provider_id integer,
-                key_creation_time timestamp with time zone)
+RETURNS TABLE ( key_name TEXT,
+                key_provider_name TEXT,
+                key_provider_id INT,
+                key_creation_time TIMESTAMP WITH TIME ZONE)
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
@@ -477,7 +477,7 @@ CREATE FUNCTION pg_tde_version() RETURNS TEXT LANGUAGE C AS 'MODULE_PATHNAME';
 
 -- Table access method
 CREATE FUNCTION pg_tdeam_handler(internal)
-RETURNS table_am_handler
+RETURNS TABLE_AM_HANDLER
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
@@ -485,12 +485,12 @@ CREATE ACCESS METHOD tde_heap TYPE TABLE HANDLER pg_tdeam_handler;
 COMMENT ON ACCESS METHOD tde_heap IS 'tde_heap table access method';
 
 CREATE FUNCTION pg_tde_ddl_command_start_capture()
-RETURNS event_trigger
+RETURNS EVENT_TRIGGER
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_ddl_command_end_capture()
-RETURNS event_trigger
+RETURNS EVENT_TRIGGER
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
@@ -519,7 +519,7 @@ LANGUAGE plpgsql
 SET search_path = @extschema@
 AS $$
 BEGIN
-    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_key_using_database_key_provider(text, text, BOOLEAN) TO %I', target_role);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION pg_tde_set_key_using_database_key_provider(TEXT, TEXT, BOOLEAN) TO %I', target_role);
 END;
 $$;
 
@@ -550,7 +550,7 @@ LANGUAGE plpgsql
 SET search_path = @extschema@
 AS $$
 BEGIN
-    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_key_using_database_key_provider(text, text, BOOLEAN) FROM %I', target_role);
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION pg_tde_set_key_using_database_key_provider(TEXT, TEXT, BOOLEAN) FROM %I', target_role);
 END;
 $$;
 


### PR DESCRIPTION
We had a mix here so I choose some rules that made the smallest diff.

- Use uppercase for types
- Refer to integer as INT