### PR TITLE
Ensure the cluster process is dead in tests

### DIFF
--- a/contrib/pg_tde/t/011_unlogged_tables.pl
+++ b/contrib/pg_tde/t/011_unlogged_tables.pl
@@ -30,7 +30,8 @@ PGTDE::psql($node, 'postgres', "INSERT INTO t SELECT generate_series(1, 4);");
 PGTDE::psql($node, 'postgres', "CHECKPOINT;");
 
 PGTDE::append_to_result_file("-- kill -9");
-$node->kill9();
+while (kill(9, $node->{_pid}) != 0) { sleep 0.1; }
+$node->kill9;
 
 PGTDE::append_to_result_file("-- server start");
 $node->start;

--- a/contrib/pg_tde/t/012_replication.pl
+++ b/contrib/pg_tde/t/012_replication.pl
@@ -74,6 +74,7 @@ PGTDE::psql($primary, 'postgres',
 
 PGTDE::psql($primary, 'postgres',
 	"ALTER SYSTEM SET pg_tde.wal_encrypt = 'on';");
+while (kill(9, $primary->{_pid}) != 0) { sleep 0.1; }
 $primary->kill9;
 
 PGTDE::append_to_result_file("-- primary start");

--- a/contrib/pg_tde/t/013_crash_recovery.pl
+++ b/contrib/pg_tde/t/013_crash_recovery.pl
@@ -46,6 +46,7 @@ PGTDE::psql($node, 'postgres', "INSERT INTO test_plain (x) VALUES (3), (4);");
 PGTDE::psql($node, 'postgres', "ALTER SYSTEM SET pg_tde.wal_encrypt = 'on';");
 
 PGTDE::append_to_result_file("-- kill -9");
+while (kill(9, $node->{_pid}) != 0) { sleep 0.1; }
 $node->kill9;
 
 PGTDE::append_to_result_file("-- server start");
@@ -60,6 +61,7 @@ PGTDE::psql($node, 'postgres',
 );
 PGTDE::psql($node, 'postgres', "INSERT INTO test_enc (x) VALUES (3), (4);");
 PGTDE::append_to_result_file("-- kill -9");
+while (kill(9, $node->{_pid}) != 0) { sleep 0.1; }
 $node->kill9;
 PGTDE::append_to_result_file("-- server start");
 PGTDE::append_to_result_file(
@@ -76,6 +78,7 @@ PGTDE::psql($node, 'postgres',
 );
 PGTDE::psql($node, 'postgres', "INSERT INTO test_enc (x) VALUES (5), (6);");
 PGTDE::append_to_result_file("-- kill -9");
+while (kill(9, $node->{_pid}) != 0) { sleep 0.1; }
 $node->kill9;
 PGTDE::append_to_result_file("-- server start");
 PGTDE::append_to_result_file(
@@ -88,6 +91,7 @@ PGTDE::psql($node, 'postgres', "TABLE test_enc;");
 PGTDE::psql($node, 'postgres',
 	"CREATE TABLE test_enc2 (x int PRIMARY KEY) USING tde_heap;");
 PGTDE::append_to_result_file("-- kill -9");
+while (kill(9, $node->{_pid}) != 0) { sleep 0.1; }
 $node->kill9;
 PGTDE::append_to_result_file("-- server start");
 PGTDE::append_to_result_file(


### PR DESCRIPTION
Sometimes kill -9 might take a bit longer than what it takes for us to restart the server. Re-signal the process until there is no process to signal.

Also do run $node->kill9 after it's already dead in order to ensure the pid in the $node object is cleared.

This is to fix the CI failures these tests often had.

This is an alternative idea to #348