### PR TITLE
Run important workflows on release branches

### DIFF
--- a/.github/workflows/matirx.yml
+++ b/.github/workflows/matirx.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - TDE_REL_17_STABLE
+      - release-[0-9]+.[0-9]+*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stormweaver.yml
+++ b/.github/workflows/stormweaver.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - TDE_REL_17_STABLE
+      - release-[0-9]+.[0-9]+*
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Add release branches to push CI trigger in stormweaver and build/test workflows. Not sure if we want to run other.