### PR TITLE
Be confident about pg_tde not existing in tests

### DIFF
--- a/contrib/pg_tde/expected/access_control.out
+++ b/contrib/pg_tde/expected/access_control.out
@@ -1,5 +1,5 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/expected/alter_index.out
+++ b/contrib/pg_tde/expected/alter_index.out
@@ -1,5 +1,5 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/expected/cache_alloc.out
+++ b/contrib/pg_tde/expected/cache_alloc.out
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 -- Just checking there are no mem debug WARNINGs during the cache population
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/expected/change_access_method.out
+++ b/contrib/pg_tde/expected/change_access_method.out
@@ -1,5 +1,5 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/expected/create_database.out
+++ b/contrib/pg_tde/expected/create_database.out
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/template_provider_global.per'
 \! rm -f '/tmp/template_provider.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 CREATE DATABASE template_db;
 SELECT current_database() AS regress_database
 \gset

--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_regression_default_key.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
-CREATE EXTENSION IF NOT EXISTS pg_buffercache;
+CREATE EXTENSION pg_tde;
+CREATE EXTENSION pg_buffercache;
 SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_key.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------

--- a/contrib/pg_tde/expected/delete_principal_key.out
+++ b/contrib/pg_tde/expected/delete_principal_key.out
@@ -1,5 +1,5 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------

--- a/contrib/pg_tde/expected/insert_update_delete.out
+++ b/contrib/pg_tde/expected/insert_update_delete.out
@@ -1,5 +1,5 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -2,7 +2,7 @@
 \! rm -f '/tmp/global-provider-file-1'
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 \! rm -f '/tmp/pg_tde_test_keyring2.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT  * FROM pg_tde_key_info();
  key_name | provider_name | provider_id | key_creation_time 
 ----------+---------------+-------------+-------------------

--- a/contrib/pg_tde/expected/pg_tde_is_encrypted.out
+++ b/contrib/pg_tde/expected/pg_tde_is_encrypted.out
@@ -1,5 +1,5 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/expected/recreate_storage.out
+++ b/contrib/pg_tde/expected/recreate_storage.out
@@ -1,5 +1,5 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/expected/relocate.out
+++ b/contrib/pg_tde/expected/relocate.out
@@ -1,6 +1,3 @@
--- Support pg_tde already being installed
-SET client_min_messages = 'warning';
-DROP EXTENSION IF EXISTS pg_tde;
 CREATE SCHEMA other;
 CREATE EXTENSION pg_tde SCHEMA other;
 SELECT other.pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');

--- a/contrib/pg_tde/expected/tablespace.out
+++ b/contrib/pg_tde/expected/tablespace.out
@@ -1,5 +1,5 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/expected/toast_decrypt.out
+++ b/contrib/pg_tde/expected/toast_decrypt.out
@@ -1,5 +1,5 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 \getenv root_token_file VAULT_ROOT_TOKEN_FILE
 \getenv cacert_file VAULT_CACERT_FILE
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-incorrect', 'https://127.0.0.1:8200', 'DUMMY-TOKEN', :'root_token_file', :'cacert_file');

--- a/contrib/pg_tde/sql/access_control.sql
+++ b/contrib/pg_tde/sql/access_control.sql
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('local-file-provider', '/tmp/pg_tde_test_keyring.per');
 

--- a/contrib/pg_tde/sql/alter_index.sql
+++ b/contrib/pg_tde/sql/alter_index.sql
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_create_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/sql/cache_alloc.sql
+++ b/contrib/pg_tde/sql/cache_alloc.sql
@@ -2,7 +2,7 @@
 
 -- Just checking there are no mem debug WARNINGs during the cache population
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_create_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/sql/change_access_method.sql
+++ b/contrib/pg_tde/sql/change_access_method.sql
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_create_key_using_database_key_provider('test-db-key', 'file-vault');

--- a/contrib/pg_tde/sql/create_database.sql
+++ b/contrib/pg_tde/sql/create_database.sql
@@ -1,7 +1,7 @@
 \! rm -f '/tmp/template_provider_global.per'
 \! rm -f '/tmp/template_provider.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 CREATE DATABASE template_db;
 

--- a/contrib/pg_tde/sql/default_principal_key.sql
+++ b/contrib/pg_tde/sql/default_principal_key.sql
@@ -1,7 +1,7 @@
 \! rm -f '/tmp/pg_tde_regression_default_key.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
-CREATE EXTENSION IF NOT EXISTS pg_buffercache;
+CREATE EXTENSION pg_tde;
+CREATE EXTENSION pg_buffercache;
 
 SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_regression_default_key.per');
 

