### PR TITLE
[PG-1637] Remove any existing keys for tables on create

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -61,6 +61,12 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 
 		pg_tde_save_principal_key_redo(mkey);
 	}
+	else if (info == XLOG_TDE_REMOVE_RELATION_KEY)
+	{
+		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
+
+		tde_smgr_delete_key_redo(&xlrec->rlocator);
+	}
 	else if (info == XLOG_TDE_ROTATE_PRINCIPAL_KEY)
 	{
 		XLogPrincipalKeyRotate *xlrec = (XLogPrincipalKeyRotate *) XLogRecGetData(record);

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -93,7 +93,7 @@ pg_tde_set_db_file_path(Oid dbOid, char *path)
 	join_path_components(path, pg_tde_get_data_dir(), psprintf(PG_TDE_MAP_FILENAME, dbOid));
 }
 
-extern void pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *key, bool write_xlog);
+extern void pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *key);
 extern bool pg_tde_has_smgr_key(RelFileLocator rel);
 extern InternalKey *pg_tde_get_smgr_key(RelFileLocator rel);
 extern void pg_tde_free_key_map_entry(RelFileLocator rel);

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog.h
@@ -17,6 +17,7 @@
 #define XLOG_TDE_ROTATE_PRINCIPAL_KEY	0x20
 #define XLOG_TDE_WRITE_KEY_PROVIDER 	0x30
 #define XLOG_TDE_INSTALL_EXTENSION		0x40
+#define XLOG_TDE_REMOVE_RELATION_KEY	0x50
 
 /* ID 140 is registered for Percona TDE extension: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
 #define RM_TDERMGR_ID	140

--- a/contrib/pg_tde/src/include/smgr/pg_tde_smgr.h
+++ b/contrib/pg_tde/src/include/smgr/pg_tde_smgr.h
@@ -14,6 +14,7 @@
 
 extern void RegisterStorageMgr(void);
 extern void tde_smgr_create_key_redo(const RelFileLocator *rlocator);
+extern void tde_smgr_delete_key_redo(const RelFileLocator *rlocator);
 extern bool tde_smgr_rel_is_encrypted(SMgrRelation reln);
 
 #endif							/* PG_TDE_SMGR_H */

--- a/contrib/pg_tde/src/pg_tde.c
+++ b/contrib/pg_tde/src/pg_tde.c
@@ -93,6 +93,7 @@ _PG_init(void)
 
 	check_percona_api_version();
 
+	pg_tde_init_data_dir();
 	AesInit();
 	TdeGucInit();
 	TdeEventCaptureInit();
@@ -113,8 +114,6 @@ _PG_init(void)
 static void
 extension_install(Oid databaseId)
 {
-	/* Initialize the TDE dir */
-	pg_tde_init_data_dir();
 	key_provider_startup_cleanup(databaseId);
 	principal_key_startup_cleanup(databaseId);
 }


### PR DESCRIPTION
Some crash scenarios can leave keys behind in the relation key file for OIDs that are unused. If these OIDs are later used when creating a non-encrypted relation the key has to be removed or we will do the wrong thing since the existence of a key makes us assume the relation is encrypted.