### PR TITLE
Fix Slack notification condition in CI job and improve message

### DIFF
--- a/.github/workflows/matirx.yml
+++ b/.github/workflows/matirx.yml
@@ -56,7 +56,7 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "Workflow *${{ github.workflow }}* failed on branch *${{ github.head_ref }}*\n
+                  text: "Workflow *${{ github.workflow }}* failed on branch *${{ github.ref_name }}*\n
                    Commit: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>\n
                    \n
                    <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"

--- a/.github/workflows/matirx.yml
+++ b/.github/workflows/matirx.yml
@@ -41,7 +41,7 @@ jobs:
     secrets: inherit
 
   slack-notification:
-    if: ${{ failure() }} && github.event_name == 'push'
+    if: failure() && github.event_name == 'push'
     needs: [ main, arm ]
     name: Slack Notification
     runs-on: ubuntu-24.04


### PR DESCRIPTION
There was a mistake in job condition expression that caused slack job execution for PRs, while we want this notifications only for our main branch. Also use better variable to extract branch name for notification text.