### PR TITLE
Be consistent about that finding no key in the provider is a success

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -256,7 +256,7 @@ set_principal_key_with_keyring(const char *key_name, const char *provider_name,
 
 		keyInfo = KeyringGetKey(new_keyring, key_name, &kr_ret);
 
-		if (kr_ret != KEYRING_CODE_SUCCESS && kr_ret != KEYRING_CODE_RESOURCE_NOT_AVAILABLE)
+		if (kr_ret != KEYRING_CODE_SUCCESS)
 		{
 			ereport(ERROR,
 					errmsg("failed to retrieve principal key from keyring provider :\"%s\"", new_keyring->provider_name),
@@ -333,7 +333,7 @@ xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec)
 	new_keyring = GetKeyProviderByID(xlrec->keyringId, xlrec->databaseId);
 	keyInfo = KeyringGetKey(new_keyring, xlrec->keyName, &kr_ret);
 
-	if (kr_ret != KEYRING_CODE_SUCCESS && kr_ret != KEYRING_CODE_RESOURCE_NOT_AVAILABLE)
+	if (kr_ret != KEYRING_CODE_SUCCESS)
 	{
 		ereport(ERROR,
 				errmsg("failed to retrieve principal key from keyring provider: \"%s\"", new_keyring->provider_name),

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -236,7 +236,6 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 
 	if (httpCode == 404)
 	{
-		*return_code = KEYRING_CODE_RESOURCE_NOT_AVAILABLE;
 		goto cleanup;
 	}
 


### PR DESCRIPTION
All different provider types except Vault treated finding no key as SUCCESS but with NULL as the key. Let's do this for Vault too which slightly simplifies the callers which used to have to understand both ways to handle a key not existing.