### PR TITLE
Tidy sanitizers' suppressions list and fix some mem leaks

### DIFF
--- a/ci_scripts/suppressions/lsan.supp
+++ b/ci_scripts/suppressions/lsan.supp
@@ -1,14 +1,52 @@
-leak:save_ps_display_args
-leak:initdb.c
-leak:fe_memutils.c
-leak:fe-exec.c
-leak:fe-connect.c
-leak:pqexpbuffer.c
-leak:strdup
-leak:preproc.y
-leak:pgtypeslib/common.c
-leak:ecpglib/memory.c
+# external submodule
 leak:kmip.c
+
+# the parser of command line arguments of the backend
+leak:save_ps_display_args
+
+# a bunch of not freed addrinfo sctructs, escaped values etc.
+leak:initdb.c
+
+# shlibs loaded with dlsym() never gets dlclose'd
+# TODO: needs an investigation as it is down the call stack
+#		of exec_simple_query->PortalRun
+leak:internal_load_library
+
+# pg_config utility does not free configdata
+leak:pg_config/pg_config.c
+
+# A psprintf() result assigned to the global var pgdata_opt
+leak:bin/pg_ctl/pg_ctl.c
+
+# TODO: A couple of not freed char *. Whilst wit's trivially to fix
+# meson complains with "maybe-uninitialized" on free()
+leak:bin/psql/describe.c
+
+# options parsing during the regressions start
+leak:regression_main
+
+# Static funcs in /bin/psql/startup.c are used
+# during the start to parse options
+leak:simple_action_list_append
+leak:parse_psql_options
+
+# A bunch of parameters, options and identifiers are not being freed.
+#
+# TODO?: ReceiveArchiveStreamChunk->CreateBackupStreamer down in the
+# callstak creates a streamer that is never freed. It's being called in a loop
+# but it looks like it is not a repetitive action and rather happens once per
+# receiving CopyData message from server.
+#
+# bin/pg_basebackup/pg_basebackup.c
+leak:BaseBackup
+
+# `varname` doesn't get freed in the case of warning and `continue` in the loop
+# 
+# bin/psql/common.c
+leak:StoreQueryTuple
+
+# does not free a bunch of parsed flags
+leak:bin/pg_waldump/pg_waldump.c
 
 #pg_dump
 leak:getSchemaData

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -1078,7 +1078,7 @@ pg_tde_fetch_wal_keys(XLogRecPtr start_lsn)
 		wal_rec = pg_tde_add_wal_key_to_cache(&stub_key, InvalidXLogRecPtr);
 
 #ifdef FRONTEND
-		/* The backen frees it after copying to the cache. */
+		/* The backend frees it after copying to the cache. */
 		pfree(principal_key);
 #endif
 		LWLockRelease(lock_pk);

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -1077,6 +1077,10 @@ pg_tde_fetch_wal_keys(XLogRecPtr start_lsn)
 
 		wal_rec = pg_tde_add_wal_key_to_cache(&stub_key, InvalidXLogRecPtr);
 
+#ifdef FRONTEND
+		/* The backen frees it after copying to the cache. */
+		pfree(principal_key);
+#endif
 		LWLockRelease(lock_pk);
 		CloseTransientFile(fd);
 		return wal_rec;
@@ -1107,6 +1111,9 @@ pg_tde_fetch_wal_keys(XLogRecPtr start_lsn)
 				return_wal_rec = wal_rec;
 		}
 	}
+#ifdef FRONTEND
+	pfree(principal_key);
+#endif
 	LWLockRelease(lock_pk);
 	CloseTransientFile(fd);
 

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -863,7 +863,7 @@ get_principal_key_from_keyring(Oid dbOid)
 	Assert(dbOid == principalKey->keyInfo.databaseId);
 
 	pfree(keyInfo);
-	pfree(keyring);
+	free_keyring(keyring);
 	pfree(principalKeyInfo);
 
 	return principalKey;

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -81,7 +81,10 @@ extern void pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocato
 static inline void
 pg_tde_set_db_file_path(Oid dbOid, char *path)
 {
-	join_path_components(path, pg_tde_get_data_dir(), psprintf(PG_TDE_MAP_FILENAME, dbOid));
+	char	   *fname = psprintf(PG_TDE_MAP_FILENAME, dbOid);
+
+	join_path_components(path, pg_tde_get_data_dir(), fname);
+	pfree(fname);
 }
 
 extern void pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *key);

--- a/contrib/pg_tde/src/include/catalog/tde_keyring.h
+++ b/contrib/pg_tde/src/include/catalog/tde_keyring.h
@@ -40,5 +40,6 @@ extern void redo_key_provider_info(KeyringProviderRecordInFile *xlrec);
 extern void ParseKeyringJSONOptions(ProviderType provider_type,
 									GenericKeyring *out_opts,
 									char *in_buf, int buf_len);
+extern void free_keyring(GenericKeyring *keyring);
 
 #endif							/* TDE_KEYRING_H */

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -438,5 +438,6 @@ json_resp_object_field_start(void *state, char *fname, bool isnull)
 			break;
 	}
 
+	pfree(fname);
 	return JSON_SUCCESS;
 }

--- a/contrib/pg_tde/src/pg_tde_change_key_provider.c
+++ b/contrib/pg_tde/src/pg_tde_change_key_provider.c
@@ -249,6 +249,7 @@ main(int argc, char *argv[])
 		controlfile->state != DB_SHUTDOWNED_IN_RECOVERY)
 		pg_fatal("cluster must be shut down");
 
+	pfree(controlfile);
 	cptr = strcat(cptr, datadir);
 	cptr = strcat(cptr, "/");
 	cptr = strcat(cptr, PG_TDE_DATA_DIR);


### PR DESCRIPTION
Tihs PR makes a suppression list as specific as possible, so it won't cover up new issues. And adds comments to existing suppressions. Also, fixes memory leaks in bin/pgctl code (all related to frontend usage) and low-hanging fruits in pgctl.