### PR TITLE
Remove 'debug' option from CI matrix

### DIFF
--- a/.github/workflows/psp-matrix.yml
+++ b/.github/workflows/psp-matrix.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: ['ubuntu-22.04']
         compiler: [gcc, clang]
-        build_type: [debug,debugoptimized]
+        build_type: [debugoptimized]
         build_script: [make, meson]
     uses: ./.github/workflows/psp-reusable.yml
     with:


### PR DESCRIPTION
There is no need to run both 'debug' and 'debugoptimized' variants in CI. 'debugoptimized' gives us everything that needed for CI run.

This PR requires repo settings update, as some `debug` jobs are marked as `required`