### PR TITLE
Clean up some prefixes for function parameters

### DIFF
--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -10,11 +10,11 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regressi
 SELECT pg_tde_verify_default_key();
 ERROR:  principal key not configured for current database
 -- Should fail: no default principal key for the server yet
-SELECT key_provider_id, key_provider_name, key_name
+SELECT provider_id, provider_name, key_name
 		FROM pg_tde_default_key_info();
- key_provider_id | key_provider_name | key_name 
------------------+-------------------+----------
-                 |                   | 
+ provider_id | provider_name | key_name 
+-------------+---------------+----------
+             |               | 
 (1 row)
 
 SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'file-provider', false);
@@ -29,11 +29,11 @@ SELECT pg_tde_verify_default_key();
  
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name
+SELECT provider_id, provider_name, key_name
 		FROM pg_tde_default_key_info();
- key_provider_id | key_provider_name |  key_name   
------------------+-------------------+-------------
-              -2 | file-provider     | default-key
+ provider_id | provider_name |  key_name   
+-------------+---------------+-------------
+          -2 | file-provider | default-key
 (1 row)
 
 -- fails
@@ -46,11 +46,11 @@ SELECT id, name FROM pg_tde_list_all_global_key_providers();
 (1 row)
 
 -- Should fail: no principal key for the database yet
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
- key_provider_id | key_provider_name | key_name 
------------------+-------------------+----------
-                 |                   | 
+ provider_id | provider_name | key_name 
+-------------+---------------+----------
+             |               | 
 (1 row)
 
 -- Should succeed: "localizes" the default principal key for the database
@@ -61,11 +61,11 @@ CREATE TABLE test_enc(
 ) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
 -- Should succeed: create table localized the principal key
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
- key_provider_id | key_provider_name |  key_name   
------------------+-------------------+-------------
-              -2 | file-provider     | default-key
+ provider_id | provider_name |  key_name   
+-------------+---------------+-------------
+          -2 | file-provider | default-key
 (1 row)
 
 SELECT current_database() AS regress_database
@@ -75,11 +75,11 @@ CREATE DATABASE regress_pg_tde_other;
 CREATE EXTENSION pg_tde;
 CREATE EXTENSION pg_buffercache;
 -- Should fail: no principal key for the database yet
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
- key_provider_id | key_provider_name | key_name 
------------------+-------------------+----------
-                 |                   | 
+ provider_id | provider_name | key_name 
+-------------+---------------+----------
+             |               | 
 (1 row)
 
 -- Should succeed: "localizes" the default principal key for the database
@@ -90,11 +90,11 @@ CREATE TABLE test_enc(
 ) USING tde_heap;
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
 -- Should succeed: create table localized the principal key
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
- key_provider_id | key_provider_name |  key_name   
------------------+-------------------+-------------
-              -2 | file-provider     | default-key
+ provider_id | provider_name |  key_name   
+-------------+---------------+-------------
+          -2 | file-provider | default-key
 (1 row)
 
 \c :regress_database
