### PR TITLE
Use `OpenTransientFile()` instead of `BasicOpenFile()`

### DIFF
--- a/contrib/pg_tde/src/include/pg_tde_fe.h
+++ b/contrib/pg_tde/src/include/pg_tde_fe.h
@@ -85,7 +85,8 @@ static int	tde_fe_error_level = 0;
 #define LW_EXCLUSIVE NULL
 #define tde_lwlock_enc_keys() NULL
 
-#define BasicOpenFile(fileName, fileFlags) open(fileName, fileFlags, PG_FILE_MODE_OWNER)
+#define OpenTransientFile(fileName, fileFlags) open(fileName, fileFlags, PG_FILE_MODE_OWNER)
+#define CloseTransientFile(fd) close(fd)
 #define AllocateFile(name, mode) fopen(name, mode)
 #define FreeFile(file) fclose(file)
 


### PR DESCRIPTION
By using `OpenTransientFile()` we do not have to close file descriptors on error plus PostgreSQL will check if we have forgot to close any files on commit.

This change made us find one instance where we had forgot to close a file which is also fixed in this commit.