### PR TITLE
Remove dead and unnecessary code from header files

### DIFF
--- a/contrib/pg_tde/src/include/access/pg_tde_xlog.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog.h
@@ -11,8 +11,6 @@
 
 #ifndef FRONTEND
 
-#include "postgres.h"
-
 /* TDE XLOG record types */
 #define XLOG_TDE_ADD_RELATION_KEY		0x00
 #define XLOG_TDE_ADD_PRINCIPAL_KEY		0x10

--- a/contrib/pg_tde/src/include/catalog/tde_global_space.h
+++ b/contrib/pg_tde/src/include/catalog/tde_global_space.h
@@ -11,7 +11,6 @@
 #ifndef TDE_GLOBAL_CATALOG_H
 #define TDE_GLOBAL_CATALOG_H
 
-#include "postgres.h"
 #include "catalog/pg_tablespace_d.h"
 
 /*

--- a/contrib/pg_tde/src/include/keyring/keyring_curl.h
+++ b/contrib/pg_tde/src/include/keyring/keyring_curl.h
@@ -12,11 +12,7 @@
 #ifndef KEYRING_CURL_H
 #define KEYRING_CURL_H
 
-#include "pg_tde_defines.h"
-
-#define VAULT_URL_MAX_LEN 512
-
-#include <stdbool.h>
+#include "c.h"
 #include <curl/curl.h>
 
 typedef struct CurlString

--- a/contrib/pg_tde/src/include/pg_tde.h
+++ b/contrib/pg_tde/src/include/pg_tde.h
@@ -19,9 +19,6 @@ typedef struct XLogExtensionInstall
 	Oid			database_id;
 } XLogExtensionInstall;
 
-typedef void (*pg_tde_on_ext_install_callback) (XLogExtensionInstall *ext_info, bool redo);
-
-extern void on_ext_install(pg_tde_on_ext_install_callback function);
 extern void extension_install_redo(XLogExtensionInstall *xlrec);
 
 #endif							/* PG_TDE_H */

--- a/contrib/pg_tde/src/include/pg_tde_defines.h
+++ b/contrib/pg_tde/src/include/pg_tde_defines.h
@@ -12,7 +12,6 @@
 
 /* #define ENCRYPTION_DEBUG 1 */
 /* #define KEYRING_DEBUG 1 */
-/* #define TDE_FORK_DEBUG 1 */
-/*  #define TDE_XLOG_DEBUG 1 */
+/* #define TDE_XLOG_DEBUG 1 */
 
 #endif							/* PG_TDE_DEFINES_H */

--- a/contrib/pg_tde/src/include/pg_tde_event_capture.h
+++ b/contrib/pg_tde/src/include/pg_tde_event_capture.h
@@ -7,10 +7,6 @@
 #ifndef PG_TDE_EVENT_CAPTURE_H
 #define PG_TDE_EVENT_CAPTURE_H
 
-#include "postgres.h"
-#include "nodes/parsenodes.h"
-#include "access/transam.h"
-
 typedef enum
 {
 	TDE_ENCRYPT_MODE_RETAIN = 0,

--- a/contrib/pg_tde/src/include/pg_tde_guc.h
+++ b/contrib/pg_tde/src/include/pg_tde_guc.h
@@ -11,7 +11,7 @@
 #ifndef TDE_GUC_H
 #define TDE_GUC_H
 
-#include "postgres.h"
+#include "c.h"
 
 #ifndef FRONTEND
 

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -29,6 +29,8 @@
 #include "pg_tde_fe.h"
 #endif
 
+#define VAULT_URL_MAX_LEN 512
+
 /*
  * JSON parser state
 */


### PR DESCRIPTION
Most of these code used to be necessary in the past but is not anymore but was missed when the code which needed it was removed.