### PR TITLE
Remove any existing keys for plaintext tables on create

### DIFF
--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -93,6 +93,7 @@ _PG_init(void)
 
 	check_percona_api_version();
 
+	pg_tde_init_data_dir();
 	AesInit();
 	TdeGucInit();
 	TdeEventCaptureInit();
@@ -113,8 +114,6 @@ _PG_init(void)
 static void
 extension_install(Oid databaseId)
 {
-	/* Initialize the TDE dir */
-	pg_tde_init_data_dir();
 	key_provider_startup_cleanup(databaseId);
 	principal_key_startup_cleanup(databaseId);
 }

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -308,6 +308,12 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 	}
 	else
 	{
+		/*
+		 * If we have a key for a relation that should not be encrypted we
+		 * need to remove it. This can happen if OID is re-used after a crash
+		 * left a key for a non-existing relation in the key file.
+		 */
+		DeleteSMGRRelationKey(reln->smgr_rlocator);
 		tdereln->encryption_status = RELATION_NOT_ENCRYPTED;
 	}
 }

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -265,7 +265,7 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 
 	mdcreate(relold, reln, forknum, isRedo);
 
-	if (forknum == MAIN_FORKNUM || forknum == INIT_FORKNUM)
+	if (forknum != MAIN_FORKNUM && forknum != INIT_FORKNUM)
 	{
 		/*
 		 * Only create keys when creating the main/init fork. Other forks can
@@ -275,25 +275,40 @@ tde_mdcreate(RelFileLocator relold, SMgrRelation reln, ForkNumber forknum, bool 
 		 *
 		 * Later calls then decide to encrypt or not based on the existence of
 		 * the key.
-		 *
-		 * Since event triggers do not fire on the standby or in recovery we
-		 * do not try to generate any new keys and instead trust the xlog.
 		 */
+		return;
+	}
+
+	if (tde_smgr_should_encrypt(&reln->smgr_rlocator, &relold))
+	{
 		InternalKey *key = tde_smgr_get_key(&reln->smgr_rlocator);
 
-		if (!isRedo && !key && tde_smgr_should_encrypt(&reln->smgr_rlocator, &relold))
-			key = pg_tde_create_smgr_key(&reln->smgr_rlocator);
-
-		if (key)
+		if (unlikely(key))
 		{
 			tdereln->encryption_status = RELATION_KEY_AVAILABLE;
 			tdereln->relKey = *key;
 			pfree(key);
 		}
+		else if (unlikely(isRedo))
+		{
+			/*
+			 * Since event triggers do not fire on the standby or in recovery
+			 * we do not try to generate any new keys and instead trust the
+			 * xlog.
+			 */
+			tdereln->encryption_status = RELATION_KEY_NOT_AVAILABLE;
+		}
 		else
 		{
-			tdereln->encryption_status = RELATION_NOT_ENCRYPTED;
+			key = pg_tde_create_smgr_key(&reln->smgr_rlocator);
+			tdereln->encryption_status = RELATION_KEY_AVAILABLE;
+			tdereln->relKey = *key;
+			pfree(key);
 		}
+	}
+	else
+	{
+		tdereln->encryption_status = RELATION_NOT_ENCRYPTED;
 	}
 }
 


### PR DESCRIPTION
Some crash scenarios can leave keys behind in the relation key file for OIDs that are unused. If these OIDs are later used when creating a non-encrypted relation the key has to be removed or we will do the wrong thing since the existence of a key makes us assume the relation is encrypted.

This means that if an encrypted relation is created in the same scenario it will use the key that was previously generated but unused. This is probably ok.

