### PR TITLE
Fix build when cassert is not set

### DIFF
--- a/contrib/pg_tde/src/encryption/enc_aes.c
+++ b/contrib/pg_tde/src/encryption/enc_aes.c
@@ -48,18 +48,12 @@ static const EVP_CIPHER *cipher_ctr_ecb = NULL;
 void
 AesInit(void)
 {
-	static bool initialized = false;
-
-	Assert(!initialized);
-
 	OpenSSL_add_all_algorithms();
 	ERR_load_crypto_strings();
 
 	cipher_cbc = EVP_aes_128_cbc();
 	cipher_gcm = EVP_aes_128_gcm();
 	cipher_ctr_ecb = EVP_aes_128_ecb();
-
-	initialized = true;
 }
 
 static void

--- a/contrib/pg_tde/src/keyring/keyring_kmip.c
+++ b/contrib/pg_tde/src/keyring/keyring_kmip.c
@@ -103,11 +103,9 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 {
 	KmipCtx		ctx;
 	KmipKeyring *kmip_keyring = (KmipKeyring *) keyring;
-	bool		sslresult;
 	int			result;
 
-	sslresult = kmipSslConnect(&ctx, kmip_keyring, true);
-	Assert(sslresult);
+	kmipSslConnect(&ctx, kmip_keyring, true);
 
 	result = pg_tde_kmip_set_by_name(ctx.bio, key->name, key->data.data, key->data.len);
 


### PR DESCRIPTION
Variables that are only ever used for `Assert()` breaks the build when asserts aren't enabled, as the compiler complains about unused variables.