### PR TITLE
Improved Docs Banner and added RC to GA upgrade warnings

### DIFF
--- a/contrib/pg_tde/documentation/_resource/overrides/main.html
+++ b/contrib/pg_tde/documentation/_resource/overrides/main.html
@@ -4,13 +4,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  This is the <strong>Release Candidate 2</strong> of Percona Transparent Data Encryption (TDE) extension. 
-  <p><strong>It is not recommended for production environments at this stage.</strong></p> 
-  There is no safe upgrade path from the Release Candidate (RC) to the General Availability (GA) version of pg_tde.  
-  We recommend starting with a <strong>clean installation</strong> for GA deployments. 
-  
-  We encourage you to test it and <a href= "https://forums.percona.com/c/postgresql/pg-tde-transparent-data-encryption-tde/82">give your feedback</a>.
-  This will help us improve the product and make it production-ready faster.
+  This is the <strong>Release Candidate 2 (RC2)</strong> of Percona Transparent Data Encryption (TDE) extension. 
+  <strong>It is not recommended for production environments at this stage.</strong> 
+  <p>There is no safe upgrade path from the Release Candidate 2 (RC2) to the General Availability (GA) version of <strong>pg_tde</strong>.
+  We recommend starting with a <strong>clean installation</strong> for GA deployments.</p>
+  <p>We encourage you to test it and <a href= "https://forums.percona.com/c/postgresql/pg-tde-transparent-data-encryption-tde/82">give your feedback</a>.
+  This will help us improve the product and make it production-ready faster.</p>
 {% endblock %}
 
 {% block scripts %}

--- a/contrib/pg_tde/documentation/_resource/overrides/main.html
+++ b/contrib/pg_tde/documentation/_resource/overrides/main.html
@@ -5,9 +5,7 @@
 
 {% block announce %}
   This is the <strong>Release Candidate 2 (RC2)</strong> of Percona Transparent Data Encryption (TDE) extension. 
-  <strong>It is not recommended for production environments at this stage.</strong> 
-  <p>There is no safe upgrade path from the Release Candidate 2 (RC2) to the General Availability (GA) version of <strong>pg_tde</strong>.
-  We recommend starting with a <strong>clean installation</strong> for GA deployments.</p>
+  <p><strong>It is not recommended for production environments at this stage.</strong></p> 
   <p>We encourage you to test it and <a href= "https://forums.percona.com/c/postgresql/pg-tde-transparent-data-encryption-tde/82">give your feedback</a>.
   This will help us improve the product and make it production-ready faster.</p>
 {% endblock %}

--- a/contrib/pg_tde/documentation/_resource/overrides/main.html
+++ b/contrib/pg_tde/documentation/_resource/overrides/main.html
@@ -4,8 +4,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  This is the Release Candidate 2 of Percona Transparent Data Encryption (TDE) extension. It is
-  <strong>not recommended for production environments</strong> at this stage. We encourage you to test it and <a href= "https://forums.percona.com/c/postgresql/pg-tde-transparent-data-encryption-tde/82">give your feedback</a>.
+  This is the <strong>Release Candidate 2</strong> of Percona Transparent Data Encryption (TDE) extension. 
+  <p><strong>It is not recommended for production environments at this stage.</strong></p> 
+  There is no safe upgrade path from the Release Candidate (RC) to the General Availability (GA) version of pg_tde.  
+  We recommend starting with a <strong>clean installation</strong> for GA deployments. 
+  
+  We encourage you to test it and <a href= "https://forums.percona.com/c/postgresql/pg-tde-transparent-data-encryption-tde/82">give your feedback</a>.
   This will help us improve the product and make it production-ready faster.
 {% endblock %}
 

--- a/contrib/pg_tde/documentation/docs/index.md
+++ b/contrib/pg_tde/documentation/docs/index.md
@@ -3,8 +3,7 @@
 `pg_tde` is the open source, community driven and futureproof PostgreSQL extension that provides Transparent Data Encryption (TDE) to protect data at rest. `pg_tde` ensures that the data stored on disk is encrypted, and that no one can read it without the proper encryption keys, even if they gain access to the physical storage media.
 
 !!! important
