### PR TITLE
 Remove RelFileLocator from the WAL key file

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
@@ -571,7 +571,7 @@ pg_tde_decrypt_wal_key(TDEPrincipalKey *principal_key, WalKeyFileEntry *entry)
 
 	if (!AesGcmDecrypt(principal_key->keyData,
 					   entry->entry_iv, MAP_ENTRY_IV_SIZE,
-					   (unsigned char *) entry, offsetof(TDEMapEntry, enc_key),
+					   (unsigned char *) entry, offsetof(WalKeyFileEntry, enc_key),
 					   entry->enc_key.key, INTERNAL_KEY_LEN,
 					   key->key,
 					   entry->aead_tag, MAP_ENTRY_AEAD_TAG_SIZE))

--- a/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
@@ -207,13 +207,11 @@ TDEXLogSmgrInitWrite(bool encrypt_xlog)
 	 */
 	if (encrypt_xlog)
 	{
-		pg_tde_create_wal_key(&EncryptionKey, &GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID),
-							  TDE_KEY_TYPE_WAL_ENCRYPTED);
+		pg_tde_create_wal_key(&EncryptionKey, TDE_KEY_TYPE_WAL_ENCRYPTED);
 	}
 	else if (key && key->type == TDE_KEY_TYPE_WAL_ENCRYPTED)
 	{
-		pg_tde_create_wal_key(&EncryptionKey, &GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID),
-							  TDE_KEY_TYPE_WAL_UNENCRYPTED);
+		pg_tde_create_wal_key(&EncryptionKey, TDE_KEY_TYPE_WAL_UNENCRYPTED);
 	}
 	else if (key)
 	{

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
@@ -2,7 +2,6 @@
 #define PG_TDE_XLOG_KEYS_H
 
 #include "access/xlog_internal.h"
-#include "storage/relfilelocator.h"
 
 #include "access/pg_tde_tdemap.h"
 #include "catalog/tde_principal_key.h"
@@ -19,8 +18,6 @@ typedef struct WalEncryptionKey
 
 typedef struct WalKeyFileEntry
 {
-	Oid			spcOid;
-	RelFileNumber relNumber;
 	uint32		type;
 	WalEncryptionKey enc_key;
 	/* IV and tag used when encrypting the key itself */
@@ -50,7 +47,7 @@ typedef struct WALKeyCacheRec
 } WALKeyCacheRec;
 
 extern int	pg_tde_count_wal_keys_in_file(void);
-extern void pg_tde_create_wal_key(WalEncryptionKey *rel_key_data, const RelFileLocator *newrlocator, TDEMapEntryType entry_type);
+extern void pg_tde_create_wal_key(WalEncryptionKey *rel_key_data, TDEMapEntryType entry_type);
 extern void pg_tde_delete_server_key(void);
 extern WALKeyCacheRec *pg_tde_fetch_wal_keys(XLogRecPtr start_lsn);
 extern WALKeyCacheRec *pg_tde_get_last_wal_key(void);

--- a/contrib/pg_tde/src/include/catalog/tde_global_space.h
+++ b/contrib/pg_tde/src/include/catalog/tde_global_space.h
@@ -14,16 +14,4 @@
 #define GLOBAL_DATA_TDE_OID		GLOBALTABLESPACE_OID
 #define DEFAULT_DATA_TDE_OID	DEFAULTTABLESPACE_OID
 
-/*
- * This oid can be anything since the database oid is gauranteed to not be a
- * real database.
- */
-#define XLOG_TDE_OID 1
-
-#define GLOBAL_SPACE_RLOCATOR(_obj_oid) (RelFileLocator) { \
-	GLOBALTABLESPACE_OID, \
-	GLOBAL_DATA_TDE_OID, \
-	_obj_oid \
-}
-
 #endif							/* TDE_GLOBAL_CATALOG_H */


### PR DESCRIPTION
Since the RelFileLocator has never actually been used for WAL keys we can remove all traces of it from the new file an from the code.

We also fix a bug where the wrong struct was used for calculating an offset.