### PR TITLE
PG-1661 Validate key coming from key providers

### DIFF
--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -252,7 +252,7 @@ WARNING:  The WAL encryption feature is currently in beta and may be unstable. D
 (1 row)
 
 SELECT pg_tde_change_global_key_provider_file('global-provider','/tmp/global-provider-file-2');
-ERROR:  could not fetch key "server-key" used as server key from modified key provider "global-provider": 0
+ERROR:  key "server-key" used as server key not found in modified key provider "global-provider"
 -- Modifying key providers fails if new settings can't fetch existing database key
 SELECT pg_tde_add_global_key_provider_file('global-provider2', '/tmp/global-provider-file-1');
  pg_tde_add_global_key_provider_file 
@@ -279,7 +279,7 @@ SELECT pg_tde_set_key_using_global_key_provider('database-key', 'global-provider
 
 \c :regress_database
 SELECT pg_tde_change_global_key_provider_file('global-provider2', '/tmp/global-provider-file-2');
-ERROR:  could not fetch key "database-key" used by database "db_using_global_provider" from modified key provider "global-provider2": 0
+ERROR:  key "database-key" used by database "db_using_global_provider" not found in modified key provider "global-provider2"
 DROP DATABASE db_using_global_provider;
 CREATE DATABASE db_using_database_provider;
 \c db_using_database_provider;
@@ -303,7 +303,7 @@ SELECT pg_tde_set_key_using_database_key_provider('database-key', 'db-provider')
 (1 row)
 
 SELECT pg_tde_change_database_key_provider_file('db-provider', '/tmp/db-provider-file-2');
-ERROR:  could not fetch key "database-key" used by database "db_using_database_provider" from modified key provider "db-provider": 0
+ERROR:  key "database-key" used by database "db_using_database_provider" not found in modified key provider "db-provider"
 \c :regress_database
 DROP DATABASE db_using_database_provider;
 -- Deleting key providers fails if key name is NULL

--- a/contrib/pg_tde/src/include/keyring/keyring_api.h
+++ b/contrib/pg_tde/src/include/keyring/keyring_api.h
@@ -14,7 +14,9 @@ typedef enum ProviderType
 } ProviderType;
 
 #define TDE_KEY_NAME_LEN 256
-#define MAX_KEY_DATA_SIZE 32	/* maximum 256 bit encryption */
+#define KEY_DATA_SIZE_128 16	/* 128 bit encryption */
+#define KEY_DATA_SIZE_256 32	/* 256 bit encryption, not yet supported */
+#define MAX_KEY_DATA_SIZE KEY_DATA_SIZE_256 /* maximum 256 bit encryption */
 #define INTERNAL_KEY_LEN 16
 
 typedef struct KeyData
@@ -35,7 +37,7 @@ typedef enum KeyringReturnCode
 	KEYRING_CODE_INVALID_PROVIDER = 1,
 	KEYRING_CODE_RESOURCE_NOT_AVAILABLE = 2,
 	KEYRING_CODE_INVALID_RESPONSE = 5,
-	KEYRING_CODE_INVALID_KEY_SIZE = 6,
+	KEYRING_CODE_INVALID_KEY = 6,
 	KEYRING_CODE_DATA_CORRUPTED = 7,
 } KeyringReturnCode;
 