@@ -105,19 +105,19 @@ SELECT pg_tde_set_default_key_using_global_key_provider('new-default-key', 'file
  
 (1 row)
 
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
- key_provider_id | key_provider_name |    key_name     
------------------+-------------------+-----------------
-              -2 | file-provider     | new-default-key
+ provider_id | provider_name |    key_name     
+-------------+---------------+-----------------
+          -2 | file-provider | new-default-key
 (1 row)
 
 \c regress_pg_tde_other
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
- key_provider_id | key_provider_name |    key_name     
------------------+-------------------+-----------------
-              -2 | file-provider     | new-default-key
+ provider_id | provider_name |    key_name     
+-------------+---------------+-----------------
+          -2 | file-provider | new-default-key
 (1 row)
 
 SELECT pg_buffercache_evict(bufferid) FROM pg_buffercache WHERE relfilenode = (SELECT relfilenode FROM pg_class WHERE oid = 'test_enc'::regclass);

--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -39,8 +39,8 @@ SELECT key_provider_id, key_provider_name, key_name
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-provider');
 ERROR:  Can't delete a provider which is currently in use
-SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
- id | provider_name 
+SELECT id, name FROM pg_tde_list_all_global_key_providers();
+ id |     name      
 ----+---------------
  -2 | file-provider
 (1 row)

--- a/contrib/pg_tde/expected/delete_principal_key.out
+++ b/contrib/pg_tde/expected/delete_principal_key.out
@@ -13,10 +13,10 @@ SELECT pg_tde_set_key_using_global_key_provider('test-db-key','file-provider');
  
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
- key_provider_id | key_provider_name |  key_name   
------------------+-------------------+-------------
-              -3 | file-provider     | test-db-key
+SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();
+ provider_id | provider_name |  key_name   
+-------------+---------------+-------------
+          -3 | file-provider | test-db-key
 (1 row)
 
 SELECT pg_tde_delete_key();
@@ -84,10 +84,10 @@ SELECT pg_tde_delete_key();
  
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
- key_provider_id | key_provider_name |  key_name   
------------------+-------------------+-------------
-              -3 | file-provider     | defalut-key
+SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();
+ provider_id | provider_name |  key_name   
+-------------+---------------+-------------
+          -3 | file-provider | defalut-key
 (1 row)
 
 -- Try to delete key when default key is used

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -22,10 +22,10 @@ SELECT pg_tde_add_database_key_provider_file('file-provider2','/tmp/pg_tde_test_
 SELECT pg_tde_add_database_key_provider_file('file-provider','/tmp/pg_tde_test_keyring_dup.per');
 ERROR:  Key provider "file-provider" already exists.
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name  | provider_type |                  options                   
-----+----------------+---------------+--------------------------------------------
-  1 | file-provider  | file          | {"path" : "/tmp/pg_tde_test_keyring.per"}
-  2 | file-provider2 | file          | {"path" : "/tmp/pg_tde_test_keyring2.per"}
+ id |      name      | type |                  options                   
+----+----------------+------+--------------------------------------------
+  1 | file-provider  | file | {"path" : "/tmp/pg_tde_test_keyring.per"}
+  2 | file-provider2 | file | {"path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
 SELECT pg_tde_verify_key();
@@ -45,19 +45,19 @@ SELECT pg_tde_verify_key();
 SELECT pg_tde_change_database_key_provider_file('not-existent-provider','/tmp/pg_tde_test_keyring.per');
 ERROR:  key provider "not-existent-provider" does not exists
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name  | provider_type |                  options                   
-----+----------------+---------------+--------------------------------------------
-  1 | file-provider  | file          | {"path" : "/tmp/pg_tde_test_keyring.per"}
-  2 | file-provider2 | file          | {"path" : "/tmp/pg_tde_test_keyring2.per"}
+ id |      name      | type |                  options                   
+----+----------------+------+--------------------------------------------
+  1 | file-provider  | file | {"path" : "/tmp/pg_tde_test_keyring.per"}
+  2 | file-provider2 | file | {"path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
 SELECT pg_tde_change_database_key_provider('file', 'file-provider', '{"path": {"foo": "/tmp/pg_tde_test_keyring.per"}}');
 ERROR:  key provider value cannot be an object
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name  | provider_type |                  options                   
-----+----------------+---------------+--------------------------------------------
-  1 | file-provider  | file          | {"path" : "/tmp/pg_tde_test_keyring.per"}
-  2 | file-provider2 | file          | {"path" : "/tmp/pg_tde_test_keyring2.per"}
+ id |      name      | type |                  options                   
+----+----------------+------+--------------------------------------------
+  1 | file-provider  | file | {"path" : "/tmp/pg_tde_test_keyring.per"}
+  2 | file-provider2 | file | {"path" : "/tmp/pg_tde_test_keyring2.per"}
 (2 rows)
 
 SELECT pg_tde_add_global_key_provider_file('file-keyring','/tmp/pg_tde_test_keyring.per');
@@ -72,8 +72,8 @@ SELECT pg_tde_add_global_key_provider_file('file-keyring2','/tmp/pg_tde_test_key
  
 (1 row)
 
-SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
- id | provider_name 
+SELECT id, name FROM pg_tde_list_all_global_key_providers();
+ id |     name      
 ----+---------------
  -4 | file-keyring
  -5 | file-keyring2
@@ -82,8 +82,8 @@ SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
 -- fails
 SELECT pg_tde_delete_database_key_provider('file-provider');
 ERROR:  Can't delete a provider which is currently in use
-SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
- id | provider_name  
+SELECT id, name FROM pg_tde_list_all_database_key_providers();
+ id |      name      
 ----+----------------
   1 | file-provider
   2 | file-provider2
@@ -96,14 +96,14 @@ SELECT pg_tde_delete_database_key_provider('file-provider2');
  
 (1 row)
 
-SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
- id | provider_name 
+SELECT id, name FROM pg_tde_list_all_database_key_providers();
+ id |     name      
 ----+---------------
   1 | file-provider
 (1 row)
 
-SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
- id | provider_name 
+SELECT id, name FROM pg_tde_list_all_global_key_providers();
+ id |     name      
 ----+---------------
  -4 | file-keyring
  -5 | file-keyring2
@@ -118,8 +118,8 @@ SELECT pg_tde_set_key_using_global_key_provider('test-db-key', 'file-keyring', f
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-keyring');
 ERROR:  Can't delete a provider which is currently in use
-SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
- id | provider_name 
+SELECT id, name FROM pg_tde_list_all_global_key_providers();
+ id |     name      
 ----+---------------
  -4 | file-keyring
  -5 | file-keyring2
@@ -132,9 +132,9 @@ SELECT pg_tde_delete_global_key_provider('file-keyring2');
  
 (1 row)
 
-SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
- id | provider_name 
-----+---------------
+SELECT id, name FROM pg_tde_list_all_global_key_providers();
+ id |     name     
+----+--------------
  -4 | file-keyring
 (1 row)
 

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -1,8 +1,8 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
 SELECT  * FROM pg_tde_key_info();
- key_name | key_provider_name | key_provider_id | key_creation_time 
-----------+-------------------+-----------------+-------------------
-          |                   |                 | 
+ key_name | provider_name | provider_id | key_creation_time 
+----------+---------------+-------------+-------------------
+          |               |             | 
 (1 row)
 
 SELECT pg_tde_add_database_key_provider('file', 'incorrect-file-provider',  '{"path": {"foo": "/tmp/pg_tde_test_keyring.per"}}');

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -77,11 +77,11 @@ SELECT pg_tde_is_encrypted(NULL);
  
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name
+SELECT provider_id, provider_name, key_name
     FROM pg_tde_key_info();
- key_provider_id | key_provider_name |  key_name   
------------------+-------------------+-------------
-               1 | file-vault        | test-db-key
+ provider_id | provider_name |  key_name   
+-------------+---------------+-------------
+           1 | file-vault    | test-db-key
 (1 row)
 
 DROP TABLE test_temp_norm;

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -271,8 +271,8 @@ REVOKE ALL ON FUNCTION pg_tde_delete_default_key() FROM PUBLIC;
 
 CREATE FUNCTION pg_tde_key_info()
 RETURNS TABLE ( key_name TEXT,
-                key_provider_name TEXT,
-                key_provider_id INT,
+                provider_name TEXT,
+                provider_id INT,
                 key_creation_time TIMESTAMP WITH TIME ZONE)
 LANGUAGE C
 AS 'MODULE_PATHNAME';
@@ -280,8 +280,8 @@ REVOKE ALL ON FUNCTION pg_tde_key_info() FROM PUBLIC;
 
 CREATE FUNCTION pg_tde_server_key_info()
 RETURNS TABLE ( key_name TEXT,
-                key_provider_name TEXT,
-                key_provider_id INT,
+                provider_name TEXT,
+                provider_id INT,
                 key_creation_time TIMESTAMP WITH TIME ZONE)
 LANGUAGE C
 AS 'MODULE_PATHNAME';
@@ -289,8 +289,8 @@ REVOKE ALL ON FUNCTION pg_tde_server_key_info() FROM PUBLIC;
 
 CREATE FUNCTION pg_tde_default_key_info()
 RETURNS TABLE ( key_name TEXT,
-                key_provider_name TEXT,
-                key_provider_id INT,
+                provider_name TEXT,
+                provider_id INT,
                 key_creation_time TIMESTAMP WITH TIME ZONE)
 LANGUAGE C
 AS 'MODULE_PATHNAME';

--- a/contrib/pg_tde/pg_tde--1.0-rc.sql
+++ b/contrib/pg_tde/pg_tde--1.0-rc.sql
@@ -2,7 +2,7 @@
 \echo Use "CREATE EXTENSION pg_tde" to load this file. \quit
 
 -- Key Provider Management
-CREATE FUNCTION pg_tde_add_database_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
+CREATE FUNCTION pg_tde_add_database_key_provider(type TEXT, name TEXT, options JSON)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
@@ -50,8 +50,8 @@ END;
 
 CREATE FUNCTION pg_tde_list_all_database_key_providers
     (OUT id INT,
-    OUT provider_name TEXT,
-    OUT provider_type TEXT,
+    OUT name TEXT,
+    OUT type TEXT,
     OUT options JSON)
 RETURNS SETOF RECORD
 LANGUAGE C
@@ -60,8 +60,8 @@ REVOKE ALL ON FUNCTION pg_tde_list_all_database_key_providers() FROM PUBLIC;
 
 CREATE FUNCTION pg_tde_list_all_global_key_providers
     (OUT id INT,
-    OUT provider_name TEXT,
-    OUT provider_type TEXT,
+    OUT name TEXT,
+    OUT type TEXT,
     OUT options JSON)
 RETURNS SETOF RECORD
 LANGUAGE C
@@ -69,7 +69,7 @@ AS 'MODULE_PATHNAME';
 REVOKE ALL ON FUNCTION pg_tde_list_all_global_key_providers() FROM PUBLIC;
 
 -- Global Tablespace Key Provider Management
-CREATE FUNCTION pg_tde_add_global_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
+CREATE FUNCTION pg_tde_add_global_key_provider(type TEXT, name TEXT, options JSON)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
@@ -116,7 +116,7 @@ BEGIN ATOMIC
 END;
 
 -- Key Provider Management
-CREATE FUNCTION pg_tde_change_database_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
+CREATE FUNCTION pg_tde_change_database_key_provider(type TEXT, name TEXT, options JSON)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';
@@ -163,7 +163,7 @@ BEGIN ATOMIC
 END;
 
 -- Global Tablespace Key Provider Management
-CREATE FUNCTION pg_tde_change_global_key_provider(provider_type TEXT, provider_name TEXT, options JSON)
+CREATE FUNCTION pg_tde_change_global_key_provider(type TEXT, name TEXT, options JSON)
 RETURNS VOID
 LANGUAGE C
 AS 'MODULE_PATHNAME';

--- a/contrib/pg_tde/sql/default_principal_key.sql
+++ b/contrib/pg_tde/sql/default_principal_key.sql
@@ -18,7 +18,7 @@ SELECT key_provider_id, key_provider_name, key_name
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-provider');
-SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
+SELECT id, name FROM pg_tde_list_all_global_key_providers();
 
 -- Should fail: no principal key for the database yet
 SELECT  key_provider_id, key_provider_name, key_name

--- a/contrib/pg_tde/sql/default_principal_key.sql
+++ b/contrib/pg_tde/sql/default_principal_key.sql
@@ -7,13 +7,13 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regressi
 SELECT pg_tde_verify_default_key();
 
 -- Should fail: no default principal key for the server yet
-SELECT key_provider_id, key_provider_name, key_name
+SELECT provider_id, provider_name, key_name
 		FROM pg_tde_default_key_info();
 
 SELECT pg_tde_set_default_key_using_global_key_provider('default-key', 'file-provider', false);
 SELECT pg_tde_verify_default_key();
 
-SELECT key_provider_id, key_provider_name, key_name
+SELECT provider_id, provider_name, key_name
 		FROM pg_tde_default_key_info();
 
 -- fails
@@ -21,7 +21,7 @@ SELECT pg_tde_delete_global_key_provider('file-provider');
 SELECT id, name FROM pg_tde_list_all_global_key_providers();
 
 -- Should fail: no principal key for the database yet
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
 
 -- Should succeed: "localizes" the default principal key for the database
@@ -34,7 +34,7 @@ CREATE TABLE test_enc(
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
 
 -- Should succeed: create table localized the principal key
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
 
 SELECT current_database() AS regress_database
@@ -48,7 +48,7 @@ CREATE EXTENSION pg_tde;
 CREATE EXTENSION pg_buffercache;
 
 -- Should fail: no principal key for the database yet
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
 
 -- Should succeed: "localizes" the default principal key for the database
@@ -61,7 +61,7 @@ CREATE TABLE test_enc(
 INSERT INTO test_enc (k) VALUES (1), (2), (3);
 
 -- Should succeed: create table localized the principal key
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
 
 \c :regress_database
@@ -70,12 +70,12 @@ CHECKPOINT;
 
 SELECT pg_tde_set_default_key_using_global_key_provider('new-default-key', 'file-provider', false);
 
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
 
 \c regress_pg_tde_other
 
-SELECT  key_provider_id, key_provider_name, key_name
+SELECT  provider_id, provider_name, key_name
 		FROM pg_tde_key_info();
 
 SELECT pg_buffercache_evict(bufferid) FROM pg_buffercache WHERE relfilenode = (SELECT relfilenode FROM pg_class WHERE oid = 'test_enc'::regclass);

--- a/contrib/pg_tde/sql/delete_principal_key.sql
+++ b/contrib/pg_tde/sql/delete_principal_key.sql
@@ -5,7 +5,7 @@ SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_test_key
 -- Set the local key and delete it without any encrypted tables
 -- Should succeed: nothing used the key
 SELECT pg_tde_set_key_using_global_key_provider('test-db-key','file-provider');
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
+SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();
 SELECT pg_tde_delete_key();
 
 -- Set local key, encrypt a table, and delete the key
@@ -32,7 +32,7 @@ SELECT pg_tde_set_default_key_using_global_key_provider('defalut-key','file-prov
 SELECT pg_tde_set_key_using_global_key_provider('test-db-key','file-provider');
 CREATE TABLE test_table (id int, data text) USING tde_heap;
 SELECT pg_tde_delete_key();
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
+SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();
 
 -- Try to delete key when default key is used
 -- Should fail: table already uses the default key, so there is no key to fallback to

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -22,27 +22,27 @@ SELECT pg_tde_add_global_key_provider_file('file-keyring','/tmp/pg_tde_test_keyr
 
 SELECT pg_tde_add_global_key_provider_file('file-keyring2','/tmp/pg_tde_test_keyring2.per');
 
-SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
+SELECT id, name FROM pg_tde_list_all_global_key_providers();
 
 -- fails
 SELECT pg_tde_delete_database_key_provider('file-provider');
-SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
+SELECT id, name FROM pg_tde_list_all_database_key_providers();
 
 -- works
 SELECT pg_tde_delete_database_key_provider('file-provider2');
-SELECT id, provider_name FROM pg_tde_list_all_database_key_providers();
+SELECT id, name FROM pg_tde_list_all_database_key_providers();
 
-SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
+SELECT id, name FROM pg_tde_list_all_global_key_providers();
 
 SELECT pg_tde_set_key_using_global_key_provider('test-db-key', 'file-keyring', false);
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-keyring');
-SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
+SELECT id, name FROM pg_tde_list_all_global_key_providers();
 
 -- works
 SELECT pg_tde_delete_global_key_provider('file-keyring2');
-SELECT id, provider_name FROM pg_tde_list_all_global_key_providers();
+SELECT id, name FROM pg_tde_list_all_global_key_providers();
 
 -- Creating a file key provider fails if we can't open or create the file
 SELECT pg_tde_add_database_key_provider_file('will-not-work','/cant-create-file-in-root.per');

--- a/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
+++ b/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
@@ -38,7 +38,7 @@ SELECT relname, pg_tde_is_encrypted(relname) FROM (VALUES ('test_enc_pkey'), ('t
 
 SELECT pg_tde_is_encrypted(NULL);
 
-SELECT key_provider_id, key_provider_name, key_name
+SELECT provider_id, provider_name, key_name
     FROM pg_tde_key_info();
 
 DROP TABLE test_temp_norm;

--- a/contrib/pg_tde/t/expected/change_key_provider.out
+++ b/contrib/pg_tde/t/expected/change_key_provider.out
@@ -6,9 +6,9 @@ SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_prov
 (1 row)
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name | provider_type |                   options                   
-----+---------------+---------------+---------------------------------------------
-  1 | file-vault    | file          | {"path" : "/tmp/change_key_provider_1.per"}
+ id |    name    | type |                   options                   
+----+------------+------+---------------------------------------------
+  1 | file-vault | file | {"path" : "/tmp/change_key_provider_1.per"}
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');
@@ -46,9 +46,9 @@ SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_p
 (1 row)
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name | provider_type |                   options                   
-----+---------------+---------------+---------------------------------------------
-  1 | file-vault    | file          | {"path" : "/tmp/change_key_provider_2.per"}
+ id |    name    | type |                   options                   
+----+------------+------+---------------------------------------------
+  1 | file-vault | file | {"path" : "/tmp/change_key_provider_2.per"}
 (1 row)
 
 SELECT pg_tde_verify_key();
@@ -109,9 +109,9 @@ SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_p
 (1 row)
 
 SELECT * FROM pg_tde_list_all_database_key_providers();
- id | provider_name | provider_type |                   options                   
-----+---------------+---------------+---------------------------------------------
-  1 | file-vault    | file          | {"path" : "/tmp/change_key_provider_1.per"}
+ id |    name    | type |                   options                   
+----+------------+------+---------------------------------------------
+  1 | file-vault | file | {"path" : "/tmp/change_key_provider_1.per"}
 (1 row)
 
 SELECT pg_tde_verify_key();

--- a/contrib/pg_tde/t/expected/rotate_key.out
+++ b/contrib/pg_tde/t/expected/rotate_key.out
@@ -59,16 +59,16 @@ SELECT * FROM test_enc ORDER BY id;
 (2 rows)
 
 -- server restart
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
- key_provider_id | key_provider_name |   key_name   
------------------+-------------------+--------------
-               1 | file-vault        | rotated-key1
+SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();
+ provider_id | provider_name |   key_name   
+-------------+---------------+--------------
+           1 | file-vault    | rotated-key1
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
- key_provider_id | key_provider_name | key_name 
------------------+-------------------+----------
-                 |                   | 
+SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();
+ provider_id | provider_name | key_name 
+-------------+---------------+----------
+             |               | 
 (1 row)
 
 SELECT * FROM test_enc ORDER BY id;
@@ -92,16 +92,16 @@ SELECT * FROM test_enc ORDER BY id;
 (2 rows)
 
 -- server restart
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
- key_provider_id | key_provider_name |   key_name   
------------------+-------------------+--------------
-               2 | file-2            | rotated-key2
+SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();
+ provider_id | provider_name |   key_name   
+-------------+---------------+--------------
+           2 | file-2        | rotated-key2
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
- key_provider_id | key_provider_name | key_name 
------------------+-------------------+----------
-                 |                   | 
+SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();
+ provider_id | provider_name | key_name 
+-------------+---------------+----------
+             |               | 
 (1 row)
 
 SELECT * FROM test_enc ORDER BY id;
@@ -125,16 +125,16 @@ SELECT * FROM test_enc ORDER BY id;
 (2 rows)
 
 -- server restart
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
- key_provider_id | key_provider_name |  key_name   
------------------+-------------------+-------------
-              -2 | file-3            | rotated-key
+SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();
+ provider_id | provider_name |  key_name   
+-------------+---------------+-------------
+          -2 | file-3        | rotated-key
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
- key_provider_id | key_provider_name | key_name 
------------------+-------------------+----------
-                 |                   | 
+SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();
+ provider_id | provider_name | key_name 
+-------------+---------------+----------
+             |               | 
 (1 row)
 
 SELECT * FROM test_enc ORDER BY id;
@@ -158,16 +158,16 @@ SELECT * FROM test_enc ORDER BY id;
 (2 rows)
 
 -- server restart
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
- key_provider_id | key_provider_name |   key_name   
------------------+-------------------+--------------
-              -1 | file-2            | rotated-keyX
+SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();
+ provider_id | provider_name |   key_name   
+-------------+---------------+--------------
+          -1 | file-2        | rotated-keyX
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
- key_provider_id | key_provider_name | key_name 
------------------+-------------------+----------
-                 |                   | 
+SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();
+ provider_id | provider_name | key_name 
+-------------+---------------+----------
+             |               | 
 (1 row)
 
 SELECT * FROM test_enc ORDER BY id;
@@ -181,16 +181,16 @@ ALTER SYSTEM SET pg_tde.inherit_global_providers = off;
 -- server restart
 SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX2', 'file-2', false);
 psql:<stdin>:1: ERROR:  Usage of global key providers is disabled. Enable it with pg_tde.inherit_global_providers = ON
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
- key_provider_id | key_provider_name |   key_name   
------------------+-------------------+--------------
-              -1 | file-2            | rotated-keyX
+SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();
+ provider_id | provider_name |   key_name   
+-------------+---------------+--------------
+          -1 | file-2        | rotated-keyX
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
- key_provider_id | key_provider_name | key_name 
------------------+-------------------+----------
-                 |                   | 
+SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();
+ provider_id | provider_name | key_name 
+-------------+---------------+----------
+             |               | 
 (1 row)
 
 SELECT pg_tde_set_key_using_database_key_provider('rotated-key2', 'file-2');
@@ -199,16 +199,16 @@ SELECT pg_tde_set_key_using_database_key_provider('rotated-key2', 'file-2');
  
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();
- key_provider_id | key_provider_name |   key_name   
------------------+-------------------+--------------
-               2 | file-2            | rotated-key2
+SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();
+ provider_id | provider_name |   key_name   
+-------------+---------------+--------------
+           2 | file-2        | rotated-key2
 (1 row)
 
-SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();
- key_provider_id | key_provider_name | key_name 
------------------+-------------------+----------
-                 |                   | 
+SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();
+ provider_id | provider_name | key_name 
+-------------+---------------+----------
+             |               | 
 (1 row)
 
 DROP TABLE test_enc;

--- a/contrib/pg_tde/t/expected/wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/wal_encrypt.out
@@ -7,10 +7,10 @@ SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/pg_tde_test
 
 SELECT pg_tde_verify_server_key();
 psql:<stdin>:1: ERROR:  principal key not configured for current database
-SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_server_key_info();
- key_name | key_provider_name | key_provider_id 
-----------+-------------------+-----------------
-          |                   |                
+SELECT key_name, provider_name, provider_id FROM pg_tde_server_key_info();
+ key_name | provider_name | provider_id 
+----------+---------------+-------------
+          |               |            
 (1 row)
 
 SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-010');
@@ -25,10 +25,10 @@ SELECT pg_tde_verify_server_key();
  
 (1 row)
 
-SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_server_key_info();
-  key_name  | key_provider_name | key_provider_id 
-------------+-------------------+-----------------
- server-key | file-keyring-010  |              -1
+SELECT key_name, provider_name, provider_id FROM pg_tde_server_key_info();
+  key_name  |  provider_name   | provider_id 
+------------+------------------+-------------
+ server-key | file-keyring-010 |          -1
 (1 row)
 
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;

--- a/contrib/pg_tde/t/pg_tde_change_key_provider.pl
+++ b/contrib/pg_tde/t/pg_tde_change_key_provider.pl
@@ -43,7 +43,7 @@ $node->start;
 
 is( $node->safe_psql(
 		'postgres',
-		q{SELECT provider_type FROM pg_tde_list_all_database_key_providers() WHERE provider_name = 'database-provider'}
+		q{SELECT type FROM pg_tde_list_all_database_key_providers() WHERE name = 'database-provider'}
 	),
 	'file',
 	'provider type is set to file');
@@ -51,7 +51,7 @@ is( $node->safe_psql(
 $options = decode_json(
 	$node->safe_psql(
 		'postgres',
-		q{SELECT options FROM pg_tde_list_all_database_key_providers() WHERE provider_name = 'database-provider'}
+		q{SELECT options FROM pg_tde_list_all_database_key_providers() WHERE name = 'database-provider'}
 	));
 is( $options->{path},
 	'/tmp/pg_tde_change_key_provider-database-2',
@@ -78,7 +78,7 @@ $node->start;
 
 is( $node->safe_psql(
 		'postgres',
-		q{SELECT provider_type FROM pg_tde_list_all_database_key_providers() WHERE provider_name = 'database-provider'}
+		q{SELECT type FROM pg_tde_list_all_database_key_providers() WHERE name = 'database-provider'}
 	),
 	'vault-v2',
 	'provider type is set to vault-v2');
@@ -86,7 +86,7 @@ is( $node->safe_psql(
 $options = decode_json(
 	$node->safe_psql(
 		'postgres',
-		q{SELECT options FROM pg_tde_list_all_database_key_providers() WHERE provider_name = 'database-provider'}
+		q{SELECT options FROM pg_tde_list_all_database_key_providers() WHERE name = 'database-provider'}
 	));
 is( $options->{url},
 	'https://vault-server.example:8200/',
@@ -118,7 +118,7 @@ $node->start;
 
 is( $node->safe_psql(
 		'postgres',
-		q{SELECT provider_type FROM pg_tde_list_all_database_key_providers() WHERE provider_name = 'database-provider'}
+		q{SELECT type FROM pg_tde_list_all_database_key_providers() WHERE name = 'database-provider'}
 	),
 	'vault-v2',
 	'provider type is set to vault-v2');
@@ -126,7 +126,7 @@ is( $node->safe_psql(
 $options = decode_json(
 	$node->safe_psql(
 		'postgres',
-		q{SELECT options FROM pg_tde_list_all_database_key_providers() WHERE provider_name = 'database-provider'}
+		q{SELECT options FROM pg_tde_list_all_database_key_providers() WHERE name = 'database-provider'}
 	));
 is( $options->{url},
 	'http://vault-server.example:8200/',
@@ -159,7 +159,7 @@ $node->start;
 
 is( $node->safe_psql(
 		'postgres',
-		q{SELECT provider_type FROM pg_tde_list_all_database_key_providers() WHERE provider_name = 'database-provider'}
+		q{SELECT type FROM pg_tde_list_all_database_key_providers() WHERE name = 'database-provider'}
 	),
 	'kmip',
 	'provider type is set to kmip');
@@ -167,7 +167,7 @@ is( $node->safe_psql(
 $options = decode_json(
 	$node->safe_psql(
 		'postgres',
-		q{SELECT options FROM pg_tde_list_all_database_key_providers() WHERE provider_name = 'database-provider'}
+		q{SELECT options FROM pg_tde_list_all_database_key_providers() WHERE name = 'database-provider'}
 	));
 is($options->{host}, 'kmip-server.example',
 	'host is set correctly for kmip provider');
@@ -200,7 +200,7 @@ $node->start;
 
 is( $node->safe_psql(
 		'postgres',
-		q{SELECT provider_type FROM pg_tde_list_all_global_key_providers() WHERE provider_name = 'global-provider'}
+		q{SELECT type FROM pg_tde_list_all_global_key_providers() WHERE name = 'global-provider'}
 	),
 	'vault-v2',
 	'provider type is set to vault-v2 for global provider');
@@ -208,7 +208,7 @@ is( $node->safe_psql(
 $options = decode_json(
 	$node->safe_psql(
 		'postgres',
-		q{SELECT options FROM pg_tde_list_all_global_key_providers() WHERE provider_name = 'global-provider'}
+		q{SELECT options FROM pg_tde_list_all_global_key_providers() WHERE name = 'global-provider'}
 	));
 is( $options->{url},
 	'http://vault-server.example:8200/',

--- a/contrib/pg_tde/t/rotate_key.pl
+++ b/contrib/pg_tde/t/rotate_key.pl
@@ -54,10 +54,9 @@ PGTDE::append_to_result_file("-- server restart");
 $node->restart;
 
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"
-);
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();");
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();"
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();"
 );
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
@@ -71,10 +70,9 @@ PGTDE::append_to_result_file("-- server restart");
 $node->restart;
 
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"
-);
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();");
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();"
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();"
 );
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
@@ -88,10 +86,9 @@ PGTDE::append_to_result_file("-- server restart");
 $node->restart;
 
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"
-);
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();");
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();"
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();"
 );
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
@@ -108,10 +105,9 @@ PGTDE::append_to_result_file("-- server restart");
 $node->restart;
 
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"
-);
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();");
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();"
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();"
 );
 PGTDE::psql($node, 'postgres', 'SELECT * FROM test_enc ORDER BY id;');
 
@@ -127,20 +123,18 @@ PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_set_key_using_global_key_provider('rotated-keyX2', 'file-2', false);"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"
-);
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();");
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();"
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();"
 );
 
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_set_key_using_database_key_provider('rotated-key2', 'file-2');"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_key_info();"
-);
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_key_info();");
 PGTDE::psql($node, 'postgres',
-	"SELECT key_provider_id, key_provider_name, key_name FROM pg_tde_server_key_info();"
+	"SELECT provider_id, provider_name, key_name FROM pg_tde_server_key_info();"
 );
 
 PGTDE::psql($node, 'postgres', 'DROP TABLE test_enc;');

--- a/contrib/pg_tde/t/wal_encrypt.pl
+++ b/contrib/pg_tde/t/wal_encrypt.pl
@@ -26,7 +26,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres', 'SELECT pg_tde_verify_server_key();');
 
 PGTDE::psql($node, 'postgres',
-	'SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_server_key_info();'
+	'SELECT key_name, provider_name, provider_id FROM pg_tde_server_key_info();'
 );
 
 PGTDE::psql($node, 'postgres',
@@ -36,7 +36,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres', 'SELECT pg_tde_verify_server_key();');
 
 PGTDE::psql($node, 'postgres',
-	'SELECT key_name, key_provider_name, key_provider_id FROM pg_tde_server_key_info();'
+	'SELECT key_name, provider_name, provider_id FROM pg_tde_server_key_info();'
 );
 
 PGTDE::psql($node, 'postgres', 'ALTER SYSTEM SET pg_tde.wal_encrypt = on;');


### PR DESCRIPTION
There were some weirdness in there. provider id and provider options was not prefixed while name and type were always prefixed.

Also key info functions had double prefixes for provider attributes.