### PR TITLE
Remove handling of frontend from pg_tde_guc.{c,h} code

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -27,7 +27,6 @@
 #include "catalog/tde_principal_key.h"
 #include "keyring/keyring_api.h"
 #include "pg_tde.h"
-#include "pg_tde_guc.h"
 
 #ifndef FRONTEND
 #include "access/genam.h"
@@ -38,6 +37,7 @@
 #include "lib/dshash.h"
 #include "storage/lwlock.h"
 #include "storage/shmem.h"
+#include "pg_tde_guc.h"
 #else
 #include "pg_tde_fe.h"
 #endif

--- a/contrib/pg_tde/src/include/pg_tde_guc.h
+++ b/contrib/pg_tde/src/include/pg_tde_guc.h
@@ -7,13 +7,10 @@
 
 #include "c.h"
 
-#ifndef FRONTEND
-
 extern bool AllowInheritGlobalProviders;
 extern bool EncryptXLog;
 extern bool EnforceEncryption;
 
 extern void TdeGucInit(void);
 
-#endif
 #endif							/* TDE_GUC_H */

--- a/contrib/pg_tde/src/pg_tde_guc.c
+++ b/contrib/pg_tde/src/pg_tde_guc.c
@@ -8,8 +8,6 @@
 
 #include "pg_tde_guc.h"
 
-#ifndef FRONTEND
-
 bool		AllowInheritGlobalProviders = true;
 bool		EncryptXLog = false;
 bool		EnforceEncryption = false;
@@ -54,5 +52,3 @@ TdeGucInit(void)
 		);
 
 }
-
-#endif


### PR DESCRIPTION
Since we do not build the GUC code when building the frontend code the code which handles the frontend define is pointless here.