### PR TITLE
PG-1651 Do not try the fetch key from old provider when changing provider settings

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -696,9 +696,9 @@ pg_tde_count_relations(Oid dbOid)
 }
 
 bool
-pg_tde_verify_principal_key_info(TDESignedPrincipalKeyInfo *signed_key_info, const TDEPrincipalKey *principal_key)
+pg_tde_verify_principal_key_info(TDESignedPrincipalKeyInfo *signed_key_info, const KeyData *principal_key_data)
 {
-	return AesGcmDecrypt(principal_key->keyData,
+	return AesGcmDecrypt(principal_key_data->data,
 						 signed_key_info->sign_iv, MAP_ENTRY_IV_SIZE,
 						 (unsigned char *) &signed_key_info->data, sizeof(signed_key_info->data),
 						 NULL, 0,

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -103,7 +103,7 @@ extern int	pg_tde_count_relations(Oid dbOid);
 extern void pg_tde_delete_tde_files(Oid dbOid);
 
 extern TDESignedPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid);
-extern bool pg_tde_verify_principal_key_info(TDESignedPrincipalKeyInfo *signed_key_info, const TDEPrincipalKey *principal_key);
+extern bool pg_tde_verify_principal_key_info(TDESignedPrincipalKeyInfo *signed_key_info, const KeyData *principal_key_data);
 extern void pg_tde_save_principal_key(const TDEPrincipalKey *principal_key, bool write_xlog);
 extern void pg_tde_save_principal_key_redo(const TDESignedPrincipalKeyInfo *signed_key_info);
 extern void pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key, bool write_xlog);

--- a/contrib/pg_tde/t/expected/change_key_provider.out
+++ b/contrib/pg_tde/t/expected/change_key_provider.out
@@ -5,10 +5,10 @@ SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_prov
  
 (1 row)
 
-SELECT pg_tde_list_all_database_key_providers();
-                pg_tde_list_all_database_key_providers                 
------------------------------------------------------------------------
- (1,file-vault,file,"{""path"" : ""/tmp/change_key_provider_1.per""}")
+SELECT * FROM pg_tde_list_all_database_key_providers();
+ id | provider_name | provider_type |                   options                   
+----+---------------+---------------+---------------------------------------------
+  1 | file-vault    | file          | {"path" : "/tmp/change_key_provider_1.per"}
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');
@@ -45,10 +45,10 @@ SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_p
  
 (1 row)
 
-SELECT pg_tde_list_all_database_key_providers();
-                pg_tde_list_all_database_key_providers                 
------------------------------------------------------------------------
- (1,file-vault,file,"{""path"" : ""/tmp/change_key_provider_2.per""}")
+SELECT * FROM pg_tde_list_all_database_key_providers();
+ id | provider_name | provider_type |                   options                   
+----+---------------+---------------+---------------------------------------------
+  1 | file-vault    | file          | {"path" : "/tmp/change_key_provider_2.per"}
 (1 row)
 
 SELECT pg_tde_verify_key();
@@ -71,6 +71,49 @@ SELECT * FROM test_enc ORDER BY id;
 (2 rows)
 
 -- server restart
+SELECT pg_tde_verify_key();
+ pg_tde_verify_key 
+-------------------
+ 
+(1 row)
+
+SELECT pg_tde_is_encrypted('test_enc');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+SELECT * FROM test_enc ORDER BY id;
+ id | k 
+----+---
+  1 | 5
+  2 | 6
+(2 rows)
+
+-- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_1.per
+-- server restart
+SELECT pg_tde_verify_key();
+psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
+SELECT pg_tde_is_encrypted('test_enc');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+SELECT * FROM test_enc ORDER BY id;
+psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
+SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');
+ pg_tde_change_database_key_provider_file 
+------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM pg_tde_list_all_database_key_providers();
+ id | provider_name | provider_type |                   options                   
+----+---------------+---------------+---------------------------------------------
+  1 | file-vault    | file          | {"path" : "/tmp/change_key_provider_1.per"}
+(1 row)
+
 SELECT pg_tde_verify_key();
  pg_tde_verify_key 
 -------------------


### PR DESCRIPTION
We used to verify that all keys are still accessible by fetching the key from cache and if not cached from the current provider settings when changing the key provider setting but this makes things fragile and prone to user error in the case where a principal key is not cached.

Instead we can rely on the AEAD tag in the header of each file, which has two advantages 1) the cached and non-cache code path works the same and 2) we do not need to care about if the old provider is accessible, only that the new one is and that it contains the right key (i.e. one that can verify the header tag).