### PR TITLE
Add warning about WAL encryption being beta

### DIFF
--- a/contrib/pg_tde/expected/access_control.out
+++ b/contrib/pg_tde/expected/access_control.out
@@ -58,6 +58,7 @@ ERROR:  must be superuser to access global key providers
 SELECT pg_tde_set_default_key_using_global_key_provider('key1', 'global-file-provider');
 ERROR:  must be superuser to access global key providers
 SELECT pg_tde_set_server_key_using_global_key_provider('key1', 'global-file-provider');
+WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 ERROR:  must be superuser to access global key providers
 SELECT pg_tde_delete_default_key();
 ERROR:  must be superuser to access global key providers

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -229,6 +229,7 @@ SELECT pg_tde_add_global_key_provider_file('global-provider', '/tmp/global-provi
 (1 row)
 
 SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'global-provider');
+WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
  pg_tde_set_server_key_using_global_key_provider 
 -------------------------------------------------
  
@@ -290,6 +291,7 @@ ERROR:  key provider name cannot be null
 SELECT pg_tde_set_key_using_global_key_provider('key', NULL);
 ERROR:  key provider name cannot be null
 SELECT pg_tde_set_server_key_using_global_key_provider('key', NULL);
+WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 ERROR:  key provider name cannot be null
 -- Setting principal key fails if key name is NULL
 SELECT pg_tde_set_default_key_using_global_key_provider(NULL, 'file-keyring');
@@ -299,6 +301,7 @@ ERROR:  key name cannot be null
 SELECT pg_tde_set_key_using_global_key_provider(NULL, 'file-keyring');
 ERROR:  key name cannot be null
 SELECT pg_tde_set_server_key_using_global_key_provider(NULL, 'file-keyring');
+WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 ERROR:  key name cannot be null
 -- Empty string is not allowed for a principal key name
 SELECT pg_tde_set_default_key_using_global_key_provider('', 'file-keyring');
@@ -308,6 +311,7 @@ ERROR:  key name "" is too short
 SELECT pg_tde_set_key_using_global_key_provider('', 'file-keyring');
 ERROR:  key name "" is too short
 SELECT pg_tde_set_server_key_using_global_key_provider('', 'file-keyring');
+WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 ERROR:  key name "" is too short
 -- Setting principal key fails if the key name is too long
 SELECT pg_tde_set_default_key_using_global_key_provider(repeat('K', 256), 'file-keyring');
@@ -317,5 +321,6 @@ ERROR:  too long principal key name, maximum length is 255 bytes
 SELECT pg_tde_set_key_using_global_key_provider(repeat('K', 256), 'file-keyring');
 ERROR:  too long principal key name, maximum length is 255 bytes
 SELECT pg_tde_set_server_key_using_global_key_provider(repeat('K', 256), 'file-keyring');
+WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 ERROR:  too long principal key name, maximum length is 255 bytes
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -498,6 +498,9 @@ pg_tde_set_server_key_using_global_key_provider(PG_FUNCTION_ARGS)
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
 	bool		ensure_new_key = PG_GETARG_BOOL(2);
 
+	ereport(WARNING,
+			errmsg("The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!"));
+
 	/* Using a global provider for the global (wal) database */
 	pg_tde_set_principal_key_internal(GLOBAL_DATA_TDE_OID, GLOBAL_DATA_TDE_OID, principal_key_name, provider_name, ensure_new_key);
 

--- a/contrib/pg_tde/t/expected/crash_recovery.out
+++ b/contrib/pg_tde/t/expected/crash_recovery.out
@@ -11,6 +11,7 @@ SELECT pg_tde_set_server_key_using_global_key_provider('wal_encryption_key', 'gl
  
 (1 row)
 
+psql:<stdin>:1: WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 SELECT pg_tde_add_database_key_provider_file('db_keyring', '/tmp/crash_recovery.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
@@ -37,6 +38,7 @@ SELECT pg_tde_set_server_key_using_global_key_provider('wal_encryption_key_1', '
  
 (1 row)
 
+psql:<stdin>:1: WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 SELECT pg_tde_set_key_using_database_key_provider('db_key_1', 'db_keyring');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------
@@ -54,6 +56,7 @@ SELECT pg_tde_set_server_key_using_global_key_provider('wal_encryption_key_2', '
  
 (1 row)
 
+psql:<stdin>:1: WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 SELECT pg_tde_set_key_using_database_key_provider('db_key_2', 'db_keyring');
  pg_tde_set_key_using_database_key_provider 
 --------------------------------------------

--- a/contrib/pg_tde/t/expected/replication.out
+++ b/contrib/pg_tde/t/expected/replication.out
@@ -68,6 +68,7 @@ SELECT pg_tde_set_server_key_using_global_key_provider('test-global-key', 'file-
  
 (1 row)
 
+psql:<stdin>:1: WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 CREATE TABLE test_enc2 (x int PRIMARY KEY) USING tde_heap;
 INSERT INTO test_enc2 (x) VALUES (1), (2);
 ALTER SYSTEM SET pg_tde.wal_encrypt = 'on';

--- a/contrib/pg_tde/t/expected/wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/wal_encrypt.out
@@ -19,6 +19,7 @@ SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyri
  
 (1 row)
 
+psql:<stdin>:1: WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 SELECT pg_tde_verify_server_key();
  pg_tde_verify_server_key 
 --------------------------


### PR DESCRIPTION
It makes sense to warn about this when a key for WAL encryption is created as this is a necessary step before WAL encryption can be enabled.