### PR TITLE
Remove nonsensical comment

### DIFF
--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -262,7 +262,6 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 	 * This is the only function that gets called during actual CREATE
 	 * TABLE/INDEX (EVENT TRIGGER)
 	 */
-	/* so we create the key here by loading it */
 
 	mdcreate(relold, reln, forknum, isRedo);
 


### PR DESCRIPTION
This comment made sense when it was written, but the code has since changed a lot without the comment being maintained. Now it means nothing relevant to the current code.