### PR TITLE
Make sure we always delete key files before running TAP tests

### DIFF
--- a/contrib/pg_tde/t/basic.pl
+++ b/contrib/pg_tde/t/basic.pl
@@ -9,6 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
+unlink('/tmp/pg_tde_test_001_basic.per');
+
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");

--- a/contrib/pg_tde/t/crash_recovery.pl
+++ b/contrib/pg_tde/t/crash_recovery.pl
@@ -7,10 +7,9 @@ use Test::More;
 use lib 't';
 use pgtde;
 
-# ensure we start with a clean key provider file
-unlink('/tmp/crash_recovery.per');
-
 PGTDE::setup_files_dir(basename($0));
+
+unlink('/tmp/crash_recovery.per');
 
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;

--- a/contrib/pg_tde/t/expected/key_rotate_tablespace.out
+++ b/contrib/pg_tde/t/expected/key_rotate_tablespace.out
@@ -1,7 +1,7 @@
 SET allow_in_place_tablespaces = true; CREATE TABLESPACE test_tblspace LOCATION '';
 CREATE DATABASE tbc TABLESPACE = test_tblspace;
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/key_rotate_tablespace.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
  

--- a/contrib/pg_tde/t/expected/replication.out
+++ b/contrib/pg_tde/t/expected/replication.out
@@ -1,6 +1,6 @@
 -- At primary
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/replication.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
  

--- a/contrib/pg_tde/t/expected/rotate_key.out
+++ b/contrib/pg_tde/t/expected/rotate_key.out
@@ -1,33 +1,33 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/rotate_key.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
  
 (1 row)
 
-SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');
+SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/rotate_key_2.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
  
 (1 row)
 
