### PR TITLE
Use the standrad syntax for initiallizing structs to zero

### DIFF
--- a/contrib/pg_tde/src/keyring/keyring_kmip_impl.c
+++ b/contrib/pg_tde/src/keyring/keyring_kmip_impl.c
@@ -19,7 +19,7 @@ pg_tde_kmip_set_by_name(BIO *bio, char *key_name, const unsigned char *key, unsi
 	int32		mask = KMIP_CRYPTOMASK_ENCRYPT | KMIP_CRYPTOMASK_DECRYPT;
 	Name		ts;
 	TextString	ts2;
-	TemplateAttribute ta = {};
+	TemplateAttribute ta = {0};
 	char	   *idp;
 	int			id_size;
 

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -47,7 +47,7 @@ typedef struct
 	Oid			rebuildSequence;
 } TdeDdlEvent;
 
-static FullTransactionId ddlEventStackTid = {};
+static FullTransactionId ddlEventStackTid = {0};
 static List *ddlEventStack = NIL;
 
 static Oid	get_db_oid(const char *name);


### PR DESCRIPTION
As far as I understand you need at least one element to write a literal which initializes a struct to all zeros. In these particular cases I do not think it matters since static variables are always zero initialized but I prefer being clear.