@@ -87,5 +89,7 @@ extern void RegisterKeyProviderType(const TDEKeyringRoutine *routine, ProviderTy
 extern KeyInfo *KeyringGetKey(GenericKeyring *keyring, const char *key_name, KeyringReturnCode *returnCode);
 extern KeyInfo *KeyringGenerateNewKeyAndStore(GenericKeyring *keyring, const char *key_name, unsigned key_len);
 extern void KeyringValidate(GenericKeyring *keyring);
+extern bool ValidateKey(KeyInfo *key);
+extern char *KeyringErrorCodeToString(KeyringReturnCode code);
 
 #endif							/* KEYRING_API_H */

--- a/contrib/pg_tde/src/keyring/keyring_kmip.c
+++ b/contrib/pg_tde/src/keyring/keyring_kmip.c
@@ -178,7 +178,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 		if (key->data.len > sizeof(key->data.data))
 		{
 			ereport(WARNING, errmsg("keyring provider returned invalid key size: %d", key->data.len));
-			*return_code = KEYRING_CODE_INVALID_KEY_SIZE;
+			*return_code = KEYRING_CODE_INVALID_KEY;
 			pfree(key);
 			BIO_free_all(ctx.bio);
 			SSL_CTX_free(ctx.ssl);

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -220,7 +220,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 
 	if (!curl_perform(vault_keyring, url, &str, &httpCode, NULL))
 	{
-		*return_code = KEYRING_CODE_INVALID_KEY_SIZE;
+		*return_code = KEYRING_CODE_INVALID_KEY;
 		ereport(WARNING,
 				errmsg("HTTP(S) request to keyring provider \"%s\" failed",
 					   vault_keyring->keyring.provider_name));
@@ -266,7 +266,7 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 
 	if (key->data.len > MAX_KEY_DATA_SIZE)
 	{
-		*return_code = KEYRING_CODE_INVALID_KEY_SIZE;
+		*return_code = KEYRING_CODE_INVALID_KEY;
 		ereport(WARNING,
 				errmsg("keyring provider \"%s\" returned invalid key size: %d",
 					   vault_keyring->keyring.provider_name, key->data.len));

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -253,6 +253,15 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode
 		goto cleanup;
 	}
 
+	if (parse.key == NULL)
+	{
+		*return_code = KEYRING_CODE_INVALID_RESPONSE;
+		ereport(WARNING,
+				errmsg("HTTP(S) request to keyring provider \"%s\" returned no key",
+					   vault_keyring->keyring.provider_name));
+		goto cleanup;
+	}
+
 	responseKey = parse.key;
 
 #if KEYRING_DEBUG

--- a/contrib/pg_tde/t/expected/basic.out
+++ b/contrib/pg_tde/t/expected/basic.out
@@ -64,6 +64,6 @@ SELECT * FROM test_enc ORDER BY id;
 TABLEFILE FOUND: yes
 CONTAINS FOO (should be empty): 
 SELECT pg_tde_verify_key()
-psql:<stdin>:1: ERROR:  failed to retrieve principal key test-db-key from keyring with ID 1
+psql:<stdin>:1: ERROR:  key "test-db-key" not found in key provider "file-vault"
 DROP TABLE test_enc;
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/t/expected/change_key_provider.out
+++ b/contrib/pg_tde/t/expected/change_key_provider.out
@@ -99,7 +99,7 @@ SELECT * FROM test_enc ORDER BY id;
 -- mv /tmp/change_key_provider_2.per /tmp/change_key_provider_1.per
 -- server restart
 SELECT pg_tde_verify_key();
-psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
+psql:<stdin>:1: ERROR:  key "test-key" not found in key provider "file-vault"
 SELECT pg_tde_is_encrypted('test_enc');
  pg_tde_is_encrypted 
 ---------------------
@@ -107,7 +107,7 @@ SELECT pg_tde_is_encrypted('test_enc');
 (1 row)
 
 SELECT * FROM test_enc ORDER BY id;
-psql:<stdin>:1: ERROR:  failed to retrieve principal key test-key from keyring with ID 1
+psql:<stdin>:1: ERROR:  key "test-key" not found in key provider "file-vault"
 SELECT pg_tde_change_database_key_provider_file('file-vault', '/tmp/change_key_provider_1.per');
  pg_tde_change_database_key_provider_file 
 ------------------------------------------

--- a/contrib/pg_tde/t/expected/key_validation.out
+++ b/contrib/pg_tde/t/expected/key_validation.out
@@ -1,0 +1,27 @@
+CREATE EXTENSION pg_tde;
+SELECT pg_tde_add_database_key_provider_file('test-file-provider', '/tmp/pg_tde_test_key_validation.per');
+ pg_tde_add_database_key_provider_file 
+---------------------------------------
+ 
+(1 row)
+
+SELECT pg_tde_create_key_using_database_key_provider('key1', 'test-file-provider');
+ pg_tde_create_key_using_database_key_provider 
+-----------------------------------------------
+ 
+(1 row)
+
+SELECT pg_tde_create_key_using_database_key_provider('key2', 'test-file-provider');
+ pg_tde_create_key_using_database_key_provider 
+-----------------------------------------------
+ 
+(1 row)
+
+SELECT pg_tde_set_key_using_database_key_provider('key1', 'test-file-provider');
+psql:<stdin>:1: WARNING:  invalid key: data length is zero
+psql:<stdin>:1: ERROR:  failed to retrieve principal key "key1" from key provider "test-file-provider"
+DETAIL:  Invalid key
+SELECT pg_tde_set_key_using_database_key_provider('key2', 'test-file-provider');
+psql:<stdin>:1: WARNING:  invalid key: unsupported key length "4294967295"
+psql:<stdin>:1: ERROR:  failed to retrieve principal key "key2" from key provider "test-file-provider"
+DETAIL:  Invalid key

--- a/contrib/pg_tde/t/key_validation.pl
+++ b/contrib/pg_tde/t/key_validation.pl
@@ -1,0 +1,77 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use File::Basename;
+use Fcntl 'SEEK_CUR';
+use Test::More;
+use lib 't';
+use pgtde;
+
+PGTDE::setup_files_dir(basename($0));
+
+unlink('/tmp/pg_tde_test_key_validation.per');
+
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
+$node->append_conf('postgresql.conf', "shared_preload_libraries = 'pg_tde'");
+$node->start;
+
+PGTDE::psql($node, 'postgres', 'CREATE EXTENSION pg_tde;');
+PGTDE::psql($node, 'postgres',
+	"SELECT pg_tde_add_database_key_provider_file('test-file-provider', '/tmp/pg_tde_test_key_validation.per');"
+);
+PGTDE::psql($node, 'postgres',
+	"SELECT pg_tde_create_key_using_database_key_provider('key1', 'test-file-provider');"
+);
+PGTDE::psql($node, 'postgres',
+	"SELECT pg_tde_create_key_using_database_key_provider('key2', 'test-file-provider');"
+);
+
+
+corrupt_key_file('/tmp/pg_tde_test_key_validation.per');
+
+
+PGTDE::psql($node, 'postgres',
+	"SELECT pg_tde_set_key_using_database_key_provider('key1', 'test-file-provider');"
+);
+PGTDE::psql($node, 'postgres',
+	"SELECT pg_tde_set_key_using_database_key_provider('key2', 'test-file-provider');"
+);
+
+sub corrupt_key_file
+{
+	my ($keyfile) = @_;
+
+	my $fh;
+	open($fh, '+<', $keyfile)
+	  or BAIL_OUT("open failed: $!");
+	binmode $fh;
+
+	# Corrupt the first page of the key file  by zeroing key data length.
+	# Offset is TDE_KEY_NAME_LEN + MAX_KEY_DATA_SIZE. See keyring_api.h for details.
+	sysseek($fh, 256 + 32, 0)
+	  or BAIL_OUT("sysseek failed: $!");
+	syswrite($fh, pack("L*", 0x00000000)) or BAIL_OUT("syswrite failed: $!");
+
+	# Corrupt the second page of the key file by setting incorrect key length.
+	# Offset is TDE_KEY_NAME_LEN + MAX_KEY_DATA_SIZE. See keyring_api.h for details.
+	sysseek($fh, 256 + 32, SEEK_CUR)
+	  or BAIL_OUT("sysseek failed: $!");
+	syswrite($fh, pack("L*", 0xFFFFFFFF)) or BAIL_OUT("syswrite failed: $!");
+
+
+	close($fh)
+	  or BAIL_OUT("close failed: $!");
+}
+
+$node->stop;
+
+# Compare the expected and out file
+my $compare = PGTDE->compare_results();
+
+is($compare, 0,
+	"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files."
+);
+
+done_testing();


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PG-1661

- Check that key that we retrieved from key provider is valid (has name, data length within range)
- Free memory once key `KeyInfo` object no longer needed
- Unify and improve error messages
- Fix potential null pointer de-reference in vault key provider