### PR TITLE
PG-1464 Run CodeChecker only on main branch

### DIFF
--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -1,6 +1,5 @@
 name: CodeChecker
 on:
-  pull_request:
   push:
     branches:
       - TDE_REL_17_STABLE


### PR DESCRIPTION
There is no actual reason to run CodeChecker for PRs at this moment. Maybe sometime later we will enable it back. That will require a solution on how to properly run such workflow for extenal PRs and keep secrets safe.