### PR TITLE
PG-1592 Return all nulls for key info when no key

### DIFF
--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -12,8 +12,11 @@ ERROR:  principal key not configured for current database
 -- Should fail: no default principal key for the server yet
 SELECT key_provider_id, key_provider_name, key_name
 		FROM pg_tde_default_key_info();
-ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
+ key_provider_id | key_provider_name | key_name 
+-----------------+-------------------+----------
+                 |                   | 
+(1 row)
+
 SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'file-provider', false);
  pg_tde_set_default_key_using_global_key_provider 
 --------------------------------------------------
@@ -48,8 +51,11 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 -- Should fail: no principal key for the database yet
 SELECT  key_provider_id, key_provider_name, key_name
 		FROM pg_tde_key_info();
-ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
+ key_provider_id | key_provider_name | key_name 
+-----------------+-------------------+----------
+                 |                   | 
+(1 row)
+
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
 	id SERIAL,
@@ -74,8 +80,11 @@ CREATE EXTENSION pg_buffercache;
 -- Should fail: no principal key for the database yet
 SELECT  key_provider_id, key_provider_name, key_name
 		FROM pg_tde_key_info();
-ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
+ key_provider_id | key_provider_name | key_name 
+-----------------+-------------------+----------
+                 |                   | 
+(1 row)
+
 -- Should succeed: "localizes" the default principal key for the database
 CREATE TABLE test_enc(
 	id SERIAL,

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -1,7 +1,10 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT  * FROM pg_tde_key_info();
-ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
+ key_name | key_provider_name | key_provider_id | key_creation_time 
+----------+-------------------+-----------------+-------------------
+          |                   |                 | 
+(1 row)
+
 SELECT pg_tde_add_database_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
 ERROR:  key provider value cannot be an object
 SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');

--- a/contrib/pg_tde/t/expected/rotate_key.out
+++ b/contrib/pg_tde/t/expected/rotate_key.out
@@ -66,8 +66,11 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 (1 row)
 
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
-psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
+ key_provider_id | key_provider_name | key_name 
+-----------------+-------------------+----------
+                 |                   | 
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
@@ -96,8 +99,11 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 (1 row)
 
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
-psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
+ key_provider_id | key_provider_name | key_name 
+-----------------+-------------------+----------
+                 |                   | 
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
@@ -126,8 +132,11 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 (1 row)
 
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
-psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
+ key_provider_id | key_provider_name | key_name 
+-----------------+-------------------+----------
+                 |                   | 
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
@@ -156,8 +165,11 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 (1 row)
 
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
-psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
+ key_provider_id | key_provider_name | key_name 
+-----------------+-------------------+----------
+                 |                   | 
+(1 row)
+
 SELECT * FROM test_enc ORDER BY id;
  id | k 
 ----+---
@@ -176,8 +188,11 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 (1 row)
 
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
-psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
+ key_provider_id | key_provider_name | key_name 
+-----------------+-------------------+----------
+                 |                   | 
+(1 row)
+
 SELECT pg_tde_set_key_using_database_key_provider('rotated-key2', 'file-2');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
@@ -191,8 +206,11 @@ SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
 (1 row)
 
 SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
-psql:<stdin>:1: ERROR:  Principal key does not exists for the database
-HINT:  Use set_key interface to set the principal key
+ key_provider_id | key_provider_name | key_name 
+-----------------+-------------------+----------
+                 |                   | 
+(1 row)
+
 DROP TABLE test_enc;
 ALTER SYSTEM RESET pg_tde.inherit_global_providers;
 -- server restart

--- a/contrib/pg_tde/t/expected/wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/wal_encrypt.out
@@ -7,6 +7,12 @@ SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/pg_tde_test
 
 SELECT pg_tde_verify_server_key();
 psql:<stdin>:1: ERROR:  principal key not configured for current database
+SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_server_key_info();
+ key_name | key_provider_name | key_provider_id 
+----------+-------------------+-----------------
+          |                   |                
+(1 row)
+
 SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-010');
  pg_tde_set_server_key_using_global_key_provider 
 -------------------------------------------------
@@ -17,6 +23,12 @@ SELECT pg_tde_verify_server_key();
  pg_tde_verify_server_key 
 --------------------------
  
+(1 row)
+
+SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_server_key_info();
+  key_name  | key_provider_name | key_provider_id 
+------------+-------------------+-----------------
+ server-key | file-keyring-010  |              -1
 (1 row)
 
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;

--- a/contrib/pg_tde/t/wal_encrypt.pl
+++ b/contrib/pg_tde/t/wal_encrypt.pl
@@ -26,10 +26,18 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres', 'SELECT pg_tde_verify_server_key();');
 
 PGTDE::psql($node, 'postgres',
+	'SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_server_key_info();'
+);
+
+PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-010');"
 );
 
 PGTDE::psql($node, 'postgres', 'SELECT pg_tde_verify_server_key();');
+
+PGTDE::psql($node, 'postgres',
+	'SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_server_key_info();'
+);
 
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;');
 


### PR DESCRIPTION
Since no key being configured is not an error we instead of raising the error we return a tuple with all fields set to NULL. This is a pattern used by other PostgreSQL functions.

Also add a more explicit test for `pg_tde_verify_server_key(`).