### PR TITLE
PG-1662 Handle changing access method of partitioned table correctly

### DIFF
--- a/contrib/pg_tde/expected/partition_table.out
+++ b/contrib/pg_tde/expected/partition_table.out
@@ -161,6 +161,30 @@ SELECT pg_tde_is_encrypted('partition_child_tde_heap');
 
 DROP TABLE partition_parent;
 RESET pg_tde.enforce_encryption;
+-- Does not change encryption of child tables when rewriting and changing AM
+CREATE TABLE partition_parent (a int, b int) PARTITION BY RANGE (a) USING tde_heap;
+CREATE TABLE partition_child PARTITION OF partition_parent FOR VALUES FROM (0) TO (9) USING tde_heap;
+SELECT pg_tde_is_encrypted('partition_child');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+ALTER TABLE partition_parent SET ACCESS METHOD heap, ALTER b TYPE bigint;
+SELECT relname, amname FROM pg_class JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname IN ('partition_parent', 'partition_child') ORDER BY relname;
+     relname      |  amname  
+------------------+----------
+ partition_child  | tde_heap
+ partition_parent | heap
+(2 rows)
+
+SELECT pg_tde_is_encrypted('partition_child');
+ pg_tde_is_encrypted 
+---------------------
+ t
+(1 row)
+
+DROP TABLE partition_parent;
 -- Partitioned indexes should be encrypted
 CREATE TABLE partition_parent (a int) PARTITION BY RANGE (a);
 CREATE TABLE partition_child PARTITION OF partition_parent FOR VALUES FROM (0) TO (9) USING tde_heap;

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -357,6 +357,7 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 			ListCell   *lcmd;
 			TdeDdlEvent event = {.parsetree = parsetree};
 			EncryptionMix encmix;
+			Relation	rel;
 
 			foreach(lcmd, stmt->cmds)
 			{
@@ -380,17 +381,25 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 						errmsg("Recursive ALTER TABLE on a mix of encrypted and unencrypted relations is not supported"));
 			}
 
+			rel = relation_open(relid, NoLock);
+
 			/*
 			 * With a SET ACCESS METHOD clause, use that as the basis for
 			 * decisions. But if it's not present, look up encryption status
 			 * of the table.
+			 *
+			 * Since partitioned tables lack storage we do not need to set the
+			 * encryption mode.
 			 */
-			if (setAccessMethod)
+			if (setAccessMethod && RELKIND_HAS_STORAGE(rel->rd_rel->relkind))
 			{
 				event.rebuildSequencesFor = relid;
 
 				if (shouldEncryptTable(setAccessMethod->name))
+				{
 					event.encryptMode = TDE_ENCRYPT_MODE_ENCRYPT;
+					checkPrincipalKeyConfigured();
+				}
 				else
 					event.encryptMode = TDE_ENCRYPT_MODE_PLAIN;
 			}
@@ -404,6 +413,8 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 				else if (encmix == ENC_MIX_PLAIN)
 					event.encryptMode = TDE_ENCRYPT_MODE_PLAIN;
 			}
+
+			relation_close(rel, NoLock);
 
 			push_event_stack(&event);
 			checkEncryptionStatus();


### PR DESCRIPTION
Since partitioned tables do not have any sotrage and only control the default access method of their children we should not try to change the encryption status of anything when changing the AM of a partitioned table.