### PR TITLE
PG-1607 PG-1652 Unify argument order for KMIP and Vault providers

### DIFF
--- a/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-change-key-provider.md
+++ b/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-change-key-provider.md
@@ -31,6 +31,6 @@ Depending on the provider type, the additional parameters are:
 
 ```bash
 pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> file <filename>
-pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> vault <token_path> <url> <mount_path> [<ca_path>]
+pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> vault-v2 <url> <mount_path> <token_path> [<ca_path>]
 pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> kmip <host> <port> <cert_path> <key_path> [<ca_path>] 
 ```

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -63,15 +63,17 @@ Use the following functions to add the Vault provider:
 ```sql
 SELECT pg_tde_add_database_key_provider_vault_v2(
   'provider-name',
+  'url',
+  'mount',
   'secret_token_path',
-  'url','mount',
   'ca_path'
 );
 
 SELECT pg_tde_add_global_key_provider_vault_v2(
   'provider-name',
+  'url',
+  'mount',
   'secret_token_path',
-  'url','mount',
   'ca_path'
 );
 ```
@@ -81,17 +83,17 @@ These functions change the Vault provider:
 ```sql
 SELECT pg_tde_change_database_key_provider_vault_v2(
   'provider-name',
-  'secret_token_path',
   'url',
   'mount',
+  'secret_token_path',
   'ca_path'
 );
 
 SELECT pg_tde_change_global_key_provider_vault_v2(
   'provider-name',
-  'secret_token_path',
   'url',
   'mount',
+  'secret_token_path',
   'ca_path'
 );
 ```
@@ -115,19 +117,19 @@ Use these functions to add a KMIP provider:
 ```sql
 SELECT pg_tde_add_database_key_provider_kmip(
   'provider-name',
-  'kmip-addr', 
-  `port`, 
-  '/path_to/server_certificate.pem', 
-  '/path_to/client_cert.pem', 
-  '/path_to/client_key.pem'
+  'kmip-addr',
+  port,
+  '/path_to/client_cert.pem',
+  '/path_to/client_key.pem',
+  '/path_to/server_certificate.pem'
 );
 SELECT pg_tde_add_global_key_provider_kmip(
   'provider-name',
-  'kmip-addr', 
-  `port`, 
-  '/path_to/server_certificate.pem', 
-  '/path_to/client_certificate.pem', 
-  '/path_to/client_key.pem'
+  'kmip-addr',
+  port,
+  '/path_to/client_certificate.pem',
+  '/path_to/client_key.pem',
+  '/path_to/server_certificate.pem'
 );
 ```
 
@@ -136,19 +138,19 @@ These functions change the KMIP provider:
 ```sql
 SELECT pg_tde_change_database_key_provider_kmip(
   'provider-name',
-  'kmip-addr', 
-  `port`, 
-  '/path_to/server_certificate.pem', 
-  '/path_to/client_cert.pem', 
-  '/path_to/client_key.pem'
+  'kmip-addr',
+  port,
+  '/path_to/client_cert.pem',
+  '/path_to/client_key.pem',
+  '/path_to/server_certificate.pem'
 );
 SELECT pg_tde_change_global_key_provider_kmip(
   'provider-name',
-  'kmip-addr', 
-  `port`, 
-  '/path_to/server_certificate.pem', 
-  '/path_to/client_certificate.pem', 
-  '/path_to/client_key.pem'
+  'kmip-addr',
+  port,
+  '/path_to/client_certificate.pem',
+  '/path_to/client_key.pem',
+  '/path_to/server_certificate.pem'
 );
 ```
 

--- a/contrib/pg_tde/documentation/docs/global-key-provider-configuration/vault.md
+++ b/contrib/pg_tde/documentation/docs/global-key-provider-configuration/vault.md
@@ -10,9 +10,9 @@ You can configure `pg_tde` to use HashiCorp Vault as a global key provider for m
 ```sql
 SELECT pg_tde_add_global_key_provider_vault_v2(
     'provider-name',
-    'secret_token_path',
     'url',
     'mount',
+    'secret_token_path',
     'ca_path'
 );
 ```
