### PR TITLE
Fixing flaky crash after 17.5 merge

### DIFF
--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -250,7 +250,11 @@ static void
 tde_mdopen(SMgrRelation reln)
 {
 	TDESMgrRelation tdereln = (TDESMgrRelation) reln;
-	InternalKey *key = tde_smgr_get_key(&reln->smgr_rlocator);
+	InternalKey *key;
+
+	mdopen(reln);
+
+	key = tde_smgr_get_key(&reln->smgr_rlocator);
 
 	if (key)
 	{
@@ -261,7 +265,6 @@ tde_mdopen(SMgrRelation reln)
 	{
 		tdereln->encrypted_relation = false;
 	}
-	mdopen(reln);
 }
 
 static const struct f_smgr tde_smgr = {


### PR DESCRIPTION
The 17.5 release includes a bugfix for the smgrcode: previously if smgropen failed, smgrclose wasn't called.

In our case we tried to retrieve the key before calling mdopen in smgropen, which meant that the open call failed before the data initialization in mdopen, which sometimes caused mdclose to crash.

The fix is simple: as mdopen only zero initializes some data, we call it before trying to retrieve the principal key. This way the failure happens after every data structure is set up properly.