### PR TITLE
Clean up static functions in `tde_keyring.c`

### DIFF
--- a/contrib/pg_tde/src/include/catalog/tde_keyring.h
+++ b/contrib/pg_tde/src/include/catalog/tde_keyring.h
@@ -35,12 +35,6 @@ extern GenericKeyring *GetKeyProviderByID(int provider_id, Oid dbOid);
 extern ProviderType get_keyring_provider_from_typename(char *provider_type);
 extern void InitializeKeyProviderInfo(void);
 extern void key_provider_startup_cleanup(Oid databaseId);
-extern void save_new_key_provider_info(KeyringProviderRecord *provider,
-									   Oid databaseId, bool write_xlog);
-extern void modify_key_provider_info(KeyringProviderRecord *provider,
-									 Oid databaseId, bool write_xlog);
-extern void delete_key_provider_info(char *provider_name,
-									 Oid databaseId, bool write_xlog);
 extern bool get_keyring_info_file_record_by_name(char *provider_name,
 												 Oid database_id,
 												 KeyringProviderRecordInFile *record);


### PR DESCRIPTION
Several functions which should have been static were not decleared as such and they also took a pointless write_xlog argument which always was true.

Plus add a couple of missing static annotations.