### PR TITLE
Use an appropriate errorcode when failing to unset principal key or removing a key provider

### DIFF
--- a/contrib/pg_tde/expected/default_principal_key.out
+++ b/contrib/pg_tde/expected/default_principal_key.out
@@ -45,7 +45,7 @@ SELECT provider_id, provider_name, key_name
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-provider');
-ERROR:  Can't delete a provider which is currently in use
+ERROR:  cannot delete provider which is currently in use
 SELECT id, name FROM pg_tde_list_all_global_key_providers();
  id |     name      
 ----+---------------

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -91,7 +91,7 @@ SELECT id, name FROM pg_tde_list_all_global_key_providers();
 
 -- fails
 SELECT pg_tde_delete_database_key_provider('file-provider');
-ERROR:  Can't delete a provider which is currently in use
+ERROR:  cannot delete provider which is currently in use
 SELECT id, name FROM pg_tde_list_all_database_key_providers();
  id |      name      
 ----+----------------
@@ -127,7 +127,7 @@ SELECT pg_tde_set_key_using_global_key_provider('test-db-key', 'file-keyring');
 
 -- fails
 SELECT pg_tde_delete_global_key_provider('file-keyring');
-ERROR:  Can't delete a provider which is currently in use
+ERROR:  cannot delete provider which is currently in use
 SELECT id, name FROM pg_tde_list_all_global_key_providers();
  id |     name      
 ----+---------------

--- a/contrib/pg_tde/src/catalog/tde_keyring.c
+++ b/contrib/pg_tde/src/catalog/tde_keyring.c
@@ -309,7 +309,8 @@ pg_tde_delete_key_provider_internal(PG_FUNCTION_ARGS, Oid db_oid)
 	if (provider_used)
 	{
 		ereport(ERROR,
-				errmsg("Can't delete a provider which is currently in use"));
+				errcode(ERRCODE_OBJECT_IN_USE),
+				errmsg("cannot delete provider which is currently in use"));
 	}
 
 	delete_key_provider_info(provider_name, db_oid);

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -706,6 +706,7 @@ pg_tde_delete_key(PG_FUNCTION_ARGS)
 		if (default_principal_key == NULL)
 		{
 			ereport(ERROR,
+					errcode(ERRCODE_OBJECT_IN_USE),
 					errmsg("cannot delete principal key"),
 					errdetail("There are encrypted tables in the database."),
 					errhint("Set default principal key as fallback option or decrypt all tables before deleting principal key."));
@@ -718,6 +719,7 @@ pg_tde_delete_key(PG_FUNCTION_ARGS)
 		if (pg_tde_is_same_principal_key(principal_key, default_principal_key))
 		{
 			ereport(ERROR,
+					errcode(ERRCODE_OBJECT_IN_USE),
 					errmsg("cannot delete principal key"),
 					errdetail("There are encrypted tables in the database."));
 		}
@@ -788,6 +790,7 @@ pg_tde_delete_default_key(PG_FUNCTION_ARGS)
 			if (pg_tde_count_encryption_keys(dbOid) != 0)
 			{
 				ereport(ERROR,
+						errcode(ERRCODE_OBJECT_IN_USE),
 						errmsg("cannot delete default principal key"),
 						errhint("There are encrypted tables in the database with id: %u.", dbOid));
 			}
@@ -806,6 +809,7 @@ pg_tde_delete_default_key(PG_FUNCTION_ARGS)
 	{
 		if (pg_tde_count_encryption_keys(GLOBAL_DATA_TDE_OID) != 0)
 			ereport(ERROR,
+					errcode(ERRCODE_OBJECT_IN_USE),
 					errmsg("cannot delete default principal key"),
 					errhint("There are WAL encryption keys."));
 		dbs = lappend_oid(dbs, GLOBAL_DATA_TDE_OID);


### PR DESCRIPTION
Also fix an error message that didn't follow the style guide https://www.postgresql.org/docs/17/error-style-guide.html