@@ -30,9 +30,9 @@ The following example is for testing purposes only. Use secure tokens and proper
 ```sql
 SELECT pg_tde_add_global_key_provider_vault_v2(
     'my-vault',
-    '/path/to/token_file',
     'https://vault.vault.svc.cluster.local:8200',
     'secret/data',
+    '/path/to/token_file',
     '/path/to/ca_cert.pem'
 );
 ```

--- a/contrib/pg_tde/documentation/docs/how-to/multi-tenant-setup.md
+++ b/contrib/pg_tde/documentation/docs/how-to/multi-tenant-setup.md
@@ -61,7 +61,7 @@ You must do these steps for every database where you have created the extension.
         For testing purposes, you can use the PyKMIP server which enables you to set up required certificates. To use a real KMIP server, make sure to obtain the valid certificates issued by the key management appliance. 
 
         ```sql
-        SELECT pg_tde_add_database_key_provider_kmip('provider-name','kmip-addr', 5696, '/path_to/server_certificate.pem', '/path_to/client_cert.pem', '/path_to/client_key.pem');
+        SELECT pg_tde_add_database_key_provider_kmip('provider-name','kmip-addr', 5696, '/path_to/client_cert.pem', '/path_to/client_key.pem', '/path_to/server_certificate.pem');
         ```
 
         where:
@@ -75,8 +75,8 @@ You must do these steps for every database where you have created the extension.
 
         <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
-        ```
-        SELECT pg_tde_add_database_key_provider_kmip('kmip','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_cert_jane_doe.pem', '/tmp/client_key_jane_doe.pem');
+        ```sql
+        SELECT pg_tde_add_database_key_provider_kmip('kmip', '127.0.0.1', 5696, '/tmp/client_cert_jane_doe.pem', '/tmp/client_key_jane_doe.pem', '/tmp/server_certificate.pem');
         ```
 
     === "With HashiCorp Vault"
@@ -84,7 +84,7 @@ You must do these steps for every database where you have created the extension.
         The Vault server setup is out of scope of this document.
 
         ```sql
-        SELECT pg_tde_add_database_key_provider_vault_v2('provider-name','secret_token_path','url','mount','ca_path');
+        SELECT pg_tde_add_database_key_provider_vault_v2('provider-name', 'url', 'mount', 'secret_token_path', 'ca_path');
         ``` 
 
         where: 
@@ -105,13 +105,13 @@ You must do these steps for every database where you have created the extension.
         This setup is intended for development and stores the keys unencrypted in the specified data file.
 
         ```sql
-        SELECT pg_tde_add_database_key_provider_file('provider-name','/path/to/the/keyring/data.file');
+        SELECT pg_tde_add_database_key_provider_file('provider-name', '/path/to/the/keyring/data.file');
         ```
 
 	    <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
 	    ```sql
-	    SELECT pg_tde_add_database_key_provider_file('file-keyring','/tmp/pg_tde_test_local_keyring.per');
+	    SELECT pg_tde_add_database_key_provider_file('file-keyring', '/tmp/pg_tde_test_local_keyring.per');
 	    ```
   
 2. Add a principal key

--- a/contrib/pg_tde/documentation/docs/wal-encryption.md
+++ b/contrib/pg_tde/documentation/docs/wal-encryption.md
@@ -19,7 +19,7 @@ Before turning WAL encryption on, you must follow the steps below to create your
         For testing purposes, you can use the PyKMIP server which enables you to set up required certificates. To use a real KMIP server, make sure to obtain the valid certificates issued by the key management appliance.
 
         ```sql
