### PR TITLE
Remove pluralization of enum name

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -238,7 +238,7 @@ set_principal_key_with_keyring(const char *key_name,
 	new_keyring = GetKeyProviderByName(provider_name, providerOid);
 
 	{
-		KeyringReturnCodes kr_ret;
+		KeyringReturnCode kr_ret;
 
 		keyInfo = KeyringGetKey(new_keyring, key_name, &kr_ret);
 
@@ -303,7 +303,7 @@ xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec)
 	TDEPrincipalKey *new_principal_key;
 	GenericKeyring *new_keyring;
 	KeyInfo    *keyInfo;
-	KeyringReturnCodes kr_ret;
+	KeyringReturnCode kr_ret;
 
 	LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
 
@@ -479,7 +479,7 @@ pg_tde_create_principal_key_internal(Oid providerOid,
 
 	GenericKeyring *provider;
 	KeyInfo    *key_info;
-	KeyringReturnCodes return_code;
+	KeyringReturnCode return_code;
 
 	if (providerOid == GLOBAL_DATA_TDE_OID && !superuser())
 		ereport(ERROR,
@@ -922,7 +922,7 @@ get_principal_key_from_keyring(Oid dbOid)
 	TDESignedPrincipalKeyInfo *principalKeyInfo;
 	GenericKeyring *keyring;
 	KeyInfo    *keyInfo;
-	KeyringReturnCodes keyring_ret;
+	KeyringReturnCode keyring_ret;
 	TDEPrincipalKey *principalKey;
 
 	Assert(LWLockHeldByMeInMode(tde_lwlock_enc_keys(), LW_EXCLUSIVE));
@@ -1180,7 +1180,7 @@ pg_tde_verify_provider_keys_in_use(GenericKeyring *modified_provider)
 		existing_principal_key->data.keyringId == modified_provider->keyring_id)
 	{
 		char	   *key_name = existing_principal_key->data.name;
-		KeyringReturnCodes return_code;
+		KeyringReturnCode return_code;
 		KeyInfo    *proposed_key;
 
 		proposed_key = KeyringGetKey(modified_provider, key_name, &return_code);
@@ -1215,7 +1215,7 @@ pg_tde_verify_provider_keys_in_use(GenericKeyring *modified_provider)
 			existing_principal_key->data.keyringId == modified_provider->keyring_id)
 		{
 			char	   *key_name = existing_principal_key->data.name;
-			KeyringReturnCodes return_code;
+			KeyringReturnCode return_code;
 			KeyInfo    *proposed_key;
 
 			proposed_key = KeyringGetKey(modified_provider, key_name, &return_code);

--- a/contrib/pg_tde/src/include/keyring/keyring_api.h
+++ b/contrib/pg_tde/src/include/keyring/keyring_api.h
@@ -29,7 +29,7 @@ typedef struct KeyInfo
 	KeyData		data;
 } KeyInfo;
 
-typedef enum KeyringReturnCodes
+typedef enum KeyringReturnCode
 {
 	KEYRING_CODE_SUCCESS = 0,
 	KEYRING_CODE_INVALID_PROVIDER = 1,
@@ -37,7 +37,7 @@ typedef enum KeyringReturnCodes
 	KEYRING_CODE_INVALID_RESPONSE = 5,
 	KEYRING_CODE_INVALID_KEY_SIZE = 6,
 	KEYRING_CODE_DATA_CORRUPTED = 7,
-} KeyringReturnCodes;
+} KeyringReturnCode;
 
 /* Base type for all keyring */
 typedef struct GenericKeyring
@@ -51,7 +51,7 @@ typedef struct GenericKeyring
 
 typedef struct TDEKeyringRoutine
 {
-	KeyInfo    *(*keyring_get_key) (GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *returnCode);
+	KeyInfo    *(*keyring_get_key) (GenericKeyring *keyring, const char *key_name, KeyringReturnCode *returnCode);
 	void		(*keyring_store_key) (GenericKeyring *keyring, KeyInfo *key);
 	void		(*keyring_validate) (GenericKeyring *keyring);
 } TDEKeyringRoutine;
@@ -84,7 +84,7 @@ typedef struct KmipKeyring
 
 extern void RegisterKeyProviderType(const TDEKeyringRoutine *routine, ProviderType type);
 
-extern KeyInfo *KeyringGetKey(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *returnCode);
+extern KeyInfo *KeyringGetKey(GenericKeyring *keyring, const char *key_name, KeyringReturnCode *returnCode);
 extern KeyInfo *KeyringGenerateNewKeyAndStore(GenericKeyring *keyring, const char *key_name, unsigned key_len);
 extern void KeyringValidate(GenericKeyring *keyring);
 

--- a/contrib/pg_tde/src/keyring/keyring_api.c
+++ b/contrib/pg_tde/src/keyring/keyring_api.c
@@ -98,7 +98,7 @@ RegisterKeyProviderType(const TDEKeyringRoutine *routine, ProviderType type)
 }
 
 KeyInfo *
