### PR TITLE
Rename relation key removal XLOG record type to match naming consistency

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog.c
@@ -53,7 +53,7 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 
 		pg_tde_save_principal_key_redo(mkey);
 	}
-	else if (info == XLOG_TDE_REMOVE_RELATION_KEY)
+	else if (info == XLOG_TDE_DELETE_RELATION_KEY)
 	{
 		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
 
@@ -118,6 +118,12 @@ tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 
 		appendStringInfo(buf, "db: %u", dbOid);
 	}
+	else if (info == XLOG_TDE_DELETE_RELATION_KEY)
+	{
+		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
+
+		appendStringInfo(buf, "rel: %u/%u/%u", xlrec->rlocator.spcOid, xlrec->rlocator.dbOid, xlrec->rlocator.relNumber);
+	}
 	else if (info == XLOG_TDE_WRITE_KEY_PROVIDER)
 	{
 		KeyringProviderRecordInFile *xlrec = (KeyringProviderRecordInFile *) XLogRecGetData(record);
@@ -143,6 +149,8 @@ tdeheap_rmgr_identify(uint8 info)
 			return "ADD_PRINCIPAL_KEY";
 		case XLOG_TDE_ROTATE_PRINCIPAL_KEY:
 			return "ROTATE_PRINCIPAL_KEY";
+		case XLOG_TDE_DELETE_RELATION_KEY:
+			return "DELETE_RELATION_KEY";
 		case XLOG_TDE_DELETE_PRINCIPAL_KEY:
 			return "DELETE_PRINCIPAL_KEY";
 		case XLOG_TDE_WRITE_KEY_PROVIDER:

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog.h
@@ -13,7 +13,7 @@
 #define XLOG_TDE_ROTATE_PRINCIPAL_KEY	0x20
 #define XLOG_TDE_WRITE_KEY_PROVIDER 	0x30
 #define XLOG_TDE_INSTALL_EXTENSION		0x40
-#define XLOG_TDE_REMOVE_RELATION_KEY	0x50
+#define XLOG_TDE_DELETE_RELATION_KEY	0x50
 #define XLOG_TDE_DELETE_PRINCIPAL_KEY	0x60
 
 /* ID 140 is registered for Percona TDE extension: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -121,7 +121,7 @@ tde_smgr_delete_key(const RelFileLocatorBackend *smgr_rlocator)
 
 	XLogBeginInsert();
 	XLogRegisterData((char *) &xlrec, sizeof(xlrec));
-	XLogInsert(RM_TDERMGR_ID, XLOG_TDE_REMOVE_RELATION_KEY);
+	XLogInsert(RM_TDERMGR_ID, XLOG_TDE_DELETE_RELATION_KEY);
 }
 
 void


### PR DESCRIPTION
Rename XLOG record type for relation key removal and add missing type description and string representations.