### PR TITLE
[PG-1635] Return void from add/change key provider functions

### DIFF
--- a/contrib/pg_tde/expected/access_control.out
+++ b/contrib/pg_tde/expected/access_control.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 CREATE USER regress_pg_tde_access_control;

--- a/contrib/pg_tde/expected/alter_index.out
+++ b/contrib/pg_tde/expected/alter_index.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/expected/cache_alloc.out
+++ b/contrib/pg_tde/expected/cache_alloc.out
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/expected/change_access_method.out
+++ b/contrib/pg_tde/expected/change_access_method.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');

--- a/contrib/pg_tde/expected/create_database.out
+++ b/contrib/pg_tde/expected/create_database.out
@@ -7,7 +7,7 @@ CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/template_provider.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');
@@ -26,7 +26,7 @@ INSERT INTO test_plain (x) VALUES (30), (40);
 SELECT pg_tde_add_global_key_provider_file('global-file-vault','/tmp/template_provider_global.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -6
+ 
 (1 row)
 
 SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'global-file-vault');

--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS pg_buffercache;
 SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_key.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -5
+ 
 (1 row)
 
 -- Should fail: no default principal key for the server yet

--- a/contrib/pg_tde/expected/insert_update_delete.out
+++ b/contrib/pg_tde/expected/insert_update_delete.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -12,7 +12,7 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
 SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
@@ -24,7 +24,7 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
 SELECT pg_tde_add_database_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     2
