### PR TITLE
Remove undocumented shorthand for when setting keys

### DIFF
--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -328,6 +328,15 @@ SELECT pg_tde_delete_database_key_provider(NULL);
 ERROR:  provider_name cannot be null
 SELECT pg_tde_delete_global_key_provider(NULL);
 ERROR:  provider_name cannot be null
+-- Setting principal key fails if provider name is NULL
+SELECT pg_tde_set_default_key_using_global_key_provider('key', NULL);
+ERROR:  key provider name cannot be null
+SELECT pg_tde_set_key_using_database_key_provider('key', NULL);
+ERROR:  key provider name cannot be null
+SELECT pg_tde_set_key_using_global_key_provider('key', NULL);
+ERROR:  key provider name cannot be null
+SELECT pg_tde_set_server_key_using_global_key_provider('key', NULL);
+ERROR:  key provider name cannot be null
 -- Setting principal key fails if key name is NULL
 SELECT pg_tde_set_default_key_using_global_key_provider(NULL, 'file-keyring');
 ERROR:  key name cannot be null

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -419,22 +419,22 @@ STRICT
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_key_using_database_key_provider(key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_key_using_database_key_provider(key_name TEXT, provider_name TEXT, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_key_using_global_key_provider(key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_key_using_global_key_provider(key_name TEXT, provider_name TEXT, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_server_key_using_global_key_provider(key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_server_key_using_global_key_provider(key_name TEXT, provider_name TEXT, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION pg_tde_set_default_key_using_global_key_provider(key_name TEXT, provider_name TEXT DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT FALSE)
+CREATE FUNCTION pg_tde_set_default_key_using_global_key_provider(key_name TEXT, provider_name TEXT, ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS VOID
 AS 'MODULE_PATHNAME'
 LANGUAGE C;

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -160,6 +160,12 @@ DROP DATABASE db_using_database_provider;
 SELECT pg_tde_delete_database_key_provider(NULL);
 SELECT pg_tde_delete_global_key_provider(NULL);
 
+-- Setting principal key fails if provider name is NULL
+SELECT pg_tde_set_default_key_using_global_key_provider('key', NULL);
+SELECT pg_tde_set_key_using_database_key_provider('key', NULL);
+SELECT pg_tde_set_key_using_global_key_provider('key', NULL);
+SELECT pg_tde_set_server_key_using_global_key_provider('key', NULL);
+
 -- Setting principal key fails if key name is NULL
 SELECT pg_tde_set_default_key_using_global_key_provider(NULL, 'file-keyring');
 SELECT pg_tde_set_key_using_database_key_provider(NULL, 'file-keyring');

--- a/contrib/pg_tde/t/002_rotate_key.pl
+++ b/contrib/pg_tde/t/002_rotate_key.pl
@@ -46,7 +46,8 @@ PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 # Rotate key
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');");
+	"SELECT pg_tde_set_key_using_database_key_provider('rotated-key1', 'file-vault');"
+);
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
 PGTDE::append_to_result_file("-- server restart");

--- a/contrib/pg_tde/t/expected/002_rotate_key.out
+++ b/contrib/pg_tde/t/expected/002_rotate_key.out
@@ -45,7 +45,7 @@ SELECT * FROM test_enc ORDER BY id;
   2 | 6
 (2 rows)
 
-SELECT pg_tde_set_key_using_database_key_provider('rotated-key1');
+SELECT pg_tde_set_key_using_database_key_provider('rotated-key1', 'file-vault');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  


### PR DESCRIPTION
If we passed NULL as the pkey provider name we used to pick the current key provider which was an undcoumented feature which made the code and API harder to understand. Let's jsut remove it and see if people complain.