### PR TITLE
PG-1607 Fix tests and documentation around Vault TLS support

### DIFF
--- a/contrib/pg_tde/documentation/docs/global-key-provider-configuration/vault.md
+++ b/contrib/pg_tde/documentation/docs/global-key-provider-configuration/vault.md
@@ -31,9 +31,9 @@ The following example is for testing purposes only. Use secure tokens and proper
 SELECT pg_tde_add_global_key_provider_vault_v2(
     'my-vault',
     '/path/to/token_file',
-    'http://vault.vault.svc.cluster.local:8200',
+    'https://vault.vault.svc.cluster.local:8200',
     'secret/data',
-    NULL
+    '/path/to/ca_cert.pem'
 );
 ```
 

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -1,6 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-\getenv root_token_file ROOT_TOKEN_FILE
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
+\getenv root_token_file VAULT_ROOT_TOKEN_FILE
+\getenv cacert_file VAULT_CACERT_FILE
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','https://127.0.0.1:8200','DUMMY-TOKEN',:'cacert_file');
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
  
@@ -16,7 +17,7 @@ CREATE TABLE test_enc(
 	) USING tde_heap;
 ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_key before using encrypted tables
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','http://127.0.0.1:8200','secret',NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','https://127.0.0.1:8200','secret',:'cacert_file');
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
  
@@ -52,9 +53,15 @@ SELECT pg_tde_verify_key();
 
 DROP TABLE test_enc;
 -- Creating provider fails if we can't connect to vault
-SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret', NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
 ERROR:  HTTP(S) request to keyring provider "will-not-work" failed
 -- Changing provider fails if we can't connect to vault
-SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:61', 'secret', NULL);
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
 ERROR:  HTTP(S) request to keyring provider "vault-v2" failed
+-- HTTPS without cert fails
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'https://127.0.0.1:8200', 'secret', NULL);
+ERROR:  HTTP(S) request to keyring provider "vault-v2" failed
+-- HTTP against HTTPS server fails
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:8200', 'secret', NULL);
+ERROR:  Listing secrets of "http://127.0.0.1:8200" at mountpoint "secret" failed
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -54,4 +54,7 @@ DROP TABLE test_enc;
 -- Creating provider fails if we can't connect to vault
 SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret', NULL);
 ERROR:  HTTP(S) request to keyring provider "will-not-work" failed
+-- Changing provider fails if we can't connect to vault
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:61', 'secret', NULL);
+ERROR:  HTTP(S) request to keyring provider "vault-v2" failed
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/vault_v2_test.sql
+++ b/contrib/pg_tde/sql/vault_v2_test.sql
@@ -1,8 +1,9 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 
-\getenv root_token_file ROOT_TOKEN_FILE
+\getenv root_token_file VAULT_ROOT_TOKEN_FILE
+\getenv cacert_file VAULT_CACERT_FILE
 
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','http://127.0.0.1:8200','DUMMY-TOKEN',NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','https://127.0.0.1:8200','DUMMY-TOKEN',:'cacert_file');
 -- FAILS
 SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-incorrect');
 
@@ -12,7 +13,7 @@ CREATE TABLE test_enc(
 	  PRIMARY KEY (id)
 	) USING tde_heap;
 
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','http://127.0.0.1:8200','secret',NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','https://127.0.0.1:8200','secret',:'cacert_file');
 SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-v2');
 
 CREATE TABLE test_enc(
@@ -32,9 +33,15 @@ SELECT pg_tde_verify_key();
 DROP TABLE test_enc;
 
 -- Creating provider fails if we can't connect to vault
-SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret', NULL);
+SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
 
 -- Changing provider fails if we can't connect to vault
-SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:61', 'secret', NULL);
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
+
+-- HTTPS without cert fails
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'https://127.0.0.1:8200', 'secret', NULL);
+
+-- HTTP against HTTPS server fails
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:8200', 'secret', NULL);
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/vault_v2_test.sql
+++ b/contrib/pg_tde/sql/vault_v2_test.sql
@@ -34,4 +34,7 @@ DROP TABLE test_enc;
 -- Creating provider fails if we can't connect to vault
 SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'http://127.0.0.1:61', 'secret', NULL);
 
+-- Changing provider fails if we can't connect to vault
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:61', 'secret', NULL);
+
 DROP EXTENSION pg_tde;


### PR DESCRIPTION
This is split out from #392 since the refactoring to use TLS by default in both documentation and tests is largely unrelated to the behavioral changes I proposed there.

This makes sure we run TLS in our test suite since that is what we will use by default anyway plus also push for TLS in our documentation.