### PR TITLE
[PG-1695] Remove extra word in error message for existing key

### DIFF
--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -351,9 +351,9 @@ SELECT pg_tde_create_key_using_database_key_provider('existing-key','file-provid
 (1 row)
 
 SELECT pg_tde_create_key_using_database_key_provider('existing-key','file-provider');
-ERROR:  cannot to create key "existing-key" because it already exists
+ERROR:  cannot create key "existing-key" because it already exists
 SELECT pg_tde_create_key_using_global_key_provider('existing-key','file-keyring');
-ERROR:  cannot to create key "existing-key" because it already exists
+ERROR:  cannot create key "existing-key" because it already exists
 -- Setting principal key fails if key does not exist
 SELECT pg_tde_set_default_key_using_global_key_provider('not-existing', 'file-keyring');
 ERROR:  key "not-existing" does not exist

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -519,7 +519,7 @@ pg_tde_create_principal_key_internal(Oid providerOid,
 	if (key_info != NULL)
 		ereport(ERROR,
 				errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				errmsg("cannot to create key \"%s\" because it already exists", key_name));
+				errmsg("cannot create key \"%s\" because it already exists", key_name));
 
 	key_info = KeyringGenerateNewKeyAndStore(provider, key_name, PRINCIPAL_KEY_LEN);
 


### PR DESCRIPTION
This "to" had no business being in this message.

This should be fixed before release, so this PR is for the release branch.