### PR TITLE
Increase the test timeout from 180 to 300 seconds

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,9 @@ on:
       - contrib/pg_tde/documentation/**
 
 env:
-  PGCTLTIMEOUT: 120 # Avoid failures on slow recovery
+  # Avoid failures on slow recovery
+  PGCTLTIMEOUT: 120
+  PG_TEST_TIMEOUT_DEFAULT: 300
 
 jobs:
   collect:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -17,7 +17,9 @@ env:
   LSAN_OPTIONS: log_path=${{ github.workspace }}/sanitize.log print_suppressions=0 suppressions=${{ github.workspace }}/ci_scripts/suppressions/lsan.supp
   ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer-14
   EXTRA_REGRESS_OPTS: "--temp-config=${{ github.workspace }}/test_postgresql.conf"
+  # Avoid failures on slow recovery
   PGCTLTIMEOUT: 120
+  PG_TEST_TIMEOUT_DEFAULT: 300
 
 jobs:
   run:


### PR DESCRIPTION
We get what looks a lot like timeouts when we try to run certain pg_tde TAP tests with code coverage enabled.