### PR TITLE
DOCS-release-notes-modif

### DIFF
--- a/contrib/pg_tde/documentation/docs/release-notes/rc2.md
+++ b/contrib/pg_tde/documentation/docs/release-notes/rc2.md
@@ -1,3 +1,5 @@
+<!-- robots: noindex, nofollow -->
+
 # pg_tde Release Candidate ({{date.RC2}})
 
 `pg_tde` extension brings in [Transparent Data Encryption (TDE)](../index/index.md) to PostgreSQL and enables you to keep sensitive data safe and secure.


### PR DESCRIPTION
To temp hide indexing until release