### PR TITLE
Skip CI run for documentation changes

### DIFF
--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - TDE_REL_17_STABLE
+    paths-ignore:
+      - contrib/pg_tde/documentation/**
 
 env:
   CC: clang

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,13 @@
 name: Code coverage
 on:
   pull_request:
+    paths-ignore:
+      - contrib/pg_tde/documentation/**
   push:
     branches:
       - TDE_REL_17_STABLE
+    paths-ignore:
+      - contrib/pg_tde/documentation/**
 
 env:
   PGCTLTIMEOUT: 120 # Avoid failures on slow recovery

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -1,10 +1,14 @@
 name: Build and Test
 on:
   pull_request:
+    paths-ignore:
+      - contrib/pg_tde/documentation/**
   push:
     branches:
       - TDE_REL_17_STABLE
       - release-[0-9]+.[0-9]+*
+    paths-ignore:
+      - contrib/pg_tde/documentation/**
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pgindent.yml
+++ b/.github/workflows/pgindent.yml
@@ -1,6 +1,8 @@
 name: Format
 on:
   pull_request:
+    paths-ignore:
+      - contrib/pg_tde/documentation/**
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,9 +1,13 @@
 name: Sanitizers
 on:
   pull_request:
+    paths-ignore:
+      - contrib/pg_tde/documentation/**
   push:
     branches:
       - TDE_REL_17_STABLE
+    paths-ignore:
+      - contrib/pg_tde/documentation/**
 
 env:
   CC: clang

--- a/.github/workflows/stormweaver.yml
+++ b/.github/workflows/stormweaver.yml
@@ -1,10 +1,14 @@
 name: Stormweaver
 on:
   pull_request:
+    paths-ignore:
+      - contrib/pg_tde/documentation/**
   push:
     branches:
       - TDE_REL_17_STABLE
       - release-[0-9]+.[0-9]+*
+    paths-ignore:
+      - contrib/pg_tde/documentation/**
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
There is no need to run all our CI workflows if only documentation were changed.