-SELECT pg_tde_add_global_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2g.per');
+SELECT pg_tde_add_global_key_provider_file('file-2', '/tmp/rotate_key_2g.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
  
 (1 row)
 
-SELECT pg_tde_add_global_key_provider_file('file-3', '/tmp/pg_tde_test_keyring_3.per');
+SELECT pg_tde_add_global_key_provider_file('file-3', '/tmp/rotate_key_3.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
  
 (1 row)
 
 SELECT pg_tde_list_all_database_key_providers();
-               pg_tde_list_all_database_key_providers                
----------------------------------------------------------------------
- (1,file-vault,file,"{""path"" : ""/tmp/pg_tde_test_keyring.per""}")
- (2,file-2,file,"{""path"" : ""/tmp/pg_tde_test_keyring_2.per""}")
+           pg_tde_list_all_database_key_providers           
+------------------------------------------------------------
+ (1,file-vault,file,"{""path"" : ""/tmp/rotate_key.per""}")
+ (2,file-2,file,"{""path"" : ""/tmp/rotate_key_2.per""}")
 (2 rows)
 
 SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');

--- a/contrib/pg_tde/t/expected/tde_heap.out
+++ b/contrib/pg_tde/t/expected/tde_heap.out
@@ -1,5 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/tde_heap.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
  

--- a/contrib/pg_tde/t/expected/wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/wal_encrypt.out
@@ -1,5 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pg_tde;
-SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/pg_tde_test_keyring010.per');
+SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/wal_encrypt.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------
  

--- a/contrib/pg_tde/t/key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/key_rotate_tablespace.pl
@@ -9,6 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
+unlink('/tmp/key_rotate_tablespace.per');
+
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
@@ -22,7 +24,7 @@ PGTDE::psql($node, 'postgres',
 
 PGTDE::psql($node, 'tbc', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 PGTDE::psql($node, 'tbc',
-	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');"
+	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/key_rotate_tablespace.per');"
 );
 PGTDE::psql($node, 'tbc',
 	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');"

--- a/contrib/pg_tde/t/multiple_extensions.pl
+++ b/contrib/pg_tde/t/multiple_extensions.pl
@@ -17,6 +17,8 @@ if (index(lc($PG_VERSION_STRING), lc("Percona Distribution")) == -1)
 	  "pg_tde test case only for PPG server package install with extensions.";
 }
 
+unlink('/tmp/keyring_data_file');
+
 open my $conf2, '>>', "/tmp/datafile-location";
 print $conf2 "/tmp/keyring_data_file\n";
 close $conf2;

--- a/contrib/pg_tde/t/pg_waldump_basic.pl
+++ b/contrib/pg_tde/t/pg_waldump_basic.pl
@@ -7,6 +7,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+unlink('/tmp/pg_waldump_basic.per');
+
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf(
@@ -28,7 +30,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_tde_test_keyring-wal.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_waldump_basic.per');"
 );
 $node->safe_psql('postgres',
 	"SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-wal');"

--- a/contrib/pg_tde/t/pg_waldump_fullpage.pl
+++ b/contrib/pg_tde/t/pg_waldump_fullpage.pl
@@ -29,6 +29,8 @@ sub get_block_lsn
 	return ($lsn_hi, $lsn_lo);
 }
 
+unlink('/tmp/pg_waldump_fullpage.per');
+
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf(
@@ -42,7 +44,7 @@ $node->start;
 
 $node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 $node->safe_psql('postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_tde_test_keyring-wal.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_waldump_fullpage.per');"
 );
 $node->safe_psql('postgres',
 	"SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyring-wal');"

--- a/contrib/pg_tde/t/replication.pl
+++ b/contrib/pg_tde/t/replication.pl
@@ -9,6 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
+unlink('/tmp/replication.per');
+
 my $primary = PostgreSQL::Test::Cluster->new('primary');
 $primary->init(allows_streaming => 1);
 $primary->append_conf(
@@ -28,7 +30,7 @@ PGTDE::append_to_result_file("-- At primary");
 
 PGTDE::psql($primary, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 PGTDE::psql($primary, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');"
+	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/replication.per');"
 );
 PGTDE::psql($primary, 'postgres',
 	"SELECT pg_tde_set_key_using_database_key_provider('test-key', 'file-vault');"

--- a/contrib/pg_tde/t/rotate_key.pl
+++ b/contrib/pg_tde/t/rotate_key.pl
@@ -9,6 +9,11 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
+unlink('/tmp/rotate_key.per');
+unlink('/tmp/rotate_key_2.per');
+unlink('/tmp/rotate_key_2g.per');
+unlink('/tmp/rotate_key_3.per');
+
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
@@ -17,16 +22,16 @@ $node->start;
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');"
+	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/rotate_key.per');"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2.per');"
+	"SELECT pg_tde_add_database_key_provider_file('file-2', '/tmp/rotate_key_2.per');"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-2', '/tmp/pg_tde_test_keyring_2g.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-2', '/tmp/rotate_key_2g.per');"
 );
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-3', '/tmp/pg_tde_test_keyring_3.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-3', '/tmp/rotate_key_3.per');"
 );
 
 PGTDE::psql($node, 'postgres',

--- a/contrib/pg_tde/t/tde_heap.pl
+++ b/contrib/pg_tde/t/tde_heap.pl
@@ -9,6 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
+unlink('/tmp/tde_heap.per');
+
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
@@ -17,7 +19,7 @@ $node->start;
 PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');"
+	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/tde_heap.per');"
 );
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_set_key_using_database_key_provider('test-db-key', 'file-vault');"

--- a/contrib/pg_tde/t/unlogged_tables.pl
+++ b/contrib/pg_tde/t/unlogged_tables.pl
@@ -9,6 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
+unlink('/tmp/unlogged_tables.per');
+
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");

--- a/contrib/pg_tde/t/wal_encrypt.pl
+++ b/contrib/pg_tde/t/wal_encrypt.pl
@@ -9,6 +9,8 @@ use pgtde;
 
 PGTDE::setup_files_dir(basename($0));
 
+unlink('/tmp/wal_encrypt.per');
+
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
@@ -20,7 +22,7 @@ $node->start;
 PGTDE::psql($node, 'postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
 
 PGTDE::psql($node, 'postgres',
-	"SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/pg_tde_test_keyring010.per');"
+	"SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/wal_encrypt.per');"
 );
 
 PGTDE::psql($node, 'postgres', 'SELECT pg_tde_verify_server_key();');


### PR DESCRIPTION
This way it is more clear what the tests actually do. And addditionally make sure the files are named consistently.