### PR TITLE
Try to use `poll_start` instead of `kill9_until_dead` in TAP tests

### DIFF
--- a/contrib/pg_tde/t/crash_recovery.pl
+++ b/contrib/pg_tde/t/crash_recovery.pl
@@ -51,10 +51,10 @@ PGTDE::psql($node, 'postgres', "INSERT INTO test_plain (x) VALUES (3), (4);");
 PGTDE::psql($node, 'postgres', "ALTER SYSTEM SET pg_tde.wal_encrypt = 'on';");
 
 PGTDE::append_to_result_file("-- kill -9");
-PGTDE::kill9_until_dead($node);
+$node->kill9;
 
 PGTDE::append_to_result_file("-- server start");
-$node->start;
+PGTDE::poll_start($node);
 
 PGTDE::append_to_result_file("-- rotate wal key");
 PGTDE::psql($node, 'postgres',
@@ -71,12 +71,12 @@ PGTDE::psql($node, 'postgres',
 );
 PGTDE::psql($node, 'postgres', "INSERT INTO test_enc (x) VALUES (3), (4);");
 PGTDE::append_to_result_file("-- kill -9");
-PGTDE::kill9_until_dead($node);
+$node->kill9;
 PGTDE::append_to_result_file("-- server start");
 PGTDE::append_to_result_file(
 	"-- check that pg_tde_save_principal_key_redo hasn't destroyed a WAL key created during the server start"
 );
-$node->start;
+PGTDE::poll_start($node);
 
 PGTDE::append_to_result_file("-- rotate wal key");
 PGTDE::psql($node, 'postgres',
@@ -93,24 +93,24 @@ PGTDE::psql($node, 'postgres',
 );
 PGTDE::psql($node, 'postgres', "INSERT INTO test_enc (x) VALUES (5), (6);");
 PGTDE::append_to_result_file("-- kill -9");
-PGTDE::kill9_until_dead($node);
+$node->kill9;
 PGTDE::append_to_result_file("-- server start");
 PGTDE::append_to_result_file(
 	"-- check that the key rotation hasn't destroyed a WAL key created during the server start"
 );
-$node->start;
+PGTDE::poll_start($node);
 
 PGTDE::psql($node, 'postgres', "TABLE test_enc;");
 
 PGTDE::psql($node, 'postgres',
 	"CREATE TABLE test_enc2 (x int PRIMARY KEY) USING tde_heap;");
 PGTDE::append_to_result_file("-- kill -9");
-PGTDE::kill9_until_dead($node);
+$node->kill9;
 PGTDE::append_to_result_file("-- server start");
 PGTDE::append_to_result_file(
 	"-- check redo of the smgr internal key creation when the key is on disk"
 );
-$node->start;
+PGTDE::poll_start($node);
 
 $node->stop;
 

--- a/contrib/pg_tde/t/replication.pl
+++ b/contrib/pg_tde/t/replication.pl
@@ -82,10 +82,10 @@ PGTDE::psql($primary, 'postgres',
 
 PGTDE::psql($primary, 'postgres',
 	"ALTER SYSTEM SET pg_tde.wal_encrypt = 'on';");
-PGTDE::kill9_until_dead($primary);
+$primary->kill9;
 
 PGTDE::append_to_result_file("-- primary start");
-$primary->start;
+PGTDE::poll_start($primary);
 $primary->wait_for_catchup('replica');
 
 PGTDE::psql($replica, 'postgres', "SELECT * FROM test_enc2 ORDER BY x;");

--- a/contrib/pg_tde/t/unlogged_tables.pl
+++ b/contrib/pg_tde/t/unlogged_tables.pl
@@ -35,10 +35,10 @@ PGTDE::psql($node, 'postgres', "INSERT INTO t SELECT generate_series(1, 4);");
 PGTDE::psql($node, 'postgres', "CHECKPOINT;");
 
 PGTDE::append_to_result_file("-- kill -9");
-PGTDE::kill9_until_dead($node);
+$node->kill9;
 
 PGTDE::append_to_result_file("-- server start");
-$node->start;
+PGTDE::poll_start($node);
 
 PGTDE::psql($node, 'postgres', "TABLE t;");
 


### PR DESCRIPTION
The `poll_start` function handles both slow `kill -9` and slow startup while `kill9_until_dead` only really handles one of them.