### PR TITLE
Make WAL keys TLI aware

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -44,6 +44,7 @@
 #define TDE_FILE_HEADER_SIZE	sizeof(TDEFileHeader)
 
 #define MaxXLogRecPtr (~(XLogRecPtr)0)
+#define MaxTimeLineID (~(TimeLineID)0)
 
 typedef struct TDEFileHeader
 {
@@ -65,7 +66,7 @@ static void pg_tde_file_header_read(const char *tde_filename, int fd, TDEFileHea
 static int	pg_tde_file_header_write(const char *tde_filename, int fd, const TDESignedPrincipalKeyInfo *signed_key_info, off_t *bytes_written);
 static bool pg_tde_read_one_map_entry(int fd, TDEMapEntry *map_entry, off_t *offset);
 static void pg_tde_read_one_map_entry2(int keydata_fd, int32 key_index, TDEMapEntry *map_entry, Oid databaseId);
-static WALKeyCacheRec *pg_tde_add_wal_key_to_cache(InternalKey *cached_key, XLogRecPtr start_lsn);
+static WALKeyCacheRec *pg_tde_add_wal_key_to_cache(InternalKey *cached_key);
 
 #ifndef FRONTEND
 static void pg_tde_sign_principal_key_info(TDESignedPrincipalKeyInfo *signed_key_info, const TDEPrincipalKey *principal_key);
@@ -369,22 +370,23 @@ pg_tde_delete_principal_key(Oid dbOid)
  * needs keyfile_path
  */
 void
-pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path)
+pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, TimeLineID tli, const char *keyfile_path)
 {
 	LWLock	   *lock_pk = tde_lwlock_enc_keys();
 	int			fd;
 	off_t		read_pos,
 				write_pos,
 				last_key_idx;
+	WALLocation loc = {.tli = tli,.lsn = lsn};
 
 	LWLockAcquire(lock_pk, LW_EXCLUSIVE);
 
 	fd = pg_tde_open_file_write(keyfile_path, NULL, false, &read_pos);
 
 	last_key_idx = ((lseek(fd, 0, SEEK_END) - TDE_FILE_HEADER_SIZE) / MAP_ENTRY_SIZE) - 1;
-	write_pos = TDE_FILE_HEADER_SIZE + (last_key_idx * MAP_ENTRY_SIZE) + offsetof(TDEMapEntry, enc_key) + offsetof(InternalKey, start_lsn);
+	write_pos = TDE_FILE_HEADER_SIZE + (last_key_idx * MAP_ENTRY_SIZE) + offsetof(TDEMapEntry, enc_key) + offsetof(InternalKey, wal_start);
 
-	if (pg_pwrite(fd, &lsn, sizeof(XLogRecPtr), write_pos) != sizeof(XLogRecPtr))
+	if (pg_pwrite(fd, &loc, sizeof(WALLocation), write_pos) != sizeof(WALLocation))
 	{
 		ereport(ERROR,
 				errcode_for_file_access(),
@@ -408,7 +410,7 @@ pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path)
 					errmsg("could not read previous WAL key: %m"));
 		}
 
