### PR TITLE
PG-1617 Remove relation key cache

### DIFF
--- a/contrib/pg_tde/expected/insert_update_delete.out
+++ b/contrib/pg_tde/expected/insert_update_delete.out
@@ -91,4 +91,18 @@ SELECT * FROM albums;
 (12 rows)
 
 DROP TABLE albums;
+CREATE TEMPORARY TABLE animals (
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    type TEXT UNIQUE,
+    num INT
+) USING tde_heap;
+INSERT INTO animals (type, num) VALUES ('cows', 3), ('pigs', 11);
+SELECT * FROM animals ORDER BY id;
+ id | type | num 
+----+------+-----
+  1 | cows |   3
+  2 | pigs |  11
+(2 rows)
+
+DROP TABLE animals;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -11,52 +11,65 @@ SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
  
 (1 row)
 
-CREATE TABLE test_enc(
-	  id SERIAL,
-	  k INTEGER DEFAULT '0' NOT NULL,
-	  PRIMARY KEY (id)
-	) USING tde_heap;
-CREATE TABLE test_norm(
-	  id SERIAL,
-	  k INTEGER DEFAULT '0' NOT NULL,
-	  PRIMARY KEY (id)
-	) USING heap;
-CREATE TABLE test_part(
-	  id SERIAL,
-	  k INTEGER DEFAULT '0' NOT NULL,
-	  PRIMARY KEY (id)
-	) PARTITION BY RANGE (id) USING tde_heap;
-SELECT relname, amname FROM pg_class JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname IN ('test_enc', 'test_norm', 'test_part') ORDER BY relname;
-  relname  |  amname  
------------+----------
- test_enc  | tde_heap
- test_norm | heap
- test_part | tde_heap
-(3 rows)
+CREATE TABLE test_enc (
+  id SERIAL,
+  PRIMARY KEY (id)
+) USING tde_heap;
+CREATE TABLE test_norm (
+  id SERIAL,
+  PRIMARY KEY (id)
+) USING heap;
+CREATE TABLE test_part (
+  id SERIAL,
+  PRIMARY KEY (id)
+) PARTITION BY RANGE (id) USING tde_heap;
+CREATE TEMP TABLE test_temp_enc (
+  id SERIAL,
+  PRIMARY KEY (id)
+) USING tde_heap;
+CREATE TEMP TABLE test_temp_norm (
+  id SERIAL,
+  PRIMARY KEY (id)
+) USING heap;
+SELECT relname, amname FROM pg_class JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname IN ('test_enc', 'test_norm', 'test_part', 'test_temp_enc', 'test_temp_norm') ORDER BY relname;
+    relname     |  amname  
+----------------+----------
+ test_enc       | tde_heap
+ test_norm      | heap
+ test_part      | tde_heap
+ test_temp_enc  | tde_heap
+ test_temp_norm | heap
+(5 rows)
 
-SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc'), ('test_norm'), ('test_part')) AS r (relname) ORDER BY relname;
-  relname  | pg_tde_is_encrypted 
------------+---------------------
- test_enc  | t
- test_norm | f
- test_part | 
-(3 rows)
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc'), ('test_norm'), ('test_part'), ('test_temp_enc'), ('test_temp_norm')) AS r (relname) ORDER BY relname;
+    relname     | pg_tde_is_encrypted 
+----------------+---------------------
+ test_enc       | t
+ test_norm      | f
+ test_part      | 
+ test_temp_enc  | t
+ test_temp_norm | f
+(5 rows)
 
-SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_id_seq'), ('test_norm_id_seq'), ('test_part_id_seq')) AS r (relname) ORDER BY relname;
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_id_seq'), ('test_norm_id_seq'), ('test_part_id_seq'), ('test_temp_enc'), ('test_temp_norm')) AS r (relname) ORDER BY relname;
      relname      | pg_tde_is_encrypted 
 ------------------+---------------------
  test_enc_id_seq  | t
  test_norm_id_seq | f
  test_part_id_seq | t
-(3 rows)
+ test_temp_enc    | t
+ test_temp_norm   | f
+(5 rows)
 
-SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_pkey'), ('test_norm_pkey'), ('test_part_pkey')) AS r (relname) ORDER BY relname;
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_pkey'), ('test_norm_pkey'), ('test_part_pkey'), ('test_temp_enc'), ('test_temp_norm')) AS r (relname) ORDER BY relname;
     relname     | pg_tde_is_encrypted 
 ----------------+---------------------
  test_enc_pkey  | t
  test_norm_pkey | f
  test_part_pkey | 
