### PR TITLE
[PG-1583, PG-1600] Do not unnecessarily try to fetch the principal key

### DIFF
--- a/contrib/pg_tde/src/common/pg_tde_utils.c
+++ b/contrib/pg_tde/src/common/pg_tde_utils.c
@@ -29,7 +29,7 @@ pg_tde_is_encrypted(PG_FUNCTION_ARGS)
 	LOCKMODE	lockmode = AccessShareLock;
 	Relation	rel = relation_open(relationOid, lockmode);
 	RelFileLocatorBackend rlocator = {.locator = rel->rd_locator,.backend = rel->rd_backend};
-	InternalKey *key;
+	bool		result;
 
 	if (!RELKIND_HAS_STORAGE(rel->rd_rel->relkind))
 	{
@@ -42,11 +42,11 @@ pg_tde_is_encrypted(PG_FUNCTION_ARGS)
 				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				errmsg("we cannot check if temporary relations from other backends are encrypted"));
 
-	key = GetSMGRRelationKey(rlocator);
+	result = IsSMGRRelationEncrypted(rlocator);
 
 	relation_close(rel, lockmode);
 
-	PG_RETURN_BOOL(key != NULL);
+	PG_RETURN_BOOL(result);
 }
 
 #endif							/* !FRONTEND */

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -109,6 +109,7 @@ pg_tde_set_db_file_path(Oid dbOid, char *path)
 	join_path_components(path, pg_tde_get_data_dir(), psprintf(PG_TDE_MAP_FILENAME, dbOid));
 }
 
+extern bool IsSMGRRelationEncrypted(RelFileLocatorBackend rel);
 extern InternalKey *GetSMGRRelationKey(RelFileLocatorBackend rel);
 extern int	pg_tde_count_relations(Oid dbOid);
 

--- a/contrib/pg_tde/t/001_basic.pl
+++ b/contrib/pg_tde/t/001_basic.pl
@@ -24,7 +24,7 @@ PGTDE::psql($node, 'postgres',
 );
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');"
+	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_001_basic.per');"
 );
 
 PGTDE::psql($node, 'postgres',
@@ -56,6 +56,12 @@ my $strings = 'CONTAINS FOO (should be empty): ';
 $strings .= `strings $tablefile | grep foo`;
 PGTDE::append_to_result_file($strings);
 
+
+# An encrypted table can be dropped even if we don't have access to the principal key.
+$node->stop;
+unlink('/tmp/pg_tde_test_001_basic.per');
+$node->start;
+PGTDE::psql($node, 'postgres', 'SELECT pg_tde_verify_key()');
 PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc;');
 
 PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');

--- a/contrib/pg_tde/t/expected/001_basic.out
+++ b/contrib/pg_tde/t/expected/001_basic.out
@@ -8,7 +8,7 @@ SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_tde';
 CREATE TABLE test_enc (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;
 psql:<stdin>:1: ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_key before using encrypted tables
-SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_001_basic.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
                                      1
@@ -39,5 +39,7 @@ SELECT * FROM test_enc ORDER BY id;
 
 TABLEFILE FOUND: yes
 CONTAINS FOO (should be empty): 
+SELECT pg_tde_verify_key()
+psql:<stdin>:1: ERROR:  failed to retrieve principal key test-db-key from keyring with ID 1
 DROP TABLE test_enc;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -121,7 +121,11 @@ SELECT * FROM test_enc ORDER BY id;
 SELECT pg_tde_verify_key();
 psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
 SELECT pg_tde_is_encrypted('test_enc');
-psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
 psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
 -- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_3.per
@@ -191,7 +195,11 @@ SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_p
 SELECT pg_tde_verify_key();
 psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, incorrect principal key or corrupted key file
 SELECT pg_tde_is_encrypted('test_enc');
-psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, incorrect principal key or corrupted key file
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
 psql:<stdin>:1: ERROR:  Failed to verify principal key header for key test-key, incorrect principal key or corrupted key file
 CREATE TABLE test_enc2 (id serial, k integer, PRIMARY KEY (id)) USING tde_heap;

--- a/src/bin/pg_checksums/pg_checksums.c
+++ b/src/bin/pg_checksums/pg_checksums.c
@@ -141,7 +141,7 @@ is_pg_tde_encypted(Oid spcOid, Oid dbOid, RelFileNumber relNumber)
 	RelFileLocator locator = {.spcOid = spcOid, .dbOid = dbOid,.relNumber = relNumber};
 	RelFileLocatorBackend rlocator = {.locator = locator,.backend = INVALID_PROC_NUMBER};
 
-	return GetSMGRRelationKey(rlocator) != NULL;
+	return IsSMGRRelationEncrypted(rlocator);
 }
 #endif
 


### PR DESCRIPTION
`tde_mdopen()` and `tde_mdunlink()` can be called after the transaction is committed, in which case it's too late to abort the transaction with ereport(ERROR) if we fail to fetch the principal key.

This PR defers the loading of relation keys until they're actually needed, so that we won't unnecessarily try to fetch the principal key.

There is obviously room for optimizations here, for example by caching the still encrypted relation keys instead of looking them up in the map file again when they're actually needed. But this is not included in this PR as we have [PG-1436](https://perconadev.atlassian.net/browse/PG-1436) for investigating the performance of this caching.

[PG-1436]: https://perconadev.atlassian.net/browse/PG-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