### PR TITLE
Ensure the cluster process is dead in tests

### DIFF
--- a/contrib/pg_tde/t/011_unlogged_tables.pl
+++ b/contrib/pg_tde/t/011_unlogged_tables.pl
@@ -30,7 +30,7 @@ PGTDE::psql($node, 'postgres', "INSERT INTO t SELECT generate_series(1, 4);");
 PGTDE::psql($node, 'postgres', "CHECKPOINT;");
 
 PGTDE::append_to_result_file("-- kill -9");
-$node->kill9();
+PGTDE::kill9_until_dead($node);
 
 PGTDE::append_to_result_file("-- server start");
 $node->start;

--- a/contrib/pg_tde/t/012_replication.pl
+++ b/contrib/pg_tde/t/012_replication.pl
@@ -74,7 +74,7 @@ PGTDE::psql($primary, 'postgres',
 
 PGTDE::psql($primary, 'postgres',
 	"ALTER SYSTEM SET pg_tde.wal_encrypt = 'on';");
-$primary->kill9;
+PGTDE::kill9_until_dead($primary);
 
 PGTDE::append_to_result_file("-- primary start");
 $primary->start;

--- a/contrib/pg_tde/t/013_crash_recovery.pl
+++ b/contrib/pg_tde/t/013_crash_recovery.pl
@@ -46,7 +46,7 @@ PGTDE::psql($node, 'postgres', "INSERT INTO test_plain (x) VALUES (3), (4);");
 PGTDE::psql($node, 'postgres', "ALTER SYSTEM SET pg_tde.wal_encrypt = 'on';");
 
 PGTDE::append_to_result_file("-- kill -9");
-$node->kill9;
+PGTDE::kill9_until_dead($node);
 
 PGTDE::append_to_result_file("-- server start");
 $node->start;
@@ -60,7 +60,7 @@ PGTDE::psql($node, 'postgres',
 );
 PGTDE::psql($node, 'postgres', "INSERT INTO test_enc (x) VALUES (3), (4);");
 PGTDE::append_to_result_file("-- kill -9");
-$node->kill9;
+PGTDE::kill9_until_dead($node);
 PGTDE::append_to_result_file("-- server start");
 PGTDE::append_to_result_file(
 	"-- check that pg_tde_save_principal_key_redo hasn't destroyed a WAL key created during the server start"
@@ -76,7 +76,7 @@ PGTDE::psql($node, 'postgres',
 );
 PGTDE::psql($node, 'postgres', "INSERT INTO test_enc (x) VALUES (5), (6);");
 PGTDE::append_to_result_file("-- kill -9");
-$node->kill9;
+PGTDE::kill9_until_dead($node);
 PGTDE::append_to_result_file("-- server start");
 PGTDE::append_to_result_file(
 	"-- check that the key rotation hasn't destroyed a WAL key created during the server start"
@@ -88,7 +88,7 @@ PGTDE::psql($node, 'postgres', "TABLE test_enc;");
 PGTDE::psql($node, 'postgres',
 	"CREATE TABLE test_enc2 (x int PRIMARY KEY) USING tde_heap;");
 PGTDE::append_to_result_file("-- kill -9");
-$node->kill9;
+PGTDE::kill9_until_dead($node);
 PGTDE::append_to_result_file("-- server start");
 PGTDE::append_to_result_file(
 	"-- check redo of the smgr internal key creation when the key is on disk"

--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -37,6 +37,23 @@ sub psql
 	}
 }
 
+sub kill9_until_dead
+{
+	my ($node) = @_;
+
+	return unless defined $node->{_pid};    # Cluster already stopped
+
+	my $pid = $node->{_pid};
+	$node->kill9;
+
+	# Wait for process to actually die.
+	while (kill(0, $pid) != 0)
+	{
+		sleep(0.1);
+	}
+}
+
+
 sub append_to_result_file
 {
 	my ($str) = @_;


### PR DESCRIPTION
Sometimes kill -9 might take a bit longer than what it takes for us to restart the server. Wait for the process to actually die before continuing.

This is to fix the CI failures these tests often had.

I have now slept on this and isn't as annoyed as I was yesterday :laughing: . I think this is the better solution.

Replaces #348 and #349 