### PR TITLE
Always write WAL record when principal key saved to key map file

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -327,7 +327,7 @@ pg_tde_save_principal_key_redo(const TDESignedPrincipalKeyInfo *signed_key_info)
  * The caller must have an EXCLUSIVE LOCK on the files before calling this function.
  */
 void
-pg_tde_save_principal_key(const TDEPrincipalKey *principal_key, bool write_xlog)
+pg_tde_save_principal_key(const TDEPrincipalKey *principal_key)
 {
 	int			map_fd;
 	off_t		curr_pos = 0;
@@ -340,12 +340,9 @@ pg_tde_save_principal_key(const TDEPrincipalKey *principal_key, bool write_xlog)
 
 	pg_tde_sign_principal_key_info(&signed_key_Info, principal_key);
 
-	if (write_xlog)
-	{
-		XLogBeginInsert();
-		XLogRegisterData((char *) &signed_key_Info, sizeof(TDESignedPrincipalKeyInfo));
-		XLogInsert(RM_TDERMGR_ID, XLOG_TDE_ADD_PRINCIPAL_KEY);
-	}
+	XLogBeginInsert();
+	XLogRegisterData((char *) &signed_key_Info, sizeof(TDESignedPrincipalKeyInfo));
+	XLogInsert(RM_TDERMGR_ID, XLOG_TDE_ADD_PRINCIPAL_KEY);
 
 	map_fd = pg_tde_open_file_write(db_map_path, &signed_key_Info, true, &curr_pos);
 	close(map_fd);

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -309,7 +309,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 	if (!already_has_key)
 	{
 		/* First key created for the database */
-		pg_tde_save_principal_key(new_principal_key, true);
+		pg_tde_save_principal_key(new_principal_key);
 		push_principal_key_to_cache(new_principal_key);
 	}
 	else
@@ -842,7 +842,7 @@ GetPrincipalKey(Oid dbOid, LWLockMode lockMode)
 	*newPrincipalKey = *principalKey;
 	newPrincipalKey->keyInfo.databaseId = dbOid;
 
-	pg_tde_save_principal_key(newPrincipalKey, false);
+	pg_tde_save_principal_key(newPrincipalKey);
 
 	push_principal_key_to_cache(newPrincipalKey);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -109,7 +109,7 @@ extern void pg_tde_delete_tde_files(Oid dbOid);
 
 extern TDESignedPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
 extern bool pg_tde_verify_principal_key_info(TDESignedPrincipalKeyInfo *signed_key_info, const TDEPrincipalKey *principal_key);
-extern void pg_tde_save_principal_key(const TDEPrincipalKey *principal_key, bool write_xlog);
+extern void pg_tde_save_principal_key(const TDEPrincipalKey *principal_key);
 extern void pg_tde_save_principal_key_redo(const TDESignedPrincipalKeyInfo *signed_key_info);
 extern void pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key, bool write_xlog);
 


### PR DESCRIPTION
WAL record skip was added as an optimization for cases where default key used for encription. We remove it to keep code simple.