-		if (prev_map_entry.enc_key.start_lsn >= lsn)
+		if (wal_location_cmp(prev_map_entry.enc_key.wal_start, loc) >= 0)
 		{
 			prev_map_entry.enc_key.type = TDE_KEY_TYPE_WAL_INVALID;
 
@@ -1035,7 +1037,7 @@ pg_tde_read_last_wal_key(void)
 
 /* Fetches WAL keys from disk and adds them to the WAL cache */
 WALKeyCacheRec *
-pg_tde_fetch_wal_keys(XLogRecPtr start_lsn)
+pg_tde_fetch_wal_keys(WALLocation start)
 {
 	RelFileLocator rlocator = GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID);
 	char		db_map_path[MAXPGPATH];
@@ -1070,10 +1072,10 @@ pg_tde_fetch_wal_keys(XLogRecPtr start_lsn)
 	{
 		WALKeyCacheRec *wal_rec;
 		InternalKey stub_key = {
-			.start_lsn = InvalidXLogRecPtr,
+			.wal_start = {.tli = 0,.lsn = InvalidXLogRecPtr},
 		};
 
-		wal_rec = pg_tde_add_wal_key_to_cache(&stub_key, InvalidXLogRecPtr);
+		wal_rec = pg_tde_add_wal_key_to_cache(&stub_key);
 
 #ifdef FRONTEND
 		/* The backend frees it after copying to the cache. */
@@ -1093,15 +1095,15 @@ pg_tde_fetch_wal_keys(XLogRecPtr start_lsn)
 		/*
 		 * Skip new (just created but not updated by write) and invalid keys
 		 */
-		if (map_entry.enc_key.start_lsn != InvalidXLogRecPtr &&
+		if (wal_location_valid(map_entry.enc_key.wal_start) &&
 			(map_entry.enc_key.type == TDE_KEY_TYPE_WAL_UNENCRYPTED ||
 			 map_entry.enc_key.type == TDE_KEY_TYPE_WAL_ENCRYPTED) &&
-			map_entry.enc_key.start_lsn >= start_lsn)
+			wal_location_cmp(map_entry.enc_key.wal_start, start) >= 0)
 		{
 			InternalKey *rel_key_data = tde_decrypt_rel_key(principal_key, &map_entry);
 			WALKeyCacheRec *wal_rec;
 
-			wal_rec = pg_tde_add_wal_key_to_cache(rel_key_data, map_entry.enc_key.start_lsn);
+			wal_rec = pg_tde_add_wal_key_to_cache(rel_key_data);
 
 			pfree(rel_key_data);
 
@@ -1119,7 +1121,7 @@ pg_tde_fetch_wal_keys(XLogRecPtr start_lsn)
 }
 
 static WALKeyCacheRec *
-pg_tde_add_wal_key_to_cache(InternalKey *key, XLogRecPtr start_lsn)
+pg_tde_add_wal_key_to_cache(InternalKey *key)
 {
 	WALKeyCacheRec *wal_rec;
 #ifndef FRONTEND
@@ -1132,8 +1134,9 @@ pg_tde_add_wal_key_to_cache(InternalKey *key, XLogRecPtr start_lsn)
 	MemoryContextSwitchTo(oldCtx);
 #endif
 
-	wal_rec->start_lsn = start_lsn;
-	wal_rec->end_lsn = MaxXLogRecPtr;
+	wal_rec->start = key->wal_start;
+	wal_rec->end.tli = MaxTimeLineID;
+	wal_rec->end.lsn = MaxXLogRecPtr;
 	wal_rec->key = *key;
 	wal_rec->crypt_ctx = NULL;
 	if (!tde_wal_key_last_rec)
@@ -1144,7 +1147,7 @@ pg_tde_add_wal_key_to_cache(InternalKey *key, XLogRecPtr start_lsn)
 	else
 	{
 		tde_wal_key_last_rec->next = wal_rec;
-		tde_wal_key_last_rec->end_lsn = wal_rec->start_lsn;
+		tde_wal_key_last_rec->end = wal_rec->start;
 		tde_wal_key_last_rec = wal_rec;
 	}
 

--- a/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
@@ -88,7 +88,14 @@ TDEXLogGetEncKeyLsn()
 static void
 TDEXLogSetEncKeyLocation(WALLocation loc)
 {
+	/*
+	 * Write TLI first and then LSN. The barrier ensures writes won't be
+	 * reordered. When reading, the opposite must be done (with a matching
+	 * barrier in between), so we always see a valid TLI after observing a
+	 * valid LSN.
+	 */
 	pg_atomic_write_u32(&EncryptionState->enc_key_tli, loc.tli);
+	pg_write_barrier();
 	pg_atomic_write_u64(&EncryptionState->enc_key_lsn, loc.lsn);
 }
 
@@ -304,7 +311,7 @@ tdeheap_xlog_seg_write(int fd, const void *buf, size_t count, off_t offset,
 	 *
 	 * This func called with WALWriteLock held, so no need in any extra sync.
 	 */
-	if (EncryptionKey.type !=MAP_ENTRY_EMPTY && TDEXLogGetEncKeyLsn() == 0)
+	if (EncryptionKey.type != MAP_ENTRY_EMPTY && TDEXLogGetEncKeyLsn() == 0)
 	{
 		XLogRecPtr	lsn;
 
@@ -353,7 +360,12 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 		keys = pg_tde_fetch_wal_keys(start);
 	}
 
+	/*
+	 * The barrier ensures that we always read a vaild TLI after the valid
+	 * LSN. See the comment in TDEXLogSetEncKeyLocation()
+	 */
 	write_key_lsn = TDEXLogGetEncKeyLsn();
+	pg_read_barrier();
 
 	if (!XLogRecPtrIsInvalid(write_key_lsn))
 	{

--- a/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
@@ -45,7 +45,7 @@ static void *EncryptionCryptCtx = NULL;
 static InternalKey EncryptionKey =
 {
 	.type = MAP_ENTRY_EMPTY,
-	.start_lsn = InvalidXLogRecPtr,
+	.wal_start = {.tli = 0,.lsn = InvalidXLogRecPtr},
 };
 
 /*
@@ -66,7 +66,13 @@ static InternalKey EncryptionKey =
 typedef struct EncryptionStateData
 {
 	char		db_map_path[MAXPGPATH];
-	pg_atomic_uint64 enc_key_lsn;	/* to sync with readers */
+
+	/*
+	 * To sync with readers. We sync on LSN only and TLI here just to
+	 * communicate its value to readers.
+	 */
+	pg_atomic_uint32 enc_key_tli;
+	pg_atomic_uint64 enc_key_lsn;
 } EncryptionStateData;
 
 static EncryptionStateData *EncryptionState = NULL;
@@ -80,9 +86,16 @@ TDEXLogGetEncKeyLsn()
 }
 
 static void
-TDEXLogSetEncKeyLsn(XLogRecPtr start_lsn)
+TDEXLogSetEncKeyLocation(WALLocation loc)
 {
-	pg_atomic_write_u64(&EncryptionState->enc_key_lsn, start_lsn);
+	pg_atomic_write_u32(&EncryptionState->enc_key_tli, loc.tli);
+	pg_atomic_write_u64(&EncryptionState->enc_key_lsn, loc.lsn);
+}
+
+static TimeLineID
+TDEXLogGetEncKeyTli()
+{
+	return (TimeLineID) pg_atomic_read_u32(&EncryptionState->enc_key_tli);
 }
 
 static Size TDEXLogEncryptBuffSize(void);
@@ -159,6 +172,7 @@ TDEXLogShmemInit(void)
 	}
 
 	pg_atomic_init_u64(&EncryptionState->enc_key_lsn, 0);
+	pg_atomic_init_u32(&EncryptionState->enc_key_tli, 0);
 
 	elog(DEBUG1, "pg_tde: initialized encryption buffer %lu bytes", TDEXLogEncryptStateSize());
 }
@@ -168,6 +182,7 @@ TDEXLogShmemInit(void)
 typedef struct EncryptionStateData
 {
 	char		db_map_path[MAXPGPATH];
+	XLogRecPtr	enc_key_tli;	/* to sync with reader */
 	XLogRecPtr	enc_key_lsn;	/* to sync with reader */
 } EncryptionStateData;
 
@@ -184,9 +199,16 @@ TDEXLogGetEncKeyLsn()
 }
 
 static void