-        SELECT pg_tde_add_global_key_provider_kmip('provider-name','kmip-addr', 5696, '/path_to/server_certificate.pem', '/path_to/client_cert.pem', '/path_to/client_key.pem');
+        SELECT pg_tde_add_global_key_provider_kmip('provider-name', 'kmip-addr', 5696, '/path_to/client_cert.pem', '/path_to/client_key.pem', '/path_to/server_certificate.pem');
         ```
 
         where:
@@ -33,14 +33,14 @@ Before turning WAL encryption on, you must follow the steps below to create your
 
         <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
-        ```
-        SELECT pg_tde_add_key_using_global_key_provider_kmip('kmip','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_cert_jane_doe.pem', '/tmp/client_key_jane_doe.pem');
+        ```sql
+        SELECT pg_tde_add_key_using_global_key_provider_kmip('kmip', '127.0.0.1', 5696, '/tmp/client_cert_jane_doe.pem', '/tmp/client_key_jane_doe.pem', '/tmp/server_certificate.pem');
         ```
 
     === "With HashiCorp Vault"
 
         ```sql
-        SELECT pg_tde_add_global_key_provider_vault_v2('provider-name', 'secret_token_path', 'url', 'mount', 'ca_path');
+        SELECT pg_tde_add_global_key_provider_vault_v2('provider-name', 'url', 'mount', 'secret_token_path', 'ca_path');
         ```
 
         where:
@@ -56,7 +56,7 @@ Before turning WAL encryption on, you must follow the steps below to create your
         This setup is **not recommended**, as it is intended for development. The keys are stored **unencrypted** in the specified data file.
 
         ```sql
-        SELECT pg_tde_add_global_key_provider_file('provider-name','/path/to/the/keyring/data.file');
+        SELECT pg_tde_add_global_key_provider_file('provider-name', '/path/to/the/keyring/data.file');
         ```
 
 3. Create principal key

--- a/contrib/pg_tde/expected/kmip_test.out
+++ b/contrib/pg_tde/expected/kmip_test.out
@@ -1,5 +1,5 @@
 CREATE EXTENSION pg_tde;
-SELECT pg_tde_add_database_key_provider_kmip('kmip-prov','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_certificate_jane_doe.pem', '/tmp/client_key_jane_doe.pem');
+SELECT pg_tde_add_database_key_provider_kmip('kmip-prov', '127.0.0.1', 5696, '/tmp/client_certificate_jane_doe.pem', '/tmp/client_key_jane_doe.pem', '/tmp/server_certificate.pem');
  pg_tde_add_database_key_provider_kmip 
 ---------------------------------------
  
@@ -35,6 +35,6 @@ SELECT pg_tde_verify_key();
 
 DROP TABLE test_enc;
 -- Creating provider fails if we can't connect to kmip server
-SELECT pg_tde_add_database_key_provider_kmip('will-not-work','127.0.0.1', 61, '/tmp/server_certificate.pem', '/tmp/client_certificate_jane_doe.pem', '/tmp/client_key_jane_doe.pem');
+SELECT pg_tde_add_database_key_provider_kmip('will-not-work', '127.0.0.1', 61, '/tmp/client_certificate_jane_doe.pem', '/tmp/client_key_jane_doe.pem', '/tmp/server_certificate.pem');
 ERROR:  SSL error: BIO_do_connect failed
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -1,14 +1,14 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 \getenv root_token_file VAULT_ROOT_TOKEN_FILE
 \getenv cacert_file VAULT_CACERT_FILE
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','https://127.0.0.1:8200','DUMMY-TOKEN',:'cacert_file');
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect', 'https://127.0.0.1:8200', 'DUMMY-TOKEN', :'root_token_file', :'cacert_file');
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
  
 (1 row)
 
 -- FAILS
-SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-incorrect');
+SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key', 'vault-incorrect');
 ERROR:  Invalid HTTP response from keyring provider "vault-incorrect": 404
 CREATE TABLE test_enc(
 	  id SERIAL,
@@ -17,13 +17,13 @@ CREATE TABLE test_enc(
 	) USING tde_heap;
 ERROR:  principal key not configured
 HINT:  create one using pg_tde_set_key before using encrypted tables
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','https://127.0.0.1:8200','secret',:'cacert_file');
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2', 'https://127.0.0.1:8200', 'secret', :'root_token_file', :'cacert_file');
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------
  
 (1 row)
 
-SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-v2');
+SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key', 'vault-v2');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
  
@@ -53,15 +53,15 @@ SELECT pg_tde_verify_key();
 
 DROP TABLE test_enc;
 -- Creating provider fails if we can't connect to vault
-SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
+SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', 'https://127.0.0.1:61', 'secret', :'root_token_file', :'cacert_file');
 ERROR:  HTTP(S) request to keyring provider "will-not-work" failed
 -- Changing provider fails if we can't connect to vault
-SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', 'https://127.0.0.1:61', 'secret', :'root_token_file', :'cacert_file');
 ERROR:  HTTP(S) request to keyring provider "vault-v2" failed
 -- HTTPS without cert fails
-SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'https://127.0.0.1:8200', 'secret', NULL);
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', 'https://127.0.0.1:8200', 'secret', :'root_token_file', NULL);
 ERROR:  HTTP(S) request to keyring provider "vault-v2" failed
 -- HTTP against HTTPS server fails
-SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:8200', 'secret', NULL);
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', 'http://127.0.0.1:8200', 'secret', :'root_token_file', NULL);
 ERROR:  Listing secrets of "http://127.0.0.1:8200" at mountpoint "secret" failed
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -27,35 +27,35 @@ BEGIN ATOMIC
 END;
 
 CREATE FUNCTION pg_tde_add_database_key_provider_vault_v2(provider_name TEXT,
-                                                vault_token_path TEXT,
                                                 vault_url TEXT,
                                                 vault_mount_path TEXT,
+                                                vault_token_path TEXT,
                                                 vault_ca_path TEXT)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     SELECT pg_tde_add_database_key_provider('vault-v2', provider_name,
                             json_object('url' VALUE vault_url,
-                            'tokenPath' VALUE vault_token_path,
                             'mountPath' VALUE vault_mount_path,
+                            'tokenPath' VALUE vault_token_path,
                             'caPath' VALUE vault_ca_path));
 END;
 
 CREATE FUNCTION pg_tde_add_database_key_provider_kmip(provider_name TEXT,
                                              kmip_host TEXT,
                                              kmip_port INT,
-                                             kmip_ca_path TEXT,
                                              kmip_cert_path TEXT,
-                                             kmip_key_path TEXT)
+                                             kmip_key_path TEXT,
+                                             kmip_ca_path TEXT)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     SELECT pg_tde_add_database_key_provider('kmip', provider_name,
                             json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
-                            'caPath' VALUE kmip_ca_path,
                             'certPath' VALUE kmip_cert_path,
-                            'keyPath' VALUE kmip_key_path));
+                            'keyPath' VALUE kmip_key_path,
+                            'caPath' VALUE kmip_ca_path));
 END;
 
 CREATE FUNCTION pg_tde_list_all_database_key_providers
@@ -102,35 +102,35 @@ BEGIN ATOMIC
 END;
 
 CREATE FUNCTION pg_tde_add_global_key_provider_vault_v2(provider_name TEXT,
-                                                        vault_token_path TEXT,
                                                         vault_url TEXT,
                                                         vault_mount_path TEXT,
+                                                        vault_token_path TEXT,
                                                         vault_ca_path TEXT)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     SELECT pg_tde_add_global_key_provider('vault-v2', provider_name,
                             json_object('url' VALUE vault_url,
-                            'tokenPath' VALUE vault_token_path,
                             'mountPath' VALUE vault_mount_path,
+                            'tokenPath' VALUE vault_token_path,
                             'caPath' VALUE vault_ca_path));
 END;
 
 CREATE FUNCTION pg_tde_add_global_key_provider_kmip(provider_name TEXT,
                                                     kmip_host TEXT,
                                                     kmip_port INT,
-                                                    kmip_ca_path TEXT,
                                                     kmip_cert_path TEXT,
-                                                    kmip_key_path TEXT)
+                                                    kmip_key_path TEXT,
+                                                    kmip_ca_path TEXT)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     SELECT pg_tde_add_global_key_provider('kmip', provider_name,
                             json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
-                            'caPath' VALUE kmip_ca_path,
                             'certPath' VALUE kmip_cert_path,
-                            'keyPath' VALUE kmip_key_path));
+                            'keyPath' VALUE kmip_key_path,
+                            'caPath' VALUE kmip_ca_path));
 END;
 
 -- Key Provider Management