--- a/contrib/pg_tde/sql/delete_principal_key.sql
+++ b/contrib/pg_tde/sql/delete_principal_key.sql
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_global_key_provider_file('file-provider','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_create_key_using_global_key_provider('defalut-key','file-provider');

--- a/contrib/pg_tde/sql/insert_update_delete.sql
+++ b/contrib/pg_tde/sql/insert_update_delete.sql
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_create_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/sql/key_provider.sql
+++ b/contrib/pg_tde/sql/key_provider.sql
@@ -3,7 +3,7 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 \! rm -f '/tmp/pg_tde_test_keyring2.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT  * FROM pg_tde_key_info();
 

--- a/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
+++ b/contrib/pg_tde/sql/pg_tde_is_encrypted.sql
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_create_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/sql/recreate_storage.sql
+++ b/contrib/pg_tde/sql/recreate_storage.sql
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_create_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/sql/relocate.sql
+++ b/contrib/pg_tde/sql/relocate.sql
@@ -1,7 +1,3 @@
--- Support pg_tde already being installed
-SET client_min_messages = 'warning';
-DROP EXTENSION IF EXISTS pg_tde;
-
 CREATE SCHEMA other;
 
 CREATE EXTENSION pg_tde SCHEMA other;

--- a/contrib/pg_tde/sql/tablespace.sql
+++ b/contrib/pg_tde/sql/tablespace.sql
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_create_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/sql/toast_decrypt.sql
+++ b/contrib/pg_tde/sql/toast_decrypt.sql
@@ -1,6 +1,6 @@
 \! rm -f '/tmp/pg_tde_test_keyring.per'
 
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 SELECT pg_tde_add_database_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_create_key_using_database_key_provider('test-db-key','file-vault');

--- a/contrib/pg_tde/sql/vault_v2_test.sql
+++ b/contrib/pg_tde/sql/vault_v2_test.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 
 \getenv root_token_file VAULT_ROOT_TOKEN_FILE
 \getenv cacert_file VAULT_CACERT_FILE

--- a/contrib/pg_tde/t/basic.pl
+++ b/contrib/pg_tde/t/basic.pl
@@ -16,7 +16,7 @@ $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 $node->start;
 
-PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION pg_tde;');
 
 # Only whitelisted C or security definer functions are granted to public by default
 PGTDE::psql(

--- a/contrib/pg_tde/t/change_key_provider.pl
+++ b/contrib/pg_tde/t/change_key_provider.pl
@@ -18,7 +18,7 @@ $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 $node->start;
 
-PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION pg_tde;');
 
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');"

--- a/contrib/pg_tde/t/crash_recovery.pl
+++ b/contrib/pg_tde/t/crash_recovery.pl
@@ -20,7 +20,7 @@ shared_preload_libraries = 'pg_tde'
 });
 $node->start;
 
-PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION pg_tde;');
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_global_key_provider_file('global_keyring', '/tmp/crash_recovery.per');"
 );

--- a/contrib/pg_tde/t/expected/basic.out
+++ b/contrib/pg_tde/t/expected/basic.out
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 		SELECT
 			pg_proc.oid::regprocedure
 		FROM