-(3 rows)
+ test_temp_enc  | t
+ test_temp_norm | f
+(5 rows)
 
 SELECT pg_tde_is_encrypted(NULL);
  pg_tde_is_encrypted 
@@ -71,6 +84,8 @@ SELECT key_provider_id, key_provider_name, key_name
                1 | file-vault        | test-db-key
 (1 row)
 
+DROP TABLE test_temp_norm;
+DROP TABLE test_temp_enc;
 DROP TABLE test_part;
 DROP TABLE test_norm;
 DROP TABLE test_enc;

--- a/contrib/pg_tde/sql/insert_update_delete.sql
+++ b/contrib/pg_tde/sql/insert_update_delete.sql
@@ -38,4 +38,16 @@ UPDATE albums SET released='2020-04-01' WHERE id=2;
 SELECT * FROM albums;
 
 DROP TABLE albums;
+
+CREATE TEMPORARY TABLE animals (
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    type TEXT UNIQUE,
+    num INT
+) USING tde_heap;
+
+INSERT INTO animals (type, num) VALUES ('cows', 3), ('pigs', 11);
+SELECT * FROM animals ORDER BY id;
+
+DROP TABLE animals;
+
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
+++ b/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
@@ -3,37 +3,46 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');
 
-CREATE TABLE test_enc(
-	  id SERIAL,
-	  k INTEGER DEFAULT '0' NOT NULL,
-	  PRIMARY KEY (id)
-	) USING tde_heap;
+CREATE TABLE test_enc (
+  id SERIAL,
+  PRIMARY KEY (id)
+) USING tde_heap;
 
-CREATE TABLE test_norm(
-	  id SERIAL,
-	  k INTEGER DEFAULT '0' NOT NULL,
-	  PRIMARY KEY (id)
-	) USING heap;
+CREATE TABLE test_norm (
+  id SERIAL,
+  PRIMARY KEY (id)
+) USING heap;
 
-CREATE TABLE test_part(
-	  id SERIAL,
-	  k INTEGER DEFAULT '0' NOT NULL,
-	  PRIMARY KEY (id)
-	) PARTITION BY RANGE (id) USING tde_heap;
+CREATE TABLE test_part (
+  id SERIAL,
+  PRIMARY KEY (id)
+) PARTITION BY RANGE (id) USING tde_heap;
 
-SELECT relname, amname FROM pg_class JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname IN ('test_enc', 'test_norm', 'test_part') ORDER BY relname;
+CREATE TEMP TABLE test_temp_enc (
+  id SERIAL,
+  PRIMARY KEY (id)
+) USING tde_heap;
 
-SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc'), ('test_norm'), ('test_part')) AS r (relname) ORDER BY relname;
+CREATE TEMP TABLE test_temp_norm (
+  id SERIAL,
+  PRIMARY KEY (id)
+) USING heap;
 
-SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_id_seq'), ('test_norm_id_seq'), ('test_part_id_seq')) AS r (relname) ORDER BY relname;
+SELECT relname, amname FROM pg_class JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname IN ('test_enc', 'test_norm', 'test_part', 'test_temp_enc', 'test_temp_norm') ORDER BY relname;
 
-SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_pkey'), ('test_norm_pkey'), ('test_part_pkey')) AS r (relname) ORDER BY relname;
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc'), ('test_norm'), ('test_part'), ('test_temp_enc'), ('test_temp_norm')) AS r (relname) ORDER BY relname;
+
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_id_seq'), ('test_norm_id_seq'), ('test_part_id_seq'), ('test_temp_enc'), ('test_temp_norm')) AS r (relname) ORDER BY relname;
+
+SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_pkey'), ('test_norm_pkey'), ('test_part_pkey'), ('test_temp_enc'), ('test_temp_norm')) AS r (relname) ORDER BY relname;
 
 SELECT pg_tde_is_encrypted(NULL);
 
 SELECT key_provider_id, key_provider_name, key_name
     FROM pg_tde_key_info();
 
+DROP TABLE test_temp_norm;
+DROP TABLE test_temp_enc;
 DROP TABLE test_part;
 DROP TABLE test_norm;
 DROP TABLE test_enc;

--- a/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
@@ -314,11 +314,11 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 		elog(DEBUG1, "WAL key %X/%X-%X/%X, encrypted: %s",
 			 LSN_FORMAT_ARGS(curr_key->start_lsn),
 			 LSN_FORMAT_ARGS(curr_key->end_lsn),
-			 curr_key->key->type & TDE_KEY_TYPE_WAL_ENCRYPTED ? "yes" : "no");
+			 curr_key->key.type & TDE_KEY_TYPE_WAL_ENCRYPTED ? "yes" : "no");
 #endif
 
