### PR TITLE
Move SMGR code out of `pg_tde_tdemap.c`

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -25,6 +25,7 @@
 
 #include "access/pg_tde_xlog.h"
 #include "encryption/enc_tde.h"
+#include "smgr/pg_tde_smgr.h"
 
 static void tdeheap_rmgr_redo(XLogReaderState *record);
 static void tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record);
@@ -52,7 +53,7 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 	{
 		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
 
-		pg_tde_create_smgr_key_perm_redo(&xlrec->rlocator);
+		tde_smgr_create_key_redo(&xlrec->rlocator);
 	}
 	else if (info == XLOG_TDE_ADD_PRINCIPAL_KEY)
 	{

--- a/contrib/pg_tde/src/common/pg_tde_utils.c
+++ b/contrib/pg_tde/src/common/pg_tde_utils.c
@@ -16,8 +16,7 @@
 
 #ifndef FRONTEND
 #include "fmgr.h"
-#include "catalog/pg_class.h"
-#include "access/pg_tde_tdemap.h"
+#include "smgr/pg_tde_smgr.h"
 #include "access/relation.h"
 #include "utils/rel.h"
 
@@ -28,7 +27,6 @@ pg_tde_is_encrypted(PG_FUNCTION_ARGS)
 	Oid			relationOid = PG_GETARG_OID(0);
 	LOCKMODE	lockmode = AccessShareLock;
 	Relation	rel = relation_open(relationOid, lockmode);
-	RelFileLocatorBackend rlocator = {.locator = rel->rd_locator,.backend = rel->rd_backend};
 	bool		result;
 
 	if (!RELKIND_HAS_STORAGE(rel->rd_rel->relkind))
@@ -42,7 +40,7 @@ pg_tde_is_encrypted(PG_FUNCTION_ARGS)
 				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				errmsg("we cannot check if temporary relations from other backends are encrypted"));
 
-	result = IsSMGRRelationEncrypted(rlocator);
+	result = tde_smgr_rel_is_encrypted(RelationGetSmgr(rel));
 
 	relation_close(rel, lockmode);
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -83,8 +83,6 @@ extern WALKeyCacheRec *pg_tde_fetch_wal_keys(XLogRecPtr start_lsn);
 extern WALKeyCacheRec *pg_tde_get_wal_cache_keys(void);
 extern void pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path);
 
-extern InternalKey *pg_tde_create_smgr_key(const RelFileLocatorBackend *newrlocator);
-extern void pg_tde_create_smgr_key_perm_redo(const RelFileLocator *newrlocator);
 extern void pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocator, TDEMapEntryType flags);
 
 #define PG_TDE_MAP_FILENAME			"%d_keys"
@@ -95,9 +93,10 @@ pg_tde_set_db_file_path(Oid dbOid, char *path)
 	join_path_components(path, pg_tde_get_data_dir(), psprintf(PG_TDE_MAP_FILENAME, dbOid));
 }
 
-extern bool IsSMGRRelationEncrypted(RelFileLocatorBackend rel);
-extern InternalKey *GetSMGRRelationKey(RelFileLocatorBackend rel);
-extern void DeleteSMGRRelationKey(RelFileLocatorBackend rel);
+extern void pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *key, bool write_xlog);
+extern bool pg_tde_has_smgr_key(RelFileLocator rel);
+extern InternalKey *pg_tde_get_smgr_key(RelFileLocator rel);
+extern void pg_tde_free_key_map_entry(RelFileLocator rel);
 
 extern int	pg_tde_count_relations(Oid dbOid);
 

--- a/contrib/pg_tde/src/include/encryption/enc_tde.h
+++ b/contrib/pg_tde/src/include/encryption/enc_tde.h
@@ -12,6 +12,7 @@
 
 #include "access/pg_tde_tdemap.h"
 
+extern void pg_tde_generate_internal_key(InternalKey *int_key, TDEMapEntryType entry_type);
 extern void pg_tde_stream_crypt(const char *iv_prefix, uint32 start_offset, const char *data, uint32 data_len, char *out, InternalKey *key, void **ctxPtr);
 
 #endif							/* ENC_TDE_H */

--- a/contrib/pg_tde/src/include/smgr/pg_tde_smgr.h
+++ b/contrib/pg_tde/src/include/smgr/pg_tde_smgr.h
@@ -9,6 +9,11 @@
 #ifndef PG_TDE_SMGR_H
 #define PG_TDE_SMGR_H
 
+#include "storage/relfilelocator.h"
+#include "storage/smgr.h"
+
 extern void RegisterStorageMgr(void);
+extern void tde_smgr_create_key_redo(const RelFileLocator *rlocator);
+extern bool tde_smgr_rel_is_encrypted(SMgrRelation reln);
 
 #endif							/* PG_TDE_SMGR_H */

--- a/src/bin/pg_checksums/pg_checksums.c
+++ b/src/bin/pg_checksums/pg_checksums.c
@@ -138,10 +138,9 @@ pg_tde_init(const char *datadir)
 static bool
 is_pg_tde_encypted(Oid spcOid, Oid dbOid, RelFileNumber relNumber)
 {
-	RelFileLocator locator = {.spcOid = spcOid, .dbOid = dbOid,.relNumber = relNumber};
-	RelFileLocatorBackend rlocator = {.locator = locator,.backend = INVALID_PROC_NUMBER};
+	RelFileLocator locator = {.spcOid = spcOid,.dbOid = dbOid,.relNumber = relNumber};
 
-	return IsSMGRRelationEncrypted(rlocator);
+	return pg_tde_has_smgr_key(locator);
 }
 #endif
 


### PR DESCRIPTION
Especially all code related to the keys of temporary tables did not  belong in the TDE map code and fit better in the SMGR code.
    
Additionally we speed up `pg_tde_is_encrypted()` by relying on the SMGR to cache the relations. This might in some cases lead to blow up of the SMGR relation cache if you query every relation in the database but given the small size I am not overly worried.

Also removes an optimization where we skipped trying to look for a key during SMGR open for catalog tables. It made the code harder to read and I do not think it was a very useful optimization.

So what do you think about the removed catalog optimization and the potential cache issue? Also I am not entirely happy with the naming of some of the functions.