### PR TITLE
Sleep after killing server in replication test

### DIFF
--- a/contrib/pg_tde/t/012_replication.pl
+++ b/contrib/pg_tde/t/012_replication.pl
@@ -75,6 +75,8 @@ PGTDE::psql($primary, 'postgres',
 PGTDE::psql($primary, 'postgres',
 	"ALTER SYSTEM SET pg_tde.wal_encrypt = 'on';");
 $primary->kill9;
+# Sleep to ensure we don't try to start the server again before it's been properly killed.
+sleep(1);
 
 PGTDE::append_to_result_file("-- primary start");
 $primary->start;


### PR DESCRIPTION
This test often failed in CI, and I believe the cause is that we tried to start the cluster again before it had been fully killed.

```
2025-05-19 16:52:15.366 UTC [17639] 012_replication.pl LOG:  statement: ALTER SYSTEM SET pg_tde.wal_encrypt = 'on';
2025-05-19 16:52:15.418 UTC [17643] FATAL:  pre-existing shared memory block (key 341122, ID 34) is still in use
2025-05-19 16:52:15.418 UTC [17643] HINT:  Terminate any old server processes associated with data directory "/home/runner/work/postgres/postgres/contrib/pg_tde/tmp_check/t_012_replication_primary_data/pgdata".
```