### PR TITLE
Update code owners to not assign Andrew and Zsolt as reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 # Order is important; the last matching pattern takes the most precedence.
 
-*                                 @dutow @dAdAbird
 /contrib/pg_tde/documentation/    @nastena1606 @Andriciuc
 /.github/                         @artemgavrilov


### PR DESCRIPTION
We have changed our process to not assign any reviewer autoamtically but to only do so manually if that is desired.