### PR TITLE
Fix non-functioning helper sql function

### DIFF
--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -405,7 +405,7 @@ LANGUAGE SQL
 BEGIN ATOMIC
     -- JSON keys in the options must be matched to the keys in
     -- load_kmip_keyring_provider_options function.
-    SELECT pg_tde_change_global_key_provider('vault-v2', provider_name,
+    SELECT pg_tde_change_global_key_provider('kmip', provider_name,
                             json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
                             'caPath' VALUE kmip_ca_path,


### PR DESCRIPTION
This function did not work as it tried to create a vault-v2 provider using kmip options.

This having gone unnoticed however leads me to another question. Are these "helpers" taking json input for all parameters really useful? I'd say they are not and anyone wanting "advanced" configuration should instead use the "raw" pg_tde_add_new_database_key_provider() et.al.