-TDEXLogSetEncKeyLsn(XLogRecPtr start_lsn)
+TDEXLogSetEncKeyLocation(WALLocation loc)
 {
-	EncryptionState->enc_key_lsn = EncryptionKey.start_lsn;
+	EncryptionState->enc_key_tli = loc.tli;
+	EncryptionState->enc_key_lsn = loc.lsn;
+}
+
+static TimeLineID
+TDEXLogGetEncKeyTli()
+{
+	return (TimeLineID) EncryptionState->enc_key_tli;
 }
 
 #endif							/* FRONTEND */
@@ -197,6 +219,7 @@ TDEXLogSmgrInit()
 	SetXLogSmgr(&tde_xlog_smgr);
 }
 
+/* On backend it should be called only during the startup */
 void
 TDEXLogSmgrInitWrite(bool encrypt_xlog)
 {
@@ -220,7 +243,7 @@ TDEXLogSmgrInitWrite(bool encrypt_xlog)
 	else if (key)
 	{
 		EncryptionKey = *key;
-		TDEXLogSetEncKeyLsn(EncryptionKey.start_lsn);
+		TDEXLogSetEncKeyLocation(EncryptionKey.wal_start);
 	}
 
 	if (key)
@@ -237,7 +260,7 @@ TDEXLogSmgrInitWriteReuseKey()
 	if (key)
 	{
 		EncryptionKey = *key;
-		TDEXLogSetEncKeyLsn(EncryptionKey.start_lsn);
+		TDEXLogSetEncKeyLocation(EncryptionKey.wal_start);
 		pfree(key);
 	}
 
@@ -260,8 +283,8 @@ TDEXLogWriteEncryptedPages(int fd, const void *buf, size_t count, off_t offset,
 #endif
 
 #ifdef TDE_XLOG_DEBUG
-	elog(DEBUG1, "write encrypted WAL, size: %lu, offset: %ld [%lX], seg: %X/%X, key_start_lsn: %X/%X",
-		 count, offset, offset, LSN_FORMAT_ARGS(segno), LSN_FORMAT_ARGS(key->start_lsn));
+	elog(DEBUG1, "write encrypted WAL, size: %lu, offset: %ld [%lX], seg: %X/%X, key_start_lsn: %u_%X/%X",
+		 count, offset, offset, LSN_FORMAT_ARGS(segno), key->wal_start.tli, LSN_FORMAT_ARGS(key->wal_start.lsn));
 #endif
 
 	CalcXLogPageIVPrefix(tli, segno, key->base_iv, iv_prefix);
@@ -281,15 +304,16 @@ tdeheap_xlog_seg_write(int fd, const void *buf, size_t count, off_t offset,
 	 *
 	 * This func called with WALWriteLock held, so no need in any extra sync.
 	 */
-	if (EncryptionKey.type != MAP_ENTRY_EMPTY && TDEXLogGetEncKeyLsn() == 0)
+	if (EncryptionKey.type !=MAP_ENTRY_EMPTY && TDEXLogGetEncKeyLsn() == 0)
 	{
 		XLogRecPtr	lsn;
 
 		XLogSegNoOffsetToRecPtr(segno, offset, segSize, lsn);
 
-		pg_tde_wal_last_key_set_lsn(lsn, EncryptionState->db_map_path);
-		EncryptionKey.start_lsn = lsn;
-		TDEXLogSetEncKeyLsn(lsn);
+		pg_tde_wal_last_key_set_lsn(lsn, tli, EncryptionState->db_map_path);
+		EncryptionKey.wal_start.tli = tli;
+		EncryptionKey.wal_start.lsn = lsn;
+		TDEXLogSetEncKeyLocation(EncryptionKey.wal_start);
 	}
 
 	if (EncryptionKey.type == TDE_KEY_TYPE_WAL_ENCRYPTED)
@@ -308,12 +332,12 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 	ssize_t		readsz;
 	WALKeyCacheRec *keys = pg_tde_get_wal_cache_keys();
 	XLogRecPtr	write_key_lsn;
-	XLogRecPtr	data_start;
-	XLogRecPtr	data_end;
+	WALLocation data_start = {.tli = tli};
+	WALLocation data_end = {.tli = tli};
 
 #ifdef TDE_XLOG_DEBUG
-	elog(DEBUG1, "read from a WAL segment, size: %lu offset: %ld [%lX], seg: %X/%X",
-		 count, offset, offset, LSN_FORMAT_ARGS(segno));
+	elog(DEBUG1, "read from a WAL segment, size: %lu offset: %ld [%lX], seg: %u_%X/%X",
+		 count, offset, offset, tli, LSN_FORMAT_ARGS(segno));
 #endif
 
 	readsz = pg_pread(fd, buf, count, offset);
@@ -323,8 +347,10 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 
 	if (!keys)
 	{
+		WALLocation start = {.tli = 1,.lsn = 0};
+
 		/* cache is empty, try to read keys from disk */
-		keys = pg_tde_fetch_wal_keys(InvalidXLogRecPtr);
+		keys = pg_tde_fetch_wal_keys(start);
 	}
 
 	write_key_lsn = TDEXLogGetEncKeyLsn();
@@ -332,21 +358,22 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 	if (!XLogRecPtrIsInvalid(write_key_lsn))
 	{
 		WALKeyCacheRec *last_key = pg_tde_get_last_wal_key();
+		WALLocation write_loc = {.tli = TDEXLogGetEncKeyTli(),.lsn = write_key_lsn};
 
 		Assert(last_key);
 
 		/* write has generated a new key, need to fetch it */
-		if (last_key->start_lsn < write_key_lsn)
+		if (wal_location_cmp(last_key->start, write_loc) < 0)
 		{
-			pg_tde_fetch_wal_keys(write_key_lsn);
+			pg_tde_fetch_wal_keys(write_loc);
 
 			/* in case cache was empty before */
 			keys = pg_tde_get_wal_cache_keys();
 		}
 	}
 
-	XLogSegNoOffsetToRecPtr(segno, offset, segSize, data_start);
-	XLogSegNoOffsetToRecPtr(segno, offset + readsz, segSize, data_end);
+	XLogSegNoOffsetToRecPtr(segno, offset, segSize, data_start.lsn);
+	XLogSegNoOffsetToRecPtr(segno, offset + readsz, segSize, data_end.lsn);
 
 	/*
 	 * TODO: this is higly ineffective. We should get rid of linked list and
@@ -355,24 +382,25 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 	for (WALKeyCacheRec *curr_key = keys; curr_key != NULL; curr_key = curr_key->next)
 	{
 #ifdef TDE_XLOG_DEBUG
-		elog(DEBUG1, "WAL key %X/%X-%X/%X, encrypted: %s",
-			 LSN_FORMAT_ARGS(curr_key->start_lsn),
-			 LSN_FORMAT_ARGS(curr_key->end_lsn),
+		elog(DEBUG1, "WAL key %u_%X/%X - %u_%X/%X, encrypted: %s",
+			 curr_key->start.tli, LSN_FORMAT_ARGS(curr_key->start.lsn),
+			 curr_key->end.tli, LSN_FORMAT_ARGS(curr_key->end.lsn),
 			 curr_key->key.type == TDE_KEY_TYPE_WAL_ENCRYPTED ? "yes" : "no");
 #endif
 
-		if (curr_key->key.start_lsn != InvalidXLogRecPtr &&
+		if (wal_location_valid(curr_key->key.wal_start) &&
 			curr_key->key.type == TDE_KEY_TYPE_WAL_ENCRYPTED)
 		{
 			/*
 			 * Check if the key's range overlaps with the buffer's and decypt
 			 * the part that does.
 			 */
-			if (data_start < curr_key->end_lsn && data_end > curr_key->start_lsn)
+
+			if (wal_location_cmp(data_start, curr_key->end) < 0 && wal_location_cmp(data_end, curr_key->start) > 0)
 			{
 				char		iv_prefix[16];
-				off_t		dec_off = XLogSegmentOffset(Max(data_start, curr_key->start_lsn), segSize);
-				off_t		dec_end = XLogSegmentOffset(Min(data_end, curr_key->end_lsn), segSize);
+				off_t		dec_off = XLogSegmentOffset(Max(data_start.lsn, curr_key->start.lsn), segSize);
+				off_t		dec_end = XLogSegmentOffset(Min(data_end.lsn, curr_key->end.lsn), segSize);
 				size_t		dec_sz;
 				char	   *dec_buf = (char *) buf + (dec_off - offset);
 
@@ -389,8 +417,8 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset,
 				dec_sz = dec_end - dec_off;
 
 #ifdef TDE_XLOG_DEBUG
-				elog(DEBUG1, "decrypt WAL, dec_off: %lu [buff_off %lu], sz: %lu | key %X/%X",
-					 dec_off, dec_off - offset, dec_sz, LSN_FORMAT_ARGS(curr_key->key->start_lsn));
+				elog(DEBUG1, "decrypt WAL, dec_off: %lu [buff_off %lu], sz: %lu | key %u_%X/%X",
+					 dec_off, dec_off - offset, dec_sz, curr_key->key.wal_start.tli, LSN_FORMAT_ARGS(curr_key->key.wal_start.lsn));
 #endif
 				pg_tde_stream_crypt(iv_prefix, dec_off, dec_buf, dec_sz, dec_buf,
 									&curr_key->key, &curr_key->crypt_ctx);

--- a/contrib/pg_tde/src/encryption/enc_tde.c
+++ b/contrib/pg_tde/src/encryption/enc_tde.c
@@ -30,7 +30,8 @@ void
 pg_tde_generate_internal_key(InternalKey *int_key, TDEMapEntryType entry_type)
 {
 	int_key->type = entry_type;
-	int_key->start_lsn = InvalidXLogRecPtr;
+	int_key->wal_start.tli = 0;
+	int_key->wal_start.lsn = InvalidXLogRecPtr;
 
 	if (!RAND_bytes(int_key->key, INTERNAL_KEY_LEN))
 		ereport(ERROR,

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -18,13 +18,47 @@ typedef enum
 #define INTERNAL_KEY_LEN 16
 #define INTERNAL_KEY_IV_LEN 16
 
+typedef struct WALLocation
+{
+	XLogRecPtr	lsn;
+	TimeLineID	tli;
+} WALLocation;
+
+/*
+ * Compares given WAL locations and returns -1 if l1 < l2, 0 if l1 == l2,
+ * and 1 if l1 > l2
+ */
+static inline int
+wal_location_cmp(WALLocation l1, WALLocation l2)
+{
+	if (unlikely(l1.tli < l2.tli))
+		return -1;
+
+	if (unlikely(l1.tli > l2.tli))
+		return 1;
+
+	if (l1.lsn < l2.lsn)
+		return -1;
+
+	if (l1.lsn > l2.lsn)
+		return 1;
+
+	return 0;
+}
+
+static inline bool
+wal_location_valid(WALLocation loc)
+{
+	return loc.tli != 0 && loc.lsn != InvalidXLogRecPtr;
+}
+
 typedef struct InternalKey
 {
 	uint8		key[INTERNAL_KEY_LEN];
 	uint8		base_iv[INTERNAL_KEY_IV_LEN];
 	uint32		type;
 
-	XLogRecPtr	start_lsn;
+	WALLocation wal_start;
 } InternalKey;
 
 #define MAP_ENTRY_IV_SIZE 16
@@ -60,8 +94,8 @@ typedef struct XLogRelKey
  */
 typedef struct WALKeyCacheRec
 {
-	XLogRecPtr	start_lsn;
-	XLogRecPtr	end_lsn;
+	WALLocation start;
+	WALLocation end;
 
 	InternalKey key;
 	void	   *crypt_ctx;
@@ -71,9 +105,9 @@ typedef struct WALKeyCacheRec
 
 extern InternalKey *pg_tde_read_last_wal_key(void);
 extern WALKeyCacheRec *pg_tde_get_last_wal_key(void);
-extern WALKeyCacheRec *pg_tde_fetch_wal_keys(XLogRecPtr start_lsn);
+extern WALKeyCacheRec *pg_tde_fetch_wal_keys(WALLocation start);
 extern WALKeyCacheRec *pg_tde_get_wal_cache_keys(void);
-extern void pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, const char *keyfile_path);
+extern void pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn, TimeLineID tli, const char *keyfile_path);
 extern void pg_tde_create_wal_key(InternalKey *rel_key_data, const RelFileLocator *newrlocator, TDEMapEntryType entry_type);
 
 #define PG_TDE_MAP_FILENAME			"%d_keys"

--- a/contrib/pg_tde/src/include/pg_tde_fe.h
+++ b/contrib/pg_tde/src/include/pg_tde_fe.h
@@ -88,6 +88,8 @@ static int	tde_fe_error_level = 0;
 #define FreeFile(file) fclose(file)
 
 #define pg_fsync(fd) fsync(fd)
+
+#define pg_read_barrier() NULL
 #endif							/* FRONTEND */
 
 #endif							/* PG_TDE_EREPORT_H */

--- a/contrib/pg_tde/t/wal_key_tli.pl
+++ b/contrib/pg_tde/t/wal_key_tli.pl
@@ -1,0 +1,83 @@
+
+# Copyright (c) 2021-2024, PostgreSQL Global Development Group
+
+# A copy pg_rewind_databases with added restart of the standby, which forces two
+# WAL keys with the same LSN but different TLI on the primary after pg_rewind.
+
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+use FindBin;
+use lib $FindBin::RealBin;
+
+use RewindTest;
+
+sub run_test
+{
+	my $test_mode = shift;
+
+	RewindTest::setup_cluster($test_mode, ['-g']);
+	RewindTest::start_primary();
+
+	# Create a database in primary with a table.
+	primary_psql('CREATE DATABASE inprimary');
+	primary_psql('CREATE TABLE inprimary_tab (a int)', 'inprimary');
+
+	RewindTest::create_standby($test_mode);
+
+	# Generates a new WAL key with the start LSN 0/300000. After running
+	# pg_rewind, the primary will end up with that key and another one with the
+	# same LSN 0/300000, but different TLI.
+	$node_standby->restart;
+
+	# Create another database with another table, the creation is
+	# replicated to the standby.
+	primary_psql('CREATE DATABASE beforepromotion');
+	primary_psql('CREATE TABLE beforepromotion_tab (a int)',
+		'beforepromotion');
+
+	RewindTest::promote_standby();
+
+	# Create databases in the old primary and the new promoted standby.
+	primary_psql('CREATE DATABASE primary_afterpromotion');
+	primary_psql('CREATE TABLE primary_promotion_tab (a int)',
+		'primary_afterpromotion');
+	standby_psql('CREATE DATABASE standby_afterpromotion');
+	standby_psql('CREATE TABLE standby_promotion_tab (a int)',
+		'standby_afterpromotion');
+
+	# The clusters are now diverged.
+
+	RewindTest::run_pg_rewind($test_mode);
+
+	# Check that the correct databases are present after pg_rewind.
+	check_query(
+		'SELECT datname FROM pg_database ORDER BY 1',
+		qq(beforepromotion
+inprimary
+postgres
+standby_afterpromotion
+template0
+template1
+),
+		'database names');
+
+	# Permissions on PGDATA should have group permissions
+  SKIP:
+	{
+		skip "unix-style permissions not supported on Windows", 1
+		  if ($windows_os || $Config::Config{osname} eq 'cygwin');
+
+		ok(check_mode_recursive($node_primary->data_dir(), 0750, 0640),
+			'check PGDATA permissions');
+	}
+
+	RewindTest::clean_rewind_test();
+	return;
+}
+
+run_test('remote');
+
+done_testing();


### PR DESCRIPTION
**_WIP, needs tests_**

Before this commit, WAL keys didn't mind TLI at all. But after pg_rewind, for example, pg_wal/ may contain segments from two timelines. And the wal reader choosing the key may pick the wrong one because LSNs of different TLIs may overlap. There was also another bug: There is a key with the start LSN 0/30000 in TLI 1. And after the start in TLI 2, the wal writer creates a new key with the SN 0/30000, but in TLI 2. But the reader wouldn't fetch the latest key because w/o TLI, these are the same.

This commit adds TLI to the Internal keys and makes use of it along with LSN for key compares.