-KeyringGetKey(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *returnCode)
+KeyringGetKey(GenericKeyring *keyring, const char *key_name, KeyringReturnCode *returnCode)
 {
 	RegisteredKeyProviderType *kp = find_key_provider_type(keyring->type);
 

--- a/contrib/pg_tde/src/keyring/keyring_file.c
+++ b/contrib/pg_tde/src/keyring/keyring_file.c
@@ -16,7 +16,7 @@
 #include "pg_tde_fe.h"
 #endif
 
-static KeyInfo *get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *return_code);
+static KeyInfo *get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode *return_code);
 static void set_key_by_name(GenericKeyring *keyring, KeyInfo *key);
 static void validate(GenericKeyring *keyring);
 
@@ -33,7 +33,7 @@ InstallFileKeyring(void)
 }
 
 static KeyInfo *
-get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *return_code)
+get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode *return_code)
 {
 	KeyInfo    *key = NULL;
 	int			fd = -1;
@@ -95,7 +95,7 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 	int			fd;
 	FileKeyring *file_keyring = (FileKeyring *) keyring;
 	KeyInfo    *existing_key;
-	KeyringReturnCodes return_code = KEYRING_CODE_SUCCESS;
+	KeyringReturnCode return_code = KEYRING_CODE_SUCCESS;
 
 	Assert(key != NULL);
 	/* See if the key with same name already exists */

--- a/contrib/pg_tde/src/keyring/keyring_kmip.c
+++ b/contrib/pg_tde/src/keyring/keyring_kmip.c
@@ -18,7 +18,7 @@
 #define MAX_LOCATE_LEN 128
 
 static void set_key_by_name(GenericKeyring *keyring, KeyInfo *key);
-static KeyInfo *get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *return_code);
+static KeyInfo *get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode *return_code);
 static void validate(GenericKeyring *keyring);
 
 const TDEKeyringRoutine keyringKmipRoutine = {
@@ -110,7 +110,7 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 }
 
 static KeyInfo *
-get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *return_code)
+get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode *return_code)
 {
 	KeyInfo    *key = NULL;
 	KmipKeyring *kmip_keyring = (KmipKeyring *) keyring;

--- a/contrib/pg_tde/src/keyring/keyring_vault.c
+++ b/contrib/pg_tde/src/keyring/keyring_vault.c
@@ -59,7 +59,7 @@ static char *get_keyring_vault_url(VaultV2Keyring *keyring, const char *key_name
 static bool curl_perform(VaultV2Keyring *keyring, const char *url, CurlString *outStr, long *httpCode, const char *postData);
 
 static void set_key_by_name(GenericKeyring *keyring, KeyInfo *key);
-static KeyInfo *get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *return_code);
+static KeyInfo *get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode *return_code);
 static void validate(GenericKeyring *keyring);
 
 const TDEKeyringRoutine keyringVaultV2Routine = {
@@ -201,7 +201,7 @@ set_key_by_name(GenericKeyring *keyring, KeyInfo *key)
 }
 
 static KeyInfo *
-get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCodes *return_code)
+get_key_by_name(GenericKeyring *keyring, const char *key_name, KeyringReturnCode *return_code)
 {
 	VaultV2Keyring *vault_keyring = (VaultV2Keyring *) keyring;
 	KeyInfo    *key = NULL;


### PR DESCRIPTION
Having this enum named as a plural made little sense as any value of this type is just a single code and not multiple.