### PR TITLE
Actually use the defines for IV and AEAD tag length

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -389,7 +389,7 @@ pg_tde_sign_principal_key_info(TDESignedPrincipalKeyInfo *signed_key_info, const
 {
 	signed_key_info->data = principal_key->keyInfo;
 
-	if (!RAND_bytes(signed_key_info->sign_iv, MAP_ENTRY_EMPTY_IV_SIZE))
+	if (!RAND_bytes(signed_key_info->sign_iv, MAP_ENTRY_IV_SIZE))
 		ereport(ERROR,
 				errcode(ERRCODE_INTERNAL_ERROR),
 				errmsg("could not generate iv for key map: %s", ERR_error_string(ERR_get_error(), NULL)));
@@ -405,7 +405,7 @@ pg_tde_initialize_map_entry(TDEMapEntry *map_entry, const TDEPrincipalKey *princ
 	map_entry->flags = rel_key_data->type;
 	map_entry->enc_key = *rel_key_data;
 
-	if (!RAND_bytes(map_entry->entry_iv, MAP_ENTRY_EMPTY_IV_SIZE))
+	if (!RAND_bytes(map_entry->entry_iv, MAP_ENTRY_IV_SIZE))
 		ereport(ERROR,
 				errcode(ERRCODE_INTERNAL_ERROR),
 				errmsg("could not generate iv for key map: %s", ERR_error_string(ERR_get_error(), NULL)));

--- a/contrib/pg_tde/src/encryption/enc_aes.c
+++ b/contrib/pg_tde/src/encryption/enc_aes.c
@@ -133,7 +133,7 @@ AesDecrypt(const unsigned char *key, const unsigned char *iv, const unsigned cha
 }
 
 void
-AesGcmEncrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *aad, int aad_len, const unsigned char *in, int in_len, unsigned char *out, unsigned char *tag)
+AesGcmEncrypt(const unsigned char *key, const unsigned char *iv, int iv_len, const unsigned char *aad, int aad_len, const unsigned char *in, int in_len, unsigned char *out, unsigned char *tag, int tag_len)
 {
 	int			out_len;
 	int			out_len_final;
@@ -153,7 +153,7 @@ AesGcmEncrypt(const unsigned char *key, const unsigned char *iv, const unsigned 
 		ereport(ERROR,
 				errmsg("EVP_CIPHER_CTX_set_padding failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
-	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 16, NULL) == 0)
+	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, iv_len, NULL) == 0)
 		ereport(ERROR,
 				errmsg("EVP_CTRL_GCM_SET_IVLEN failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
@@ -173,7 +173,7 @@ AesGcmEncrypt(const unsigned char *key, const unsigned char *iv, const unsigned 
 		ereport(ERROR,
 				errmsg("EVP_CipherFinal_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
-	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, tag) == 0)
+	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, tag_len, tag) == 0)
 		ereport(ERROR,
 				errmsg("EVP_CTRL_GCM_GET_TAG failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
@@ -189,7 +189,7 @@ AesGcmEncrypt(const unsigned char *key, const unsigned char *iv, const unsigned 
 }
 
 bool
-AesGcmDecrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *aad, int aad_len, const unsigned char *in, int in_len, unsigned char *out, unsigned char *tag)
+AesGcmDecrypt(const unsigned char *key, const unsigned char *iv, int iv_len, const unsigned char *aad, int aad_len, const unsigned char *in, int in_len, unsigned char *out, unsigned char *tag, int tag_len)
 {
 	int			out_len;
 	int			out_len_final;
@@ -208,7 +208,7 @@ AesGcmDecrypt(const unsigned char *key, const unsigned char *iv, const unsigned 
 		ereport(ERROR,
 				errmsg("EVP_CIPHER_CTX_set_padding failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
-	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 16, NULL) == 0)
+	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, iv_len, NULL) == 0)
 		ereport(ERROR,
 				errmsg("EVP_CTRL_GCM_SET_IVLEN failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
@@ -216,7 +216,7 @@ AesGcmDecrypt(const unsigned char *key, const unsigned char *iv, const unsigned 
 		ereport(ERROR,
 				errmsg("EVP_EncryptInit_ex failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 
-	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, tag) == 0)
+	if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, tag_len, tag) == 0)
 		ereport(ERROR,
 				errmsg("EVP_CTRL_GCM_SET_TAG failed. OpenSSL error: %s", ERR_error_string(ERR_get_error(), NULL)));
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -38,8 +38,8 @@ typedef struct InternalKey
 	(((key)->type & TDE_KEY_TYPE_WAL_UNENCRYPTED) != 0 || \
 	((key)->type & TDE_KEY_TYPE_WAL_ENCRYPTED) != 0)
 
-#define MAP_ENTRY_EMPTY_IV_SIZE 16
-#define MAP_ENTRY_EMPTY_AEAD_TAG_SIZE 16
+#define MAP_ENTRY_IV_SIZE 16
+#define MAP_ENTRY_AEAD_TAG_SIZE 16
 
 typedef struct
 {
@@ -56,8 +56,8 @@ typedef struct TDEMapEntry
 	uint32		flags;
 	InternalKey enc_key;
 	/* IV and tag used when encrypting the key itself */
-	unsigned char entry_iv[MAP_ENTRY_EMPTY_IV_SIZE];
-	unsigned char aead_tag[MAP_ENTRY_EMPTY_AEAD_TAG_SIZE];
+	unsigned char entry_iv[MAP_ENTRY_IV_SIZE];
+	unsigned char aead_tag[MAP_ENTRY_AEAD_TAG_SIZE];
 } TDEMapEntry;
 
 typedef struct XLogRelKey

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -44,8 +44,8 @@ typedef struct InternalKey
 typedef struct
 {
 	TDEPrincipalKeyInfo data;
-	unsigned char sign_iv[16];
-	unsigned char aead_tag[16];
+	unsigned char sign_iv[MAP_ENTRY_IV_SIZE];
+	unsigned char aead_tag[MAP_ENTRY_AEAD_TAG_SIZE];
 } TDESignedPrincipalKeyInfo;
 
 /* We do not need the dbOid since the entries are stored in a file per db */

--- a/contrib/pg_tde/src/include/encryption/enc_aes.h
+++ b/contrib/pg_tde/src/include/encryption/enc_aes.h
@@ -15,8 +15,8 @@
 extern void AesInit(void);
 extern void AesEncrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *in, int in_len, unsigned char *out);
 extern void AesDecrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *in, int in_len, unsigned char *out);
-extern void AesGcmEncrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *aad, int aad_len, const unsigned char *in, int in_len, unsigned char *out, unsigned char *tag);
-extern bool AesGcmDecrypt(const unsigned char *key, const unsigned char *iv, const unsigned char *aad, int aad_len, const unsigned char *in, int in_len, unsigned char *out, unsigned char *tag);
+extern void AesGcmEncrypt(const unsigned char *key, const unsigned char *iv, int iv_len, const unsigned char *aad, int aad_len, const unsigned char *in, int in_len, unsigned char *out, unsigned char *tag, int tag_len);
+extern bool AesGcmDecrypt(const unsigned char *key, const unsigned char *iv, int iv_len, const unsigned char *aad, int aad_len, const unsigned char *in, int in_len, unsigned char *out, unsigned char *tag, int tag_len);
 extern void AesCtrEncryptedZeroBlocks(void *ctxPtr, const unsigned char *key, const char *iv_prefix, uint64_t blockNumber1, uint64_t blockNumber2, unsigned char *out);
 
 #endif							/* ENC_AES_H */


### PR DESCRIPTION
The defines were only used in some places, in the rest we had a hardcoded 16.