### PR TITLE
PG-1607 Make Vault CA path optional and clean up HTTPS code in general for Vault

### DIFF
--- a/ci_scripts/setup-keyring-servers.sh
+++ b/ci_scripts/setup-keyring-servers.sh
@@ -17,12 +17,14 @@ cd ..
 echo $SCRIPT_DIR
 pykmip-server -f "$SCRIPT_DIR/../contrib/pg_tde/pykmip-server.conf" -l /tmp/kmip-server.log &
 
-TV=$(mktemp)
-{ exec >$TV; vault server -dev; } &
+CLUSTER_INFO=$(mktemp)
+vault server -dev -dev-tls -dev-cluster-json="$CLUSTER_INFO" > /dev/null &
 sleep 10
-export ROOT_TOKEN_FILE=$(mktemp)
-cat $TV | grep "Root Token" | cut -d ":" -f 2 | xargs echo -n > $ROOT_TOKEN_FILE
-echo "export ROOT_TOKEN_FILE=$ROOT_TOKEN_FILE"
+export VAULT_ROOT_TOKEN_FILE=$(mktemp)
+<"$CLUSTER_INFO" python3 -c 'import json, sys; print(json.load(sys.stdin)["root_token"])' > "$VAULT_ROOT_TOKEN_FILE"
+export VAULT_CACERT_FILE=$(<"$CLUSTER_INFO" python3 -c 'import json, sys; print(json.load(sys.stdin)["ca_cert_path"])')
+rm "$CLUSTER_INFO"
 if [ -v GITHUB_ACTIONS ]; then
-    echo "ROOT_TOKEN_FILE=$ROOT_TOKEN_FILE" >> $GITHUB_ENV
+    echo "VAULT_ROOT_TOKEN_FILE=$VAULT_ROOT_TOKEN_FILE" >> $GITHUB_ENV
+    echo "VAULT_CACERT_FILE=$VAULT_CACERT_FILE" >> $GITHUB_ENV
 fi

--- a/contrib/pg_tde/README.md
+++ b/contrib/pg_tde/README.md
@@ -118,7 +118,8 @@ _See [Make Builds for Developers](https://github.com/percona/pg_tde/wiki/Make-bu
             'vault-provider',
             '/path/to/token_file',
             'https://your.vault.server',
-            'secret', NULL);
+            'secret',
+            '/path/to/ca_cert.pem');
 
         -- For File key provider
         -- pg_tde_add_database_key_provider_file(provider_name, file_path);

