### PR TITLE
Always kill web servers used in tests

### DIFF
--- a/contrib/pg_tde/t/003_remote_config.pl
+++ b/contrib/pg_tde/t/003_remote_config.pl
@@ -49,6 +49,7 @@ use pgtde;
 }
 
 my $pid = MyWebServer->new(8888)->background();
+END { kill('TERM', $pid); }
 
 PGTDE::setup_files_dir(basename($0));
 
@@ -84,8 +85,6 @@ PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');
 PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
 $node->stop;
-
-kill('TERM', $pid);
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();

--- a/contrib/pg_tde/t/006_remote_vault_config.pl
+++ b/contrib/pg_tde/t/006_remote_vault_config.pl
@@ -58,6 +58,7 @@ use pgtde;
 }
 
 my $pid = MyWebServer->new(8889)->background();
+END { kill('TERM', $pid); }
 
 PGTDE::setup_files_dir(basename($0));
 
@@ -93,8 +94,6 @@ PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc2;');
 PGTDE::psql($node, 'postgres', 'DROP EXTENSION pg_tde;');
 
 $node->stop;
-
-kill('TERM', $pid);
 
 # Compare the expected and out file
 my $compare = PGTDE->compare_results();


### PR DESCRIPTION
Previously these processes would stay around if the test script crashed or was otherwise aborted before reaching the kill command.