--- a/contrib/pg_tde/t/expected/change_key_provider.out
+++ b/contrib/pg_tde/t/expected/change_key_provider.out
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/t/expected/crash_recovery.out
+++ b/contrib/pg_tde/t/expected/crash_recovery.out
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_global_key_provider_file('global_keyring', '/tmp/crash_recovery.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------

--- a/contrib/pg_tde/t/expected/key_rotate_tablespace.out
+++ b/contrib/pg_tde/t/expected/key_rotate_tablespace.out
@@ -1,6 +1,6 @@
 SET allow_in_place_tablespaces = true; CREATE TABLESPACE test_tblspace LOCATION '';
 CREATE DATABASE tbc TABLESPACE = test_tblspace;
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/key_rotate_tablespace.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/t/expected/multiple_extensions.out
+++ b/contrib/pg_tde/t/expected/multiple_extensions.out
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 CREATE TABLE test_enc1 (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;
 INSERT INTO test_enc1 (k) VALUES (5), (6);
 SELECT * FROM test_enc1 ORDER BY id;

--- a/contrib/pg_tde/t/expected/replication.out
+++ b/contrib/pg_tde/t/expected/replication.out
@@ -1,5 +1,5 @@
 -- At primary
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/replication.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/t/expected/rotate_key.out
+++ b/contrib/pg_tde/t/expected/rotate_key.out
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/rotate_key.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/t/expected/tde_heap.out
+++ b/contrib/pg_tde/t/expected/tde_heap.out
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/tde_heap.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/t/expected/unlogged_tables.out
+++ b/contrib/pg_tde/t/expected/unlogged_tables.out
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------

--- a/contrib/pg_tde/t/expected/wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/wal_encrypt.out
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pg_tde;
+CREATE EXTENSION pg_tde;
 SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/wal_encrypt.per');
  pg_tde_add_global_key_provider_file 
 -------------------------------------

--- a/contrib/pg_tde/t/key_rotate_tablespace.pl
+++ b/contrib/pg_tde/t/key_rotate_tablespace.pl
@@ -22,7 +22,7 @@ PGTDE::psql($node, 'postgres',
 PGTDE::psql($node, 'postgres',
 	'CREATE DATABASE tbc TABLESPACE = test_tblspace;');
 
-PGTDE::psql($node, 'tbc', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+PGTDE::psql($node, 'tbc', 'CREATE EXTENSION pg_tde;');
 PGTDE::psql($node, 'tbc',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/key_rotate_tablespace.per');"
 );

--- a/contrib/pg_tde/t/multiple_extensions.pl
+++ b/contrib/pg_tde/t/multiple_extensions.pl
@@ -50,10 +50,8 @@ ok($cmdret == 0, "Reset PGSM EXTENSION");
 PGTDE::append_to_debug_file($stdout);
 
 # Create pg_tde extension
-($cmdret, $stdout, $stderr) = $node->psql(
-	'postgres',
-	'CREATE EXTENSION IF NOT EXISTS pg_tde;',
-	extra_params => ['-a']);
+($cmdret, $stdout, $stderr) =
+  $node->psql('postgres', 'CREATE EXTENSION pg_tde;', extra_params => ['-a']);
 ok($cmdret == 0, "CREATE PGTDE EXTENSION");
 PGTDE::append_to_result_file($stdout);
 

--- a/contrib/pg_tde/t/pg_tde_change_key_provider.pl
+++ b/contrib/pg_tde/t/pg_tde_change_key_provider.pl
@@ -11,7 +11,7 @@ $node->init;
 $node->append_conf('postgresql.conf', q{shared_preload_libraries = 'pg_tde'});
 $node->start;
 
-$node->safe_psql('postgres', q{CREATE EXTENSION IF NOT EXISTS pg_tde});
+$node->safe_psql('postgres', q{CREATE EXTENSION pg_tde});
 $node->safe_psql('postgres',
 	q{SELECT pg_tde_add_global_key_provider_file('global-provider', '/tmp/pg_tde_change_key_provider-global')}
 );

--- a/contrib/pg_tde/t/pg_waldump_basic.pl
+++ b/contrib/pg_tde/t/pg_waldump_basic.pl
@@ -28,7 +28,7 @@ shared_preload_libraries = 'pg_tde'
 });
 $node->start;
 
-$node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
+$node->safe_psql('postgres', "CREATE EXTENSION pg_tde;");
 $node->safe_psql('postgres',
 	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_waldump_basic.per');"
 );

--- a/contrib/pg_tde/t/pg_waldump_fullpage.pl
+++ b/contrib/pg_tde/t/pg_waldump_fullpage.pl
@@ -42,7 +42,7 @@ shared_preload_libraries = 'pg_tde'
 });
 $node->start;
 
-$node->safe_psql('postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
+$node->safe_psql('postgres', "CREATE EXTENSION pg_tde;");
 $node->safe_psql('postgres',
 	"SELECT pg_tde_add_global_key_provider_file('file-keyring-wal', '/tmp/pg_waldump_fullpage.per');"
 );

--- a/contrib/pg_tde/t/replication.pl
+++ b/contrib/pg_tde/t/replication.pl
@@ -28,7 +28,7 @@ $replica->start;
 
 PGTDE::append_to_result_file("-- At primary");
 
-PGTDE::psql($primary, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+PGTDE::psql($primary, 'postgres', 'CREATE EXTENSION pg_tde;');
 PGTDE::psql($primary, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/replication.per');"
 );

--- a/contrib/pg_tde/t/rotate_key.pl
+++ b/contrib/pg_tde/t/rotate_key.pl
@@ -19,7 +19,7 @@ $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 $node->start;
 
-PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION pg_tde;');
 
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/rotate_key.per');"

--- a/contrib/pg_tde/t/tde_heap.pl
+++ b/contrib/pg_tde/t/tde_heap.pl
@@ -16,7 +16,7 @@ $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 $node->start;
 
-PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION pg_tde;');
 
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/tde_heap.per');"

--- a/contrib/pg_tde/t/unlogged_tables.pl
+++ b/contrib/pg_tde/t/unlogged_tables.pl
@@ -16,7 +16,7 @@ $node->init;
 $node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
 $node->start;
 
-PGTDE::psql($node, 'postgres', 'CREATE EXTENSION IF NOT EXISTS pg_tde;');
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION pg_tde;');
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/unlogged_tables.per');"
 );

--- a/contrib/pg_tde/t/wal_encrypt.pl
+++ b/contrib/pg_tde/t/wal_encrypt.pl
@@ -19,7 +19,7 @@ $node->append_conf('postgresql.conf', "wal_level = 'logical'");
 #$node->append_conf('postgresql.conf', "pg_tde.wal_encrypt = 1"});
 $node->start;
 
-PGTDE::psql($node, 'postgres', "CREATE EXTENSION IF NOT EXISTS pg_tde;");
+PGTDE::psql($node, 'postgres', "CREATE EXTENSION pg_tde;");
 
 PGTDE::psql($node, 'postgres',
 	"SELECT pg_tde_add_global_key_provider_file('file-keyring-010', '/tmp/wal_encrypt.per');"


### PR DESCRIPTION
We no longer run theses tests when pg_tde is turned on globally.

There is no reason for us to CREATE IF NOT EXISTS in tests as we should _know_ what state the database is in when running them.