@@ -157,26 +157,26 @@ BEGIN ATOMIC
 END;
 
 CREATE FUNCTION pg_tde_change_database_key_provider_vault_v2(provider_name TEXT,
-                                                    vault_token_path TEXT,
                                                     vault_url TEXT,
                                                     vault_mount_path TEXT,
+                                                    vault_token_path TEXT,
                                                     vault_ca_path TEXT)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     SELECT pg_tde_change_database_key_provider('vault-v2', provider_name,
                             json_object('url' VALUE vault_url,
-                            'tokenPath' VALUE vault_token_path,
                             'mountPath' VALUE vault_mount_path,
+                            'tokenPath' VALUE vault_token_path,
                             'caPath' VALUE vault_ca_path));
 END;
 
 CREATE FUNCTION pg_tde_change_database_key_provider_kmip(provider_name TEXT,
                                                 kmip_host TEXT,
                                                 kmip_port INT,
-                                                kmip_ca_path TEXT,
                                                 kmip_cert_path TEXT,
-                                                kmip_key_path TEXT)
+                                                kmip_key_path TEXT,
+                                                kmip_ca_path TEXT)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
@@ -212,35 +212,35 @@ BEGIN ATOMIC
 END;
 
 CREATE FUNCTION pg_tde_change_global_key_provider_vault_v2(provider_name TEXT,
-                                                           vault_token_path TEXT,
                                                            vault_url TEXT,
                                                            vault_mount_path TEXT,
+                                                           vault_token_path TEXT,
                                                            vault_ca_path TEXT)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     SELECT pg_tde_change_global_key_provider('vault-v2', provider_name,
                             json_object('url' VALUE vault_url,
-                            'tokenPath' VALUE vault_token_path,
                             'mountPath' VALUE vault_mount_path,
+                            'tokenPath' VALUE vault_token_path,
                             'caPath' VALUE vault_ca_path));
 END;
 
 CREATE FUNCTION pg_tde_change_global_key_provider_kmip(provider_name TEXT,
                                                        kmip_host TEXT,
                                                        kmip_port INT,
-                                                       kmip_ca_path TEXT,
                                                        kmip_cert_path TEXT,
-                                                       kmip_key_path TEXT)
+                                                       kmip_key_path TEXT,
+                                                       kmip_ca_path TEXT)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
     SELECT pg_tde_change_global_key_provider('kmip', provider_name,
                             json_object('host' VALUE kmip_host,
                             'port' VALUE kmip_port,
-                            'caPath' VALUE kmip_ca_path,
                             'certPath' VALUE kmip_cert_path,
-                            'keyPath' VALUE kmip_key_path));
+                            'keyPath' VALUE kmip_key_path,
+                            'caPath' VALUE kmip_ca_path));
 END;
 
 CREATE FUNCTION pg_tde_is_encrypted(relation REGCLASS)

--- a/contrib/pg_tde/sql/kmip_test.sql
+++ b/contrib/pg_tde/sql/kmip_test.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION pg_tde;
 
