### PR TITLE
Fix our `poll_start()` helper by including `usleep()`

### DIFF
--- a/contrib/pg_tde/t/pgtde.pm
+++ b/contrib/pg_tde/t/pgtde.pm
@@ -6,6 +6,7 @@ use PostgreSQL::Test::Utils;
 use File::Basename;
 use File::Compare;
 use Test::More;
+use Time::HiRes qw(usleep);
 
 # Expected .out filename of TAP testcase being executed. These are already part of repo under t/expected/*.
 our $expected_filename_with_path;


### PR DESCRIPTION
The helper crashed if it failed on the first attempt due to a missing dependency.