-
-    This is the {{release}} version of the extension and it is not meant for production use yet. We encourage you to use it in testing environments and [provide your feedback](https://forums.percona.com/c/postgresql/pg-tde-transparent-data-encryption-tde/82). 
+    This is the {{release}} version of the extension and **it is not meant for production use yet**. We encourage you to use it in testing environments and [provide your feedback](https://forums.percona.com/c/postgresql/pg-tde-transparent-data-encryption-tde/82).
 
 [Overview](index/index.md){.md-button}
 [Get Started](install.md){.md-button}

--- a/contrib/pg_tde/documentation/docs/index/tde-limitations.md
+++ b/contrib/pg_tde/documentation/docs/index/tde-limitations.md
@@ -6,4 +6,7 @@
 * `pg_rewind` doesn't work with encrypted WAL for now. We plan to fix it in future releases.
 * `pg_tde` Release candidate is incompatible with `pg_tde`Beta2 due to significant changes in code. There is no direct upgrade flow from one version to another. You must [uninstall](../how-to/uninstall.md) `pg_tde` Beta2 first and then [install](../install.md) and configure the new Release Candidate version.
 
+!!! important
+    This is the {{release}} version of the extension and **it is not meant for production use yet**. We encourage you to use it in testing environments and [provide your feedback](https://forums.percona.com/c/postgresql/pg-tde-transparent-data-encryption-tde/82).
+
 [Versions and Supported PostgreSQL Deployments](supported-versions.md){.md-button}

--- a/contrib/pg_tde/documentation/docs/install.md
+++ b/contrib/pg_tde/documentation/docs/install.md
@@ -1,8 +1,8 @@
 # Install pg_tde
 
-!!! warning "No upgrade path from RC to GA"
+<!-- !!! warning "No upgrade path from RC to GA"
     There is no safe upgrade path from the Release Candidate 2 (RC2) to the General Availability (GA) version of `pg_tde`.  
-    We recommend starting with a **clean installation** for GA deployments. Avoid using RC environments in production.
+    We recommend starting with a **clean installation** for GA deployments. Avoid using RC environments in production. -->
 
 To install `pg_tde`, use one of the following methods:
 

--- a/contrib/pg_tde/documentation/docs/install.md
+++ b/contrib/pg_tde/documentation/docs/install.md
@@ -1,7 +1,7 @@
 # Install pg_tde
 
 !!! warning "No upgrade path from RC to GA"
-    There is no safe upgrade path from the Release Candidate (RC 2) to the General Availability (GA) version of `pg_tde`.  
+    There is no safe upgrade path from the Release Candidate 2 (RC2) to the General Availability (GA) version of `pg_tde`.  
     We recommend starting with a **clean installation** for GA deployments. Avoid using RC environments in production.
 
 To install `pg_tde`, use one of the following methods:

--- a/contrib/pg_tde/documentation/docs/install.md
+++ b/contrib/pg_tde/documentation/docs/install.md
@@ -1,8 +1,8 @@
 # Install pg_tde
 
-<!-- !!! warning "No upgrade path from RC to GA"
+!!! warning "No upgrade path from RC to GA"
     There is no safe upgrade path from the Release Candidate 2 (RC2) to the General Availability (GA) version of `pg_tde`.  
-    We recommend starting with a **clean installation** for GA deployments. Avoid using RC environments in production. -->
+    We recommend starting with a **clean installation** for GA deployments. Avoid using RC environments in production.
 
 To install `pg_tde`, use one of the following methods:
 

--- a/contrib/pg_tde/documentation/docs/install.md
+++ b/contrib/pg_tde/documentation/docs/install.md
@@ -1,5 +1,9 @@
 # Install pg_tde
 
+!!! warning "No upgrade path from RC to GA"
+    There is no safe upgrade path from the Release Candidate (RC 2) to the General Availability (GA) version of `pg_tde`.  
+    We recommend starting with a **clean installation** for GA deployments. Avoid using RC environments in production.
+
 To install `pg_tde`, use one of the following methods:
 
 === ":octicons-terminal-16: Package manager"

--- a/contrib/pg_tde/documentation/docs/release-notes/release-notes.md
+++ b/contrib/pg_tde/documentation/docs/release-notes/release-notes.md
@@ -2,7 +2,7 @@
 
 `pg_tde` extension brings in [Transparent Data Encryption (TDE)](../index/index.md) to PostgreSQL and enables you to keep sensitive data safe and secure.
 
-* [pg_tde Release Candidate 2 ({{date.RC}})](rc2.md)
+* [pg_tde Release Candidate 2 (RC2) ({{date.RC2}})](rc2.md)
 * [pg_tde Release Candidate ({{date.RC}})](rc.md)
 * [pg_tde Beta2 (2024-12-16)](beta2.md)
 * [pg_tde Beta (2024-06-30)](beta.md)

--- a/contrib/pg_tde/documentation/variables.yml
+++ b/contrib/pg_tde/documentation/variables.yml
@@ -5,5 +5,5 @@ pgversion17: '17.5.1'
 tdebranch: TDE_REL_17_STABLE
 
 date:
-  RC2: '2025-05-21'
+  RC2: '2025-05-29'
   RC: '2025-03-27'


### PR DESCRIPTION
Added to banner and other chapters notes for the user to **NOT** upgrade RC to GA, do a fresh install for GA, and added more important notes regarding the fact that this is an RC build that should **NOT** be used in prod env.