-SELECT pg_tde_add_database_key_provider_kmip('kmip-prov','127.0.0.1', 5696, '/tmp/server_certificate.pem', '/tmp/client_certificate_jane_doe.pem', '/tmp/client_key_jane_doe.pem');
+SELECT pg_tde_add_database_key_provider_kmip('kmip-prov', '127.0.0.1', 5696, '/tmp/client_certificate_jane_doe.pem', '/tmp/client_key_jane_doe.pem', '/tmp/server_certificate.pem');
 SELECT pg_tde_set_key_using_database_key_provider('kmip-key','kmip-prov');
 
 CREATE TABLE test_enc(
@@ -20,6 +20,6 @@ SELECT pg_tde_verify_key();
 DROP TABLE test_enc;
 
 -- Creating provider fails if we can't connect to kmip server
-SELECT pg_tde_add_database_key_provider_kmip('will-not-work','127.0.0.1', 61, '/tmp/server_certificate.pem', '/tmp/client_certificate_jane_doe.pem', '/tmp/client_key_jane_doe.pem');
+SELECT pg_tde_add_database_key_provider_kmip('will-not-work', '127.0.0.1', 61, '/tmp/client_certificate_jane_doe.pem', '/tmp/client_key_jane_doe.pem', '/tmp/server_certificate.pem');
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/sql/vault_v2_test.sql
+++ b/contrib/pg_tde/sql/vault_v2_test.sql
@@ -3,9 +3,9 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 \getenv root_token_file VAULT_ROOT_TOKEN_FILE
 \getenv cacert_file VAULT_CACERT_FILE
 
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect',:'root_token_file','https://127.0.0.1:8200','DUMMY-TOKEN',:'cacert_file');
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect', 'https://127.0.0.1:8200', 'DUMMY-TOKEN', :'root_token_file', :'cacert_file');
 -- FAILS
-SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-incorrect');
+SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key', 'vault-incorrect');
 
 CREATE TABLE test_enc(
 	  id SERIAL,
@@ -13,8 +13,8 @@ CREATE TABLE test_enc(
 	  PRIMARY KEY (id)
 	) USING tde_heap;
 
-SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2',:'root_token_file','https://127.0.0.1:8200','secret',:'cacert_file');
-SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key','vault-v2');
+SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2', 'https://127.0.0.1:8200', 'secret', :'root_token_file', :'cacert_file');
+SELECT pg_tde_set_key_using_database_key_provider('vault-v2-key', 'vault-v2');
 
 CREATE TABLE test_enc(
 	  id SERIAL,
@@ -33,15 +33,15 @@ SELECT pg_tde_verify_key();
 DROP TABLE test_enc;
 
 -- Creating provider fails if we can't connect to vault
-SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
+SELECT pg_tde_add_database_key_provider_vault_v2('will-not-work', 'https://127.0.0.1:61', 'secret', :'root_token_file', :'cacert_file');
 
 -- Changing provider fails if we can't connect to vault
-SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'https://127.0.0.1:61', 'secret', :'cacert_file');
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', 'https://127.0.0.1:61', 'secret', :'root_token_file', :'cacert_file');
 
 -- HTTPS without cert fails
-SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'https://127.0.0.1:8200', 'secret', NULL);
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', 'https://127.0.0.1:8200', 'secret', :'root_token_file', NULL);
 
 -- HTTP against HTTPS server fails
-SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', :'root_token_file', 'http://127.0.0.1:8200', 'secret', NULL);
+SELECT pg_tde_change_database_key_provider_vault_v2('vault-v2', 'http://127.0.0.1:8200', 'secret', :'root_token_file', NULL);
 
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/src/pg_tde_change_key_provider.c
+++ b/contrib/pg_tde/src/pg_tde_change_key_provider.c
@@ -27,7 +27,7 @@ help(void)
 	puts("Depending on the provider type, the complete parameter list is:");
 	puts("");
 	puts("pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> file <filename>");
-	puts("pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> vault-v2 <url> <token_path> <mount_path> [<ca_path>]");
+	puts("pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> vault-v2 <url> <mount_path> <token_path> [<ca_path>]");
 	puts("pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> kmip <host> <port> <cert_path> <key_path> [<ca_path>]");
 	puts("");
 	printf("Use dbOid %d for global key providers.\n", GLOBAL_DATA_TDE_OID);
@@ -196,8 +196,8 @@ main(int argc, char *argv[])
 
 		if (!build_json(json, 4,
 						"url", argv[4 + argstart],
-						"tokenPath", argv[5 + argstart],
-						"mountPath", argv[6 + argstart],
+						"mountPath", argv[5 + argstart],
+						"tokenPath", argv[6 + argstart],
 						"caPath", (argc - argstart > 7 ? argv[7 + argstart] : "")))
 		{
 			exit(1);
@@ -219,9 +219,9 @@ main(int argc, char *argv[])
 		if (!build_json(json, 5,
 						"host", argv[4 + argstart],
 						"port", argv[5 + argstart],
-						"caPath", (argc - argstart > 8 ? argv[8 + argstart] : ""),
 						"certPath", argv[6 + argstart],
-						"keyPath", argv[7 + argstart]))
+						"keyPath", argv[7 + argstart],
+						"caPath", argc - argstart > 8 ? argv[8 + argstart] : ""))
 		{
 			exit(1);
 		}