-		if (curr_key->key->start_lsn != InvalidXLogRecPtr &&
-			(curr_key->key->type & TDE_KEY_TYPE_WAL_ENCRYPTED))
+		if (curr_key->key.start_lsn != InvalidXLogRecPtr &&
+			(curr_key->key.type & TDE_KEY_TYPE_WAL_ENCRYPTED))
 		{
 			/*
 			 * Check if the key's range overlaps with the buffer's and decypt
@@ -334,7 +334,7 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 
 				Assert(dec_off >= offset);
 
-				CalcXLogPageIVPrefix(tli, segno, curr_key->key->base_iv, iv_prefix);
+				CalcXLogPageIVPrefix(tli, segno, curr_key->key.base_iv, iv_prefix);
 
 				/* We have reached the end of the segment */
 				if (dec_end == 0)
@@ -349,7 +349,7 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 					 dec_off, dec_off - offset, dec_sz, LSN_FORMAT_ARGS(curr_key->key->start_lsn));
 #endif
 				pg_tde_stream_crypt(iv_prefix, dec_off, dec_buf, dec_sz, dec_buf,
-									curr_key->key, &curr_key->crypt_ctx);
+									&curr_key->key, &curr_key->crypt_ctx);
 
 				if (dec_off + dec_sz == offset)
 				{

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -90,7 +90,6 @@ extern void pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path
 extern InternalKey *pg_tde_create_smgr_key(const RelFileLocatorBackend *newrlocator);
 extern void pg_tde_create_smgr_key_perm_redo(const RelFileLocator *newrlocator);
 extern void pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocator, uint32 flags);
-extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator);
 
 #define PG_TDE_MAP_FILENAME			"%d_keys"
 
@@ -102,6 +101,8 @@ pg_tde_set_db_file_path(Oid dbOid, char *path)
 
 extern bool IsSMGRRelationEncrypted(RelFileLocatorBackend rel);
 extern InternalKey *GetSMGRRelationKey(RelFileLocatorBackend rel);
+extern void DeleteSMGRRelationKey(RelFileLocatorBackend rel);
+
 extern int	pg_tde_count_relations(Oid dbOid);
 
 extern void pg_tde_delete_tde_files(Oid dbOid);

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -66,20 +66,15 @@ typedef struct XLogRelKey
 } XLogRelKey;
 
 /*
- * WALKeyCacheRec is built on top of the InternalKeys cache. We still don't
- * want to key data be swapped out to the disk (implemented in the InternalKeys
- * cache) but we need extra information and the ability to have and reference
- * a sequence of keys.
- *
  * TODO: For now it's a simple linked list which is no good. So consider having
- * 			dedicated WAL keys cache inside some proper data structure.
+ * 		 dedicated WAL keys cache inside some proper data structure.
  */
 typedef struct WALKeyCacheRec
 {
 	XLogRecPtr	start_lsn;
 	XLogRecPtr	end_lsn;
 
-	InternalKey *key;
+	InternalKey key;
 	void	   *crypt_ctx;
 
 	struct WALKeyCacheRec *next;

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -161,8 +161,8 @@ tde_mdunlink(RelFileLocatorBackend rlocator, ForkNumber forknum, bool isRedo)
 	 */
 	if (forknum == MAIN_FORKNUM || forknum == InvalidForkNumber)
 	{
-		if (!RelFileLocatorBackendIsTemp(rlocator) && IsSMGRRelationEncrypted(rlocator))
-			pg_tde_free_key_map_entry(&rlocator.locator);
+		if (IsSMGRRelationEncrypted(rlocator))
+			DeleteSMGRRelationKey(rlocator);
 	}
 }
 


### PR DESCRIPTION
Since the relation keys are cached in the SMGR cache (or arguably the relation cache) the double layers of caching only complicated the code and caused an issue with possible key re-use or even data corruption on oid wraparound.
    
This will slow down some code paths like `pg_tde_is_encrypted()` but the code simplification and fixing of the oid wraparound bug makes it worth it and some of that performance loss can be added back in future commits.

This loses us the `mlock()` protection of the relation keys in the cache but since the keys in the SMGR were not protected anyway this is not a significant loss.

We previously abused the cache to implement encryption of temporary tables so that we now solve with a hash table where we delete entries when the table is dropped protecting us against the wraparound bug.

We also previously stored WAL keys in the relation cache as a clever trick to `mlock()` them so that protection we lose, but since protection were far from perfect I think this is fine.