### PR TITLE
PG-1710 Decrypt partial WAL segments when archvining them

### DIFF
--- a/contrib/pg_tde/src/bin/pg_tde_archive_decrypt.c
+++ b/contrib/pg_tde/src/bin/pg_tde_archive_decrypt.c
@@ -16,7 +16,8 @@
 static bool
 is_segment(const char *filename)
 {
-	return strspn(filename, "0123456789ABCDEF") == XLOG_FNAME_LEN && filename[XLOG_FNAME_LEN] == '\0';
+	return strspn(filename, "0123456789ABCDEF") == XLOG_FNAME_LEN &&
+		(filename[XLOG_FNAME_LEN] == '\0' || strcmp(filename + XLOG_FNAME_LEN, ".partial") == 0);
 }
 
 static void

--- a/contrib/pg_tde/src/bin/pg_tde_restore_encrypt.c
+++ b/contrib/pg_tde/src/bin/pg_tde_restore_encrypt.c
@@ -13,10 +13,17 @@
 
 #define TMPFS_DIRECTORY "/dev/shm"
 
+/*
+ * Partial WAL segments are archived but never automatically fetched from the
+ * archive by the restore_command. We support them here for symmetry though
+ * since if someone would want to fetch a partial segment from the archive and
+ * write it to pg_wal then they would want it encrypted.
+ */
 static bool
 is_segment(const char *filename)
 {
-	return strspn(filename, "0123456789ABCDEF") == XLOG_FNAME_LEN && filename[XLOG_FNAME_LEN] == '\0';
+	return strspn(filename, "0123456789ABCDEF") == XLOG_FNAME_LEN &&
+		(filename[XLOG_FNAME_LEN] == '\0' || strcmp(filename + XLOG_FNAME_LEN, ".partial") == 0);
 }
 
 static void


### PR DESCRIPTION
While the restore_command will never be called for partial WAL segments we should sitll make sure to decrypt them when archiving so a sysadmin manually could use them. As the comemnt explains we also add the same logic to the restore command for symmetry and if someone ever would call it manually or PostgreSQL would add support for restoring partial WAL segments.

If you want to learn more about partial WAL segments read the comment for CleanupAfterArchiveRecovery().