### PR TITLE
Make check for temporary table owned by other backend idiomatic

### DIFF
--- a/contrib/pg_tde/src/common/pg_tde_utils.c
+++ b/contrib/pg_tde/src/common/pg_tde_utils.c
@@ -37,7 +37,7 @@ pg_tde_is_encrypted(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 	}
 
-	if (RelFileLocatorBackendIsTemp(rlocator) && !rel->rd_islocaltemp)
+	if (RELATION_IS_OTHER_TEMP(rel))
 		ereport(ERROR,
 				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				errmsg("we cannot check if temporary relations from other backends are encrypted"));


### PR DESCRIPTION
Instead of doing it our own way do the way the rest of the code does it.