--- a/contrib/pg_tde/t/pg_tde_change_key_provider.pl
+++ b/contrib/pg_tde/t/pg_tde_change_key_provider.pl
@@ -67,8 +67,8 @@ command_like(
 		'database-provider',
 		'vault-v2',
 		'https://vault-server.example:8200/',
-		$token_file,
 		'mount-path',
+		$token_file,
 		'/tmp/ca_path',
 	],
 	qr/Key provider updated successfully!/,
@@ -88,13 +88,13 @@ $options = decode_json(
 		'postgres',
 		q{SELECT options FROM pg_tde_list_all_database_key_providers() WHERE provider_name = 'database-provider'}
 	));
-is($options->{tokenPath}, $token_file,
-	'tokenPath is set correctly for vault-v2 provider');
 is( $options->{url},
 	'https://vault-server.example:8200/',
 	'url is set correctly for vault-v2 provider');
 is($options->{mountPath}, 'mount-path',
 	'mount path is set correctly for vault-v2 provider');
+is($options->{tokenPath}, $token_file,
+	'tokenPath is set correctly for vault-v2 provider');
 is($options->{caPath}, '/tmp/ca_path',
 	'CA path is set correctly for vault-v2 provider');
 
@@ -108,8 +108,8 @@ command_like(
 		'database-provider',
 		'vault-v2',
 		'http://vault-server.example:8200/',
-		$token_file,
 		'mount-path-2',
+		$token_file,
 	],
 	qr/Key provider updated successfully!/,
 	'updates key provider to vault-v2 type with http');
@@ -128,13 +128,13 @@ $options = decode_json(
 		'postgres',
 		q{SELECT options FROM pg_tde_list_all_database_key_providers() WHERE provider_name = 'database-provider'}
 	));
-is($options->{tokenPath}, $token_file,
-	'tokenPath is set correctly for vault-v2 provider');
 is( $options->{url},
 	'http://vault-server.example:8200/',
 	'url is set correctly for vault-v2 provider');
 is($options->{mountPath}, 'mount-path-2',
 	'mount path is set correctly for vault-v2 provider');
+is($options->{tokenPath}, $token_file,
+	'tokenPath is set correctly for vault-v2 provider');
 is($options->{caPath}, '', 'CA path is set correctly for vault-v2 provider');
 
 $node->stop;
@@ -189,8 +189,8 @@ command_like(
 		'global-provider',
 		'vault-v2',
 		'http://vault-server.example:8200/',
-		$token_file,
 		'mount-path',
+		$token_file,
 		'/tmp/ca_path',
 	],
 	qr/Key provider updated successfully!/,


### PR DESCRIPTION
The argument order differed between the CLI tool and the SQL functions which could cause confusion so we pick one order and standardize on it.

I also decided to not make the CA cert parameter optional, passing NULL is good enough.