--- a/contrib/pg_tde/documentation/docs/global-key-provider-configuration/vault.md
+++ b/contrib/pg_tde/documentation/docs/global-key-provider-configuration/vault.md
@@ -31,9 +31,9 @@ The following example is for testing purposes only. Use secure tokens and proper
 SELECT pg_tde_add_global_key_provider_vault_v2(
     'my-vault',
     '/path/to/token_file',
-    'http://vault.vault.svc.cluster.local:8200',
+    'https://vault.vault.svc.cluster.local:8200',
     'secret/data',
-    NULL
+    '/path/to/ca_cert.pem'
 );
 ```
 

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 \getenv root_token_file ROOT_TOKEN_FILE
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','http://127.0.0.1:8200','DUMMY-TOKEN');
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
  
@@ -16,7 +16,7 @@ CREATE TABLE test_enc(
 	) USING tde_heap;
 ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_key before using encrypted tables
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','http://127.0.0.1:8200','secret',NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','http://127.0.0.1:8200','secret');
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
  
@@ -52,6 +52,6 @@ SELECT pg_tde_verify_key();
 
 DROP TABLE test_enc;
 -- Creating provider fails if we can't connect to vault
-SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret', NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret');
 ERROR:  HTTP(S) request to keyring provider "will-not-work" failed
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -54,4 +54,7 @@ DROP TABLE test_enc;
 -- Creating provider fails if we can't connect to vault
 SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret');
 ERROR:  HTTP(S) request to keyring provider "will-not-work" failed
+-- Changing provider fails if we can't connect to vault
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:61', 'secret');
+ERROR:  HTTP(S) request to keyring provider "vault-v2" failed
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -1,6 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-\getenv root_token_file ROOT_TOKEN_FILE
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','http://127.0.0.1:8200','DUMMY-TOKEN');
+\getenv root_token_file VAULT_ROOT_TOKEN_FILE
+\getenv cacert_file VAULT_CACERT_FILE
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','https://127.0.0.1:8200','DUMMY-TOKEN',:'cacert_file');
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
  
@@ -16,7 +17,7 @@ CREATE TABLE test_enc(
 	) USING tde_heap;
 ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_key before using encrypted tables
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','http://127.0.0.1:8200','secret');
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','https://127.0.0.1:8200','secret',:'cacert_file');
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
  
@@ -52,9 +53,15 @@ SELECT pg_tde_verify_key();
 
 DROP TABLE test_enc;
 -- Creating provider fails if we can't connect to vault
-SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret');
+SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
 ERROR:  HTTP(S) request to keyring provider "will-not-work" failed
 -- Changing provider fails if we can't connect to vault
-SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:61', 'secret');
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
 ERROR:  HTTP(S) request to keyring provider "vault-v2" failed
+-- HTTPS without cert fails
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','https://127.0.0.1:8200','DUMMY-TOKEN');
+ERROR:  HTTP(S) request to keyring provider "vault-incorrect" failed
+-- HTTP against HTTPS server fails
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','http://127.0.0.1:8200','DUMMY-TOKEN');
+ERROR:  Listing secrets of "http://127.0.0.1:8200" at mountpoint "DUMMY-TOKEN" failed
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -34,7 +34,7 @@ CREATE FUNCTION pg_tde_add_database_key_provider_vault_v2(provider_name TEXT,
                                                 vault_token_path TEXT,
                                                 vault_url TEXT,
                                                 vault_mount_path TEXT,
-                                                vault_ca_path TEXT)
+                                                vault_ca_path TEXT DEFAULT NULL)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
@@ -117,7 +117,7 @@ CREATE FUNCTION pg_tde_add_global_key_provider_vault_v2(provider_name TEXT,
                                                         vault_token_path TEXT,
                                                         vault_url TEXT,
                                                         vault_mount_path TEXT,
-                                                        vault_ca_path TEXT)
+                                                        vault_ca_path TEXT DEFAULT NULL)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
@@ -180,7 +180,7 @@ CREATE FUNCTION pg_tde_change_database_key_provider_vault_v2(provider_name TEXT,
                                                     vault_token_path TEXT,
                                                     vault_url TEXT,
                                                     vault_mount_path TEXT,
-                                                    vault_ca_path TEXT)
+                                                    vault_ca_path TEXT DEFAULT NULL)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
@@ -243,7 +243,7 @@ CREATE FUNCTION pg_tde_change_global_key_provider_vault_v2(provider_name TEXT,
                                                            vault_token_path TEXT,
                                                            vault_url TEXT,
                                                            vault_mount_path TEXT,
-                                                           vault_ca_path TEXT)
+                                                           vault_ca_path TEXT DEFAULT NULL)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC

--- a/contrib/pg_tde/sql/vault_v2_test.sql
+++ b/contrib/pg_tde/sql/vault_v2_test.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 \getenv root_token_file ROOT_TOKEN_FILE
 
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','http://127.0.0.1:8200','DUMMY-TOKEN');
 -- FAILS
 SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-incorrect');
 
@@ -12,7 +12,7 @@ CREATE TABLE test_enc(
 	  PRIMARY KEY (id)
 	) USING tde_heap;
 
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','http://127.0.0.1:8200','secret',NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','http://127.0.0.1:8200','secret');
 SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-v2');
 
 CREATE TABLE test_enc(
@@ -32,6 +32,6 @@ SELECT pg_tde_verify_key();
 DROP TABLE test_enc;
 
 -- Creating provider fails if we can't connect to vault
-SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret', NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret');
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/vault_v2_test.sql
+++ b/contrib/pg_tde/sql/vault_v2_test.sql
@@ -1,8 +1,9 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-\getenv root_token_file ROOT_TOKEN_FILE
+\getenv root_token_file VAULT_ROOT_TOKEN_FILE
+\getenv cacert_file VAULT_CACERT_FILE
 
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','http://127.0.0.1:8200','DUMMY-TOKEN');
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','https://127.0.0.1:8200','DUMMY-TOKEN',:'cacert_file');
 -- FAILS
 SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-incorrect');
 
@@ -12,7 +13,7 @@ CREATE TABLE test_enc(
 	  PRIMARY KEY (id)
 	) USING tde_heap;
 
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','http://127.0.0.1:8200','secret');
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','https://127.0.0.1:8200','secret',:'cacert_file');
 SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-v2');
 
 CREATE TABLE test_enc(
@@ -32,9 +33,15 @@ SELECT pg_tde_verify_key();
 DROP TABLE test_enc;
 
 -- Creating provider fails if we can't connect to vault
-SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret');
+SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
 
 -- Changing provider fails if we can't connect to vault
-SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:61', 'secret');
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
+
+-- HTTPS without cert fails
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','https://127.0.0.1:8200','DUMMY-TOKEN');
+
+-- HTTP against HTTPS server fails
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','http://127.0.0.1:8200','DUMMY-TOKEN');
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/vault_v2_test.sql
+++ b/contrib/pg_tde/sql/vault_v2_test.sql
@@ -34,4 +34,7 @@ DROP TABLE test_enc;
 -- Creating provider fails if we can't connect to vault
 SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret');
 
+-- Changing provider fails if we can't connect to vault
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:61', 'secret');
+
 DROP EXTENSION pg_tde;


### PR DESCRIPTION
Instead of inputting `NULL` into the `vault_ca_path` argument we allow users to just leave it out. But additionally we fix our tests to always use HTTPS and update the documentation examples to prefer HTTPS over HTTP: