### PR TITLE
Stop coalescing NULL to empty string in key provider functions

### DIFF
--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -17,7 +17,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_add_database_key_provider('file', provider_name,
-                json_object('path' VALUE COALESCE(file_path, '')));
+                json_object('path' VALUE file_path));
 END;
 
 CREATE FUNCTION pg_tde_add_database_key_provider_file(provider_name TEXT, file_path JSON)
@@ -41,10 +41,10 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_add_database_key_provider('vault-v2', provider_name,
-                            json_object('url' VALUE COALESCE(vault_url, ''),
-                            'tokenPath' VALUE COALESCE(vault_token_path, ''),
-                            'mountPath' VALUE COALESCE(vault_mount_path, ''),
-                            'caPath' VALUE COALESCE(vault_ca_path, '')));
+                            json_object('url' VALUE vault_url,
+                            'tokenPath' VALUE vault_token_path,
+                            'mountPath' VALUE vault_mount_path,
+                            'caPath' VALUE vault_ca_path));
 END;
 
 CREATE FUNCTION pg_tde_add_database_key_provider_kmip(provider_name TEXT,
@@ -59,11 +59,11 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_add_database_key_provider('kmip', provider_name,
-                            json_object('host' VALUE COALESCE(kmip_host, ''),
+                            json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
-                            'caPath' VALUE COALESCE(kmip_ca_path, ''),
-                            'certPath' VALUE COALESCE(kmip_cert_path, ''),
-                            'keyPath' VALUE COALESCE(kmip_key_path, '')));
+                            'caPath' VALUE kmip_ca_path,
+                            'certPath' VALUE kmip_cert_path,
+                            'keyPath' VALUE kmip_key_path));
 END;
 
 CREATE FUNCTION pg_tde_list_all_database_key_providers
@@ -100,7 +100,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_add_global_key_provider('file', provider_name,
-                json_object('path' VALUE COALESCE(file_path, '')));
+                json_object('path' VALUE file_path));
 END;
 
 CREATE FUNCTION pg_tde_add_global_key_provider_file(provider_name TEXT, file_path JSON)
@@ -124,10 +124,10 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_add_global_key_provider('vault-v2', provider_name,
-                            json_object('url' VALUE COALESCE(vault_url, ''),
-                            'tokenPath' VALUE COALESCE(vault_token_path, ''),
-                            'mountPath' VALUE COALESCE(vault_mount_path, ''),
-                            'caPath' VALUE COALESCE(vault_ca_path, '')));
+                            json_object('url' VALUE vault_url,
+                            'tokenPath' VALUE vault_token_path,
+                            'mountPath' VALUE vault_mount_path,
+                            'caPath' VALUE vault_ca_path));
 END;
 
 CREATE FUNCTION pg_tde_add_global_key_provider_kmip(provider_name TEXT,
@@ -142,11 +142,11 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_add_global_key_provider('kmip', provider_name,
-                            json_object('host' VALUE COALESCE(kmip_host, ''),
+                            json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
-                            'caPath' VALUE COALESCE(kmip_ca_path, ''),
-                            'certPath' VALUE COALESCE(kmip_cert_path, ''),
-                            'keyPath' VALUE COALESCE(kmip_key_path, '')));
+                            'caPath' VALUE kmip_ca_path,
+                            'certPath' VALUE kmip_cert_path,
+                            'keyPath' VALUE kmip_key_path));
 END;
 
 -- Key Provider Management
@@ -163,7 +163,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_change_database_key_provider('file', provider_name,
-                json_object('path' VALUE COALESCE(file_path, '')));
+                json_object('path' VALUE file_path));
 END;
 
 CREATE FUNCTION pg_tde_change_database_key_provider_file(provider_name TEXT, file_path JSON)
@@ -187,10 +187,10 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_change_database_key_provider('vault-v2', provider_name,
-                            json_object('url' VALUE COALESCE(vault_url, ''),
-                            'tokenPath' VALUE COALESCE(vault_token_path, ''),
-                            'mountPath' VALUE COALESCE(vault_mount_path, ''),
-                            'caPath' VALUE COALESCE(vault_ca_path, '')));
+                            json_object('url' VALUE vault_url,
+                            'tokenPath' VALUE vault_token_path,
+                            'mountPath' VALUE vault_mount_path,
+                            'caPath' VALUE vault_ca_path));
 END;
 
 CREATE FUNCTION pg_tde_change_database_key_provider_kmip(provider_name TEXT,
@@ -205,11 +205,11 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_change_database_key_provider('kmip', provider_name,
-                            json_object('host' VALUE COALESCE(kmip_host, ''),
+                            json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
-                            'caPath' VALUE COALESCE(kmip_ca_path, ''),
-                            'certPath' VALUE COALESCE(kmip_cert_path, ''),
-                            'keyPath' VALUE COALESCE(kmip_key_path, '')));
+                            'caPath' VALUE kmip_ca_path,
+                            'certPath' VALUE kmip_cert_path,
+                            'keyPath' VALUE kmip_key_path));
 END;
 
 -- Global Tablespace Key Provider Management
@@ -226,7 +226,7 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_file_keyring_provider_options function.
     SELECT pg_tde_change_global_key_provider('file', provider_name,
-                json_object('path' VALUE COALESCE(file_path, '')));
+                json_object('path' VALUE file_path));
 END;
 
 CREATE FUNCTION pg_tde_change_global_key_provider_file(provider_name TEXT, file_path JSON)
@@ -250,10 +250,10 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_vaultV2_keyring_provider_options function.
     SELECT pg_tde_change_global_key_provider('vault-v2', provider_name,
-                            json_object('url' VALUE COALESCE(vault_url, ''),
-                            'tokenPath' VALUE COALESCE(vault_token_path, ''),
-                            'mountPath' VALUE COALESCE(vault_mount_path, ''),
-                            'caPath' VALUE COALESCE(vault_ca_path, '')));
+                            json_object('url' VALUE vault_url,
+                            'tokenPath' VALUE vault_token_path,
+                            'mountPath' VALUE vault_mount_path,
+                            'caPath' VALUE vault_ca_path));
 END;
 
 CREATE FUNCTION pg_tde_change_global_key_provider_kmip(provider_name TEXT,
@@ -268,11 +268,11 @@ BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
     SELECT pg_tde_change_global_key_provider('kmip', provider_name,
-                            json_object('host' VALUE COALESCE(kmip_host, ''),
+                            json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
-                            'caPath' VALUE COALESCE(kmip_ca_path, ''),
-                            'certPath' VALUE COALESCE(kmip_cert_path, ''),
-                            'keyPath' VALUE COALESCE(kmip_key_path, '')));
+                            'caPath' VALUE kmip_ca_path,
+                            'certPath' VALUE kmip_cert_path,
+                            'keyPath' VALUE kmip_key_path));
 END;
 
 CREATE FUNCTION pg_tde_is_encrypted(relation REGCLASS)


### PR DESCRIPTION
Since we can pass NULL values in the functions which takes JSON it makes no sense to not do so in the functions which take text. By doing this we only risk not excercising some code paths.