### PR TITLE
PG-1700 Fix error hint when missing principal key

### DIFF
--- a/contrib/pg_tde/expected/vault_v2_test.out
+++ b/contrib/pg_tde/expected/vault_v2_test.out
@@ -16,7 +16,7 @@ CREATE TABLE test_enc(
 	  PRIMARY KEY (id)
 	) USING tde_heap;
 ERROR:  principal key not configured
-HINT:  create one using pg_tde_set_key before using encrypted tables
+HINT:  Use pg_tde_set_key_using_database_key_provider() or pg_tde_set_key_using_global_key_provider() to configure one.
 SELECT pg_tde_add_database_key_provider_vault_v2('vault-v2', 'https://127.0.0.1:8200', 'secret', :'root_token_file', :'cacert_file');
  pg_tde_add_database_key_provider_vault_v2 
 -------------------------------------------

--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -84,7 +84,7 @@ pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *rel_key_data)
 	{
 		ereport(ERROR,
 				errmsg("principal key not configured"),
-				errhint("create one using pg_tde_set_key before using encrypted tables"));
+				errhint("Use pg_tde_set_key_using_database_key_provider() or pg_tde_set_key_using_global_key_provider() to configure one."));
 	}
 
 	pg_tde_write_key_map_entry(&rel, rel_key_data, principal_key);
@@ -967,8 +967,7 @@ pg_tde_get_smgr_key(RelFileLocator rel)
 	if (principal_key == NULL)
 		ereport(ERROR,
 				errmsg("principal key not configured"),
-				errhint("create one using pg_tde_set_key before using encrypted tables"));
-
+				errhint("Use pg_tde_set_key_using_database_key_provider() or pg_tde_set_key_using_global_key_provider() to configure one."));
 	rel_key = tde_decrypt_rel_key(principal_key, &map_entry);
 
 	LWLockRelease(lock_pk);

--- a/contrib/pg_tde/src/pg_tde_event_capture.c
+++ b/contrib/pg_tde/src/pg_tde_event_capture.c
@@ -89,7 +89,7 @@ checkPrincipalKeyConfigured(void)
 	if (!pg_tde_principal_key_configured(MyDatabaseId))
 		ereport(ERROR,
 				errmsg("principal key not configured"),
-				errhint("create one using pg_tde_set_key before using encrypted tables"));
+				errhint("Use pg_tde_set_key_using_database_key_provider() or pg_tde_set_key_using_global_key_provider() to configure one."));
 }
 
 static void

--- a/contrib/pg_tde/t/expected/basic.out
+++ b/contrib/pg_tde/t/expected/basic.out
@@ -25,7 +25,7 @@ SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_tde';
 
 CREATE TABLE test_enc (id SERIAL, k INTEGER, PRIMARY KEY (id)) USING tde_heap;
 psql:<stdin>:1: ERROR:  principal key not configured
-HINT:  create one using pg_tde_set_key before using encrypted tables
+HINT:  Use pg_tde_set_key_using_database_key_provider() or pg_tde_set_key_using_global_key_provider() to configure one.
 SELECT pg_tde_add_database_key_provider_file('file-vault', '/tmp/pg_tde_test_001_basic.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------


### PR DESCRIPTION
The function this message referenced does not exist, and even if it did it wouldn't create keys.

Also error hint messages are supposed to be full sentences with capital letter and period.

This PR is for the release branch.

https://perconadev.atlassian.net/browse/PG-1700