### PR TITLE
Remove add/change file provider with json fragment

### DIFF
--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -5,7 +5,7 @@ SELECT  * FROM pg_tde_key_info();
           |                   |                 | 
 (1 row)
 
-SELECT pg_tde_add_database_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
+SELECT pg_tde_add_database_key_provider('file', 'incorrect-file-provider',  '{"path": {"foo": "/tmp/pg_tde_test_keyring.per"}}');
 ERROR:  key provider value cannot be an object
 SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
@@ -51,7 +51,7 @@ SELECT * FROM pg_tde_list_all_database_key_providers();
   2 | file-provider2 | file          | {"path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
-SELECT pg_tde_change_database_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
+SELECT pg_tde_change_database_key_provider('file', 'file-provider', '{"path": {"foo": "/tmp/pg_tde_test_keyring.per"}}');
 ERROR:  key provider value cannot be an object
 SELECT * FROM pg_tde_list_all_database_key_providers();
  id | provider_name  | provider_type |                  options                   

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -18,13 +18,6 @@ BEGIN ATOMIC
                 json_object('path' VALUE file_path));
 END;
 
-CREATE FUNCTION pg_tde_add_database_key_provider_file(provider_name TEXT, file_path JSON)
-RETURNS VOID
-LANGUAGE SQL
-BEGIN ATOMIC
-    SELECT pg_tde_add_database_key_provider('file', provider_name,
-                json_object('path' VALUE file_path));
-END;
 
 CREATE FUNCTION pg_tde_add_database_key_provider_vault_v2(provider_name TEXT,
                                                 vault_token_path TEXT,
@@ -93,13 +86,6 @@ BEGIN ATOMIC
                 json_object('path' VALUE file_path));
 END;
 
-CREATE FUNCTION pg_tde_add_global_key_provider_file(provider_name TEXT, file_path JSON)
-RETURNS VOID
-LANGUAGE SQL
-BEGIN ATOMIC
-    SELECT pg_tde_add_global_key_provider('file', provider_name,
-                json_object('path' VALUE file_path));
-END;
 
 CREATE FUNCTION pg_tde_add_global_key_provider_vault_v2(provider_name TEXT,
                                                         vault_token_path TEXT,
@@ -141,14 +127,6 @@ AS 'MODULE_PATHNAME';
 REVOKE ALL ON FUNCTION pg_tde_change_database_key_provider(TEXT, TEXT, JSON) FROM PUBLIC;
 
 CREATE FUNCTION pg_tde_change_database_key_provider_file(provider_name TEXT, file_path TEXT)
-RETURNS VOID
-LANGUAGE SQL
-BEGIN ATOMIC
-    SELECT pg_tde_change_database_key_provider('file', provider_name,
-                json_object('path' VALUE file_path));
-END;
-
-CREATE FUNCTION pg_tde_change_database_key_provider_file(provider_name TEXT, file_path JSON)
 RETURNS VOID
 LANGUAGE SQL
 BEGIN ATOMIC
@@ -203,13 +181,6 @@ BEGIN ATOMIC
                 json_object('path' VALUE file_path));
 END;
 
-CREATE FUNCTION pg_tde_change_global_key_provider_file(provider_name TEXT, file_path JSON)
-RETURNS VOID
-LANGUAGE SQL
-BEGIN ATOMIC
-    SELECT pg_tde_change_global_key_provider('file', provider_name,
-                json_object('path' VALUE file_path));
-END;
 
 CREATE FUNCTION pg_tde_change_global_key_provider_vault_v2(provider_name TEXT,
                                                            vault_token_path TEXT,

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pg_tde;
 
 SELECT  * FROM pg_tde_key_info();
 
-SELECT pg_tde_add_database_key_provider_file('incorrect-file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
+SELECT pg_tde_add_database_key_provider('file', 'incorrect-file-provider',  '{"path": {"foo": "/tmp/pg_tde_test_keyring.per"}}');
 SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_add_database_key_provider_file('file-provider2','/tmp/pg_tde_test_keyring2.per');
 SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_dup.per');
@@ -15,7 +15,7 @@ SELECT pg_tde_verify_key();
 SELECT pg_tde_change_database_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
 SELECT * FROM pg_tde_list_all_database_key_providers();
 
-SELECT pg_tde_change_database_key_provider_file('file-provider',  json_object('foo' VALUE '/tmp/pg_tde_test_keyring.per'));
+SELECT pg_tde_change_database_key_provider('file', 'file-provider', '{"path": {"foo": "/tmp/pg_tde_test_keyring.per"}}');
 SELECT * FROM pg_tde_list_all_database_key_providers();
 
 SELECT pg_tde_add_global_key_provider_file('file-keyring','/tmp/pg_tde_test_keyring.per');


### PR DESCRIPTION
These seem to have been overlooked in
75aad06e5678d1c3bf905a680e5539f1537b45d7 when similar functions for kmip and vault were removed.