+ 
 (1 row)
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
@@ -69,13 +69,13 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
 SELECT pg_tde_add_global_key_provider_file('file-keyring','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -1
+ 
 (1 row)
 
 SELECT pg_tde_add_global_key_provider_file('file-keyring2','/tmp/pg_tde_test_keyring2.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -2
+ 
 (1 row)
 
 SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
@@ -271,7 +271,7 @@ ERROR:  unexpected boolean in field "path"
 SELECT pg_tde_add_global_key_provider_file('global-provider', '/tmp/global-provider-file-1');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -3
+ 
 (1 row)
 
 SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'global-provider');
@@ -286,7 +286,7 @@ ERROR:  could not fetch key "server-key" used as server key from modified key pr
 SELECT pg_tde_add_global_key_provider_file('global-provider2', '/tmp/global-provider-file-1');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -4
+ 
 (1 row)
 
 SELECT current_database() AS regress_database
@@ -310,7 +310,7 @@ CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('db-provider', '/tmp/db-provider-file');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('database-key', 'db-provider');

--- a/contrib/pg_tde/expected/kmip_test.out
+++ b/contrib/pg_tde/expected/kmip_test.out
@@ -2,7 +2,7 @@ CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_kmip('kmip-prov','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_certificate_jane_doe.pem', '/tmp/client_key_jane_doe.pem');
  pg_tde_add_database_key_provider_kmip 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('kmip-key','kmip-prov');

--- a/contrib/pg_tde/expected/partition_table.out
+++ b/contrib/pg_tde/expected/partition_table.out
@@ -2,7 +2,7 @@ CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('database_keyring_provider','/tmp/pg_tde_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('table_key','database_keyring_provider');

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/expected/recreate_storage.out
+++ b/contrib/pg_tde/expected/recreate_storage.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/expected/relocate.out
+++ b/contrib/pg_tde/expected/relocate.out
@@ -6,7 +6,7 @@ CREATE EXTENSION pg_tde SCHEMA other;
 SELECT other.pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT other.pg_tde_grant_key_viewer_to_role('public');

--- a/contrib/pg_tde/expected/tablespace.out
+++ b/contrib/pg_tde/expected/tablespace.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/expected/toast_decrypt.out
+++ b/contrib/pg_tde/expected/toast_decrypt.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
-                                         1
+ 
 (1 row)
 
 -- FAILS
@@ -19,7 +19,7 @@ HINT:  create one using pg_tde_set_key before using encrypted tables
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0.1:8200','secret',NULL);
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
-                                         2
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-v2');

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -5,12 +5,12 @@
 
 -- Key Provider Management
 CREATE FUNCTION pg_tde_add_database_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_add_database_key_provider_file(provider_name TEXT, file_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -20,7 +20,7 @@ BEGIN ATOMIC
 END;
 
 CREATE FUNCTION pg_tde_add_database_key_provider_file(provider_name TEXT, file_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -34,7 +34,7 @@ CREATE FUNCTION pg_tde_add_database_key_provider_vault_v2(provider_name TEXT,
                                                 vault_url TEXT,
                                                 vault_mount_path TEXT,
                                                 vault_ca_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -51,7 +51,7 @@ CREATE FUNCTION pg_tde_add_database_key_provider_vault_v2(provider_name TEXT,
                                                 vault_url JSON,
                                                 vault_mount_path JSON,
                                                 vault_ca_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -69,7 +69,7 @@ CREATE FUNCTION pg_tde_add_database_key_provider_kmip(provider_name TEXT,
                                              kmip_ca_path TEXT,
                                              kmip_cert_path TEXT,
                                              kmip_key_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -88,7 +88,7 @@ CREATE FUNCTION pg_tde_add_database_key_provider_kmip(provider_name TEXT,
                                              kmip_ca_path JSON,
                                              kmip_cert_path JSON,
                                              kmip_key_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -121,12 +121,12 @@ AS 'MODULE_PATHNAME';
 
 -- Global Tablespace Key Provider Management
 CREATE FUNCTION pg_tde_add_global_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_add_global_key_provider_file(provider_name TEXT, file_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -136,7 +136,7 @@ BEGIN ATOMIC
 END;
 
 CREATE FUNCTION pg_tde_add_global_key_provider_file(provider_name TEXT, file_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -150,7 +150,7 @@ CREATE FUNCTION pg_tde_add_global_key_provider_vault_v2(provider_name TEXT,
                                                         vault_url TEXT,
                                                         vault_mount_path TEXT,
                                                         vault_ca_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -167,7 +167,7 @@ CREATE FUNCTION pg_tde_add_global_key_provider_vault_v2(provider_name TEXT,
                                                         vault_url JSON,
                                                         vault_mount_path JSON,
                                                         vault_ca_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -185,7 +185,7 @@ CREATE FUNCTION pg_tde_add_global_key_provider_kmip(provider_name TEXT,
                                                     kmip_ca_path TEXT,
                                                     kmip_cert_path TEXT,
                                                     kmip_key_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -204,7 +204,7 @@ CREATE FUNCTION pg_tde_add_global_key_provider_kmip(provider_name TEXT,
                                                     kmip_ca_path JSON,
                                                     kmip_cert_path JSON,
                                                     kmip_key_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -219,12 +219,12 @@ END;
 
 -- Key Provider Management
 CREATE FUNCTION pg_tde_change_database_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_change_database_key_provider_file(provider_name TEXT, file_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -234,7 +234,7 @@ BEGIN ATOMIC
 END;
 
 CREATE FUNCTION pg_tde_change_database_key_provider_file(provider_name TEXT, file_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -248,7 +248,7 @@ CREATE FUNCTION pg_tde_change_database_key_provider_vault_v2(provider_name TEXT,
                                                     vault_url TEXT,
                                                     vault_mount_path TEXT,
                                                     vault_ca_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -265,7 +265,7 @@ CREATE FUNCTION pg_tde_change_database_key_provider_vault_v2(provider_name TEXT,
                                                     vault_url JSON,
                                                     vault_mount_path JSON,
                                                     vault_ca_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -283,7 +283,7 @@ CREATE FUNCTION pg_tde_change_database_key_provider_kmip(provider_name TEXT,
                                                 kmip_ca_path TEXT,
                                                 kmip_cert_path TEXT,
                                                 kmip_key_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -302,7 +302,7 @@ CREATE FUNCTION pg_tde_change_database_key_provider_kmip(provider_name TEXT,
                                                 kmip_ca_path JSON,
                                                 kmip_cert_path JSON,
                                                 kmip_key_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -317,12 +317,12 @@ END;
 
 -- Global Tablespace Key Provider Management
 CREATE FUNCTION pg_tde_change_global_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
 CREATE FUNCTION pg_tde_change_global_key_provider_file(provider_name TEXT, file_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -332,7 +332,7 @@ BEGIN ATOMIC
 END;
 
 CREATE FUNCTION pg_tde_change_global_key_provider_file(provider_name TEXT, file_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -346,7 +346,7 @@ CREATE FUNCTION pg_tde_change_global_key_provider_vault_v2(provider_name TEXT,
                                                            vault_url TEXT,
                                                            vault_mount_path TEXT,
                                                            vault_ca_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -363,7 +363,7 @@ CREATE FUNCTION pg_tde_change_global_key_provider_vault_v2(provider_name TEXT,
                                                            vault_url JSON,
                                                            vault_mount_path JSON,
                                                            vault_ca_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -381,7 +381,7 @@ CREATE FUNCTION pg_tde_change_global_key_provider_kmip(provider_name TEXT,
                                                        kmip_ca_path TEXT,
                                                        kmip_cert_path TEXT,
                                                        kmip_key_path TEXT)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
@@ -400,7 +400,7 @@ CREATE FUNCTION pg_tde_change_global_key_provider_kmip(provider_name TEXT,
                                                        kmip_ca_path JSON,
                                                        kmip_cert_path JSON,
                                                        kmip_key_path JSON)
-RETURNS INT
+RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -235,7 +235,7 @@ pg_tde_change_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 
 	modify_key_provider_info(&provider, dbOid, true);
 
-	PG_RETURN_INT32(provider.provider_id);
+	PG_RETURN_VOID();
 }
 
 Datum
@@ -294,7 +294,7 @@ pg_tde_add_key_provider_internal(PG_FUNCTION_ARGS, Oid dbOid)
 	provider.provider_type = get_keyring_provider_from_typename(provider_type);
 	save_new_key_provider_info(&provider, dbOid, true);
 
-	PG_RETURN_INT32(provider.provider_id);
+	PG_RETURN_VOID();
 }
 
 Datum

--- a/contrib/pg_tde/t/expected/001_basic.out
+++ b/contrib/pg_tde/t/expected/001_basic.out
@@ -11,7 +11,7 @@ HINT:  create one using pg_tde_set_key before using encrypted tables
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_001_basic.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -2,25 +2,25 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     2
+ 
 (1 row)
 
 SELECT pg_tde_add_global_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2g.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -1
+ 
 (1 row)
 
 SELECT pg_tde_add_global_key_provider_file('file-3', '/tmp/pg_tde_test_keyring_3.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -2
+ 
 (1 row)
 
 SELECT pg_tde_list_all_database_key_providers();

--- a/contrib/pg_tde/t/expected/003_remote_config.out
+++ b/contrib/pg_tde/t/expected/003_remote_config.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-provider', json_object('type' VALUE 'remote', 'url' VALUE 'http://localhost:8888/hello'));
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-provider');

--- a/contrib/pg_tde/t/expected/004_file_config.out
+++ b/contrib/pg_tde/t/expected/004_file_config.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-provider', json_object('type' VALUE 'file', 'path' VALUE '/tmp/datafile-location'));
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-provider');

--- a/contrib/pg_tde/t/expected/006_remote_vault_config.out
+++ b/contrib/pg_tde/t/expected/006_remote_vault_config.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-provider', json_object('type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/token'), json_object('type' VALUE 'remote', 'url' VALUE 'http://localhost:8889/url'), to_json('secret'::text), NULL);
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
-                                         1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'vault-provider');

--- a/contrib/pg_tde/t/expected/007_tde_heap.out
+++ b/contrib/pg_tde/t/expected/007_tde_heap.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');

--- a/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
+++ b/contrib/pg_tde/t/expected/008_key_rotate_tablespace.out
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');

--- a/contrib/pg_tde/t/expected/009_wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/009_wal_encrypt.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/pg_tde_test_keyring010.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -1
+ 
 (1 row)
 
 SELECT pg_tde_verify_server_key();

--- a/contrib/pg_tde/t/expected/010_change_key_provider.out
+++ b/contrib/pg_tde/t/expected/010_change_key_provider.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_list_all_database_key_providers();
@@ -42,7 +42,7 @@ SELECT * FROM test_enc ORDER BY id;
 SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_2.per');
  pg_tde_change_database_key_provider_file 
 ------------------------------------------
-                                        1
+ 
 (1 row)
 
 SELECT pg_tde_list_all_database_key_providers();

--- a/contrib/pg_tde/t/expected/011_unlogged_tables.out
+++ b/contrib/pg_tde/t/expected/011_unlogged_tables.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');

--- a/contrib/pg_tde/t/expected/012_replication.out
+++ b/contrib/pg_tde/t/expected/012_replication.out
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');
@@ -59,7 +59,7 @@ SELECT * FROM test_plain ORDER BY x;
 SELECT pg_tde_add_global_key_provider_file('file-vault', '/tmp/unlogged_tables.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -1
+ 
 (1 row)
 
 SELECT pg_tde_set_server_key_using_global_key_provider('test-global-key', 'file-vault');

--- a/contrib/pg_tde/t/expected/013_crash_recovery.out
+++ b/contrib/pg_tde/t/expected/013_crash_recovery.out
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT pg_tde_add_global_key_provider_file('global_keyring', '/tmp/crash_recovery.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
-                                  -1
+ 
 (1 row)
 
 SELECT pg_tde_set_server_key_using_global_key_provider('wal_encryption_key', 'global_keyring');
@@ -14,7 +14,7 @@ SELECT pg_tde_set_server_key_using_global_key_provider('wal_encryption_key', 'gl
 SELECT pg_tde_add_database_key_provider_file('db_keyring', '/tmp/crash_recovery.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
-                                     1
+ 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('db_key', 'db_keyring');


### PR DESCRIPTION
The returned provider id was not useful for end-users as they cannot do anything with it. They always use the provider name when interacting with these settings.

If they really want to see these ids they can easily just use the functions to list all providers to see them.

The reason for this change is that it might be confusing for users when the function to create a global provider returns -1 on success without any indication that it's just the generated id and not an error code.