### PR TITLE
Use ubuntu 24.04 in main CI workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,6 +31,12 @@ jobs:
           submodules: recursive
           ref: ${{ github.ref }}
 
+      # KMIP server don't support Python 3.12 for now: https://github.com/OpenKMIP/PyKMIP/pull/707 
+      - name: Downgrade python to 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
       - name: Install dependencies
         run: src/ci_scripts/ubuntu-deps.sh
 
@@ -64,9 +70,14 @@ jobs:
       - name: Extract artifact file
         run: tar -xzf artifacts.tar
 
+      - name: Downgrade python to 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
       - name: Install dependencies
         run: src/ci_scripts/ubuntu-deps.sh
-  
+
       - name: Setup kmip and vault
         run: src/ci_scripts/setup-keyring-servers.sh
 
@@ -108,6 +119,12 @@ jobs:
 
       - name: Extract artifact file
         run: tar -xzf artifacts.tar
+
+      # KMIP server don't support Python 3.12 for now: https://github.com/OpenKMIP/PyKMIP/pull/707
+      - name: Downgrade python to 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
 
       - name: Install dependencies
         run: src/ci_scripts/ubuntu-deps.sh

--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -11,12 +11,18 @@ env:
 jobs:
   run:
     name: Run
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      # CodeChecker doesn't support python 3.12 for now: https://github.com/Ericsson/codechecker/issues/4350
+      - name: Downgrade python to 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
 
       - name: Install dependencies
         run: ci_scripts/ubuntu-deps.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,12 +11,18 @@ env:
 jobs:
   collect:
     name: Collect and upload
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      # KMIP server doesn't support Python 3.12 for now: https://github.com/OpenKMIP/PyKMIP/pull/707
+      - name: Downgrade python to 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
 
       - name: Install dependencies
         run: ci_scripts/ubuntu-deps.sh

--- a/.github/workflows/matirx.yml
+++ b/.github/workflows/matirx.yml
@@ -11,7 +11,7 @@ jobs:
     name: Main matrix
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         compiler: [gcc, clang]
         build_type: [debugoptimized]
         build_script: [make, meson]
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name != 'pull_request'
     strategy:
       matrix:
-        os: [ubuntu-22.04-arm]
+        os: [ubuntu-24.04-arm]
         compiler: [gcc, clang]
         build_type: [debugoptimized]
         build_script: [make, meson]

--- a/ci_scripts/ubuntu-deps.sh
+++ b/ci_scripts/ubuntu-deps.sh
@@ -29,11 +29,6 @@ DEPS=(
     mawk
     perl
     pkgconf
-    python3-dev
-    python3
-    python3-pip
-    python3-setuptools
-    python3-wheel
     systemtap-sdt-dev
     tcl-dev
     uuid-dev
@@ -45,7 +40,6 @@ DEPS=(
     # Test
     libipc-run-perl
     # Test pg_tde
-    python3-pykmip
     libhttp-server-simple-perl
     lcov
     # Run pgperltidy
@@ -56,7 +50,7 @@ sudo apt-get update
 sudo apt-get install -y ${DEPS[@]}
 
 sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
-pip3 install meson
+pip3 install meson pykmip cryptography setuptools wheel
 
 # Vault
 wget -O - https://apt.releases.hashicorp.com/gpg | sudo tee /etc/apt/keyrings/hashicorp-archive-keyring.asc


### PR DESCRIPTION
This PR upgrades ubuntu version used in main CI workflows. There was a problem caused by Python version 3.12 installed in ubuntu 24.04 image. KMIP server and CodeChecker tool don't work with Python version as it introduced some breaking changes. So we have to downgrade Python version.

https://github.com/OpenKMIP/PyKMIP/pull/707
https://github.com/Ericsson/codechecker/issues/4350

The only workflow that I wasn't able to migrate to ubuntu 24.04 is sanitizers.yml due LLVM version. Clang versions > 14 causes some weird troubles during tests run. It requires dedicated investigation. 