### PR TITLE
Change the file name of the wal keys to match better

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
@@ -22,7 +22,7 @@
 #endif
 
 #define PG_TDE_WAL_KEY_FILE_MAGIC 0x014B4557	/* version ID value = WEK 01 */
-#define PG_TDE_WAL_KEY_FILE_NAME "wal_encryption_keys"
+#define PG_TDE_WAL_KEY_FILE_NAME "wal_keys"
 
 #define MaxXLogRecPtr (~(XLogRecPtr)0)
 


### PR DESCRIPTION
The other keys are stored in `<oid>_keys` so `wal_keys` fits better into that pattern than the more redundant wal_encryption_keys where "encryption" does not add any information but just makes the path longer.

A bit bikshedding but this PR was quick to write.