### PR TITLE
Remove an invalid optimization when reading WAL

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
@@ -342,11 +342,6 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 #endif
 				pg_tde_stream_crypt(iv_prefix, dec_off, dec_buf, dec_sz, dec_buf,
 									&curr_key->key, &curr_key->crypt_ctx);
-
-				if (dec_off + dec_sz == offset)
-				{
-					break;
-				}
 			}
 		}
 	}


### PR DESCRIPTION
It is a bit unclear what this optimization was supposed to do, presumably it was to break from the loop once the whole buffer was decrypted, but the logic was very confused since if we want to do a similar optimization it should be something like `if (dec_off + read_sz == offset + readsz)`.