### PR TITLE
Move things out of header files after key file split

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
@@ -26,6 +26,21 @@
 
 #define MaxXLogRecPtr (~(XLogRecPtr)0)
 
+typedef struct WalKeyFileHeader
+{
+	int32		file_version;
+	TDESignedPrincipalKeyInfo signed_key_info;
+} WalKeyFileHeader;
+
+typedef struct WalKeyFileEntry
+{
+	uint32		type;
+	WalEncryptionKey enc_key;
+	/* IV and tag used when encrypting the key itself */
+	unsigned char entry_iv[MAP_ENTRY_IV_SIZE];
+	unsigned char aead_tag[MAP_ENTRY_AEAD_TAG_SIZE];
+} WalKeyFileEntry;
+
 static WALKeyCacheRec *tde_wal_key_cache = NULL;
 static WALKeyCacheRec *tde_wal_key_last_rec = NULL;
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -37,34 +37,6 @@ typedef struct
 	unsigned char aead_tag[MAP_ENTRY_AEAD_TAG_SIZE];
 } TDESignedPrincipalKeyInfo;
 
-/* We do not need the dbOid since the entries are stored in a file per db */
-typedef struct TDEMapEntry
-{
-	Oid			spcOid;
-	RelFileNumber relNumber;
-	uint32		type;
-	InternalKey enc_key;
-	/* IV and tag used when encrypting the key itself */
-	unsigned char entry_iv[MAP_ENTRY_IV_SIZE];
-	unsigned char aead_tag[MAP_ENTRY_AEAD_TAG_SIZE];
-} TDEMapEntry;
-
-typedef struct XLogRelKey
-{
-	RelFileLocator rlocator;
-} XLogRelKey;
-
-#define PG_TDE_MAP_FILENAME			"%d_keys"
-
-static inline void
-pg_tde_set_db_file_path(Oid dbOid, char *path)
-{
-	char	   *fname = psprintf(PG_TDE_MAP_FILENAME, dbOid);
-
-	join_path_components(path, pg_tde_get_data_dir(), fname);
-	pfree(fname);
-}
-
 extern void pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *key);
 extern bool pg_tde_has_smgr_key(RelFileLocator rel);
 extern InternalKey *pg_tde_get_smgr_key(RelFileLocator rel);

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog.h
@@ -19,6 +19,11 @@
 /* ID 140 is registered for Percona TDE extension: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
 #define RM_TDERMGR_ID	140
 
+typedef struct XLogRelKey
+{
+	RelFileLocator rlocator;
+} XLogRelKey;
+
 extern void RegisterTdeRmgr(void);
 
 #endif							/* !FRONTEND */

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
@@ -5,7 +5,6 @@
 
 #include "access/pg_tde_tdemap.h"
 #include "catalog/tde_principal_key.h"
-#include "common/pg_tde_utils.h"
 
 typedef struct WalEncryptionKey
 {
@@ -15,21 +14,6 @@ typedef struct WalEncryptionKey
 
 	XLogRecPtr	start_lsn;
 } WalEncryptionKey;
-
-typedef struct WalKeyFileEntry
-{
-	uint32		type;
-	WalEncryptionKey enc_key;
-	/* IV and tag used when encrypting the key itself */
-	unsigned char entry_iv[MAP_ENTRY_IV_SIZE];
-	unsigned char aead_tag[MAP_ENTRY_AEAD_TAG_SIZE];
-} WalKeyFileEntry;
-
-typedef struct WalKeyFileHeader
-{
-	int32		file_version;
-	TDESignedPrincipalKeyInfo signed_key_info;
-} WalKeyFileHeader;
 
 /*
  * TODO: For now it's a simple linked list which is no good. So consider having


### PR DESCRIPTION
Some definitions should be in the .c files rather than in the header files since they are just used in one file.