### PR TITLE
Make it clear which fields are not used in the SGMR key file

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -56,7 +56,13 @@ typedef struct TDEMapEntry
 	Oid			spcOid;
 	RelFileNumber relNumber;
 	uint32		type;
-	InternalKey enc_key;
+	struct {
+		InternalKey enc_key;
+
+		/* These fields were used when WAL keys were in the same file */
+		uint32		_unused1;
+		uint64		_unused2;
+	} 			k;
 	/* IV and tag used when encrypting the key itself */
 	unsigned char entry_iv[MAP_ENTRY_IV_SIZE];
 	unsigned char aead_tag[MAP_ENTRY_AEAD_TAG_SIZE];
@@ -210,9 +216,6 @@ pg_tde_free_key_map_entry(const RelFileLocator rlocator)
 		{
 			TDEMapEntry empty_map_entry = {
 				.type = MAP_ENTRY_EMPTY,
-				.enc_key = {
-					.type = MAP_ENTRY_EMPTY,
-				},
 			};
 
 			pg_tde_write_one_map_entry(map_fd, &empty_map_entry, &prev_pos, db_map_path);
@@ -407,8 +410,10 @@ pg_tde_initialize_map_entry(TDEMapEntry *map_entry, const TDEPrincipalKey *princ
 {
 	map_entry->spcOid = rlocator->spcOid;
 	map_entry->relNumber = rlocator->relNumber;
-	map_entry->type = rel_key_data->type;
-	map_entry->enc_key = *rel_key_data;
+	map_entry->type = TDE_KEY_TYPE_SMGR;
+	map_entry->k.enc_key = *rel_key_data;
+	map_entry->k._unused1 = 0;
+	map_entry->k._unused2 = 0;
 
 	if (!RAND_bytes(map_entry->entry_iv, MAP_ENTRY_IV_SIZE))
 		ereport(ERROR,
@@ -417,9 +422,9 @@ pg_tde_initialize_map_entry(TDEMapEntry *map_entry, const TDEPrincipalKey *princ
 
 	AesGcmEncrypt(principal_key->keyData,
 				  map_entry->entry_iv, MAP_ENTRY_IV_SIZE,
-				  (unsigned char *) map_entry, offsetof(TDEMapEntry, enc_key),
+				  (unsigned char *) map_entry, offsetof(TDEMapEntry, k),
 				  rel_key_data->key, INTERNAL_KEY_LEN,
-				  map_entry->enc_key.key,
+				  map_entry->k.enc_key.key,
 				  map_entry->aead_tag, MAP_ENTRY_AEAD_TAG_SIZE);
 }
 #endif
@@ -589,12 +594,12 @@ tde_decrypt_rel_key(TDEPrincipalKey *principal_key, TDEMapEntry *map_entry)
 
 	Assert(principal_key);
 
-	*rel_key_data = map_entry->enc_key;
+	*rel_key_data = map_entry->k.enc_key;
 
 	if (!AesGcmDecrypt(principal_key->keyData,
 					   map_entry->entry_iv, MAP_ENTRY_IV_SIZE,
-					   (unsigned char *) map_entry, offsetof(TDEMapEntry, enc_key),
-					   map_entry->enc_key.key, INTERNAL_KEY_LEN,
+					   (unsigned char *) map_entry, offsetof(TDEMapEntry, k),
+					   map_entry->k.enc_key.key, INTERNAL_KEY_LEN,
 					   rel_key_data->key,
 					   map_entry->aead_tag, MAP_ENTRY_AEAD_TAG_SIZE))
 		ereport(ERROR,

--- a/contrib/pg_tde/src/encryption/enc_tde.c
+++ b/contrib/pg_tde/src/encryption/enc_tde.c
@@ -27,11 +27,8 @@ iv_prefix_debug(const char *iv_prefix, char *out_hex)
 #endif
 
 void
-pg_tde_generate_internal_key(InternalKey *int_key, TDEMapEntryType entry_type)
+pg_tde_generate_internal_key(InternalKey *int_key)
 {
-	int_key->type = entry_type;
-	int_key->start_lsn = InvalidXLogRecPtr;
-
 	if (!RAND_bytes(int_key->key, INTERNAL_KEY_LEN))
 		ereport(ERROR,
 				errcode(ERRCODE_INTERNAL_ERROR),

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -1,7 +1,6 @@
 #ifndef PG_TDE_MAP_H
 #define PG_TDE_MAP_H
 
-#include "access/xlog_internal.h"
 #include "storage/relfilelocator.h"
 #include "catalog/tde_principal_key.h"
 #include "common/pg_tde_utils.h"
@@ -22,9 +21,6 @@ typedef struct InternalKey
 {
 	uint8		key[INTERNAL_KEY_LEN];
 	uint8		base_iv[INTERNAL_KEY_IV_LEN];
-	uint32		type;
-
-	XLogRecPtr	start_lsn;
 } InternalKey;
 
 #define MAP_ENTRY_IV_SIZE 16

--- a/contrib/pg_tde/src/include/encryption/enc_tde.h
+++ b/contrib/pg_tde/src/include/encryption/enc_tde.h
@@ -7,7 +7,7 @@
 
 #include "access/pg_tde_tdemap.h"
 
-extern void pg_tde_generate_internal_key(InternalKey *int_key, TDEMapEntryType entry_type);
+extern void pg_tde_generate_internal_key(InternalKey *int_key);
 extern void pg_tde_stream_crypt(const char *iv_prefix,
 								uint32 start_offset,
 								const char *data,

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -75,7 +75,7 @@ tde_smgr_create_key(const RelFileLocatorBackend *smgr_rlocator)
 {
 	InternalKey *key = palloc_object(InternalKey);
 
-	pg_tde_generate_internal_key(key, TDE_KEY_TYPE_SMGR);
+	pg_tde_generate_internal_key(key);
 
 	if (RelFileLocatorBackendIsTemp(*smgr_rlocator))
 		tde_smgr_save_temp_key(&smgr_rlocator->locator, key);
@@ -105,7 +105,7 @@ tde_smgr_create_key_redo(const RelFileLocator *rlocator)
 	if (pg_tde_has_smgr_key(*rlocator))
 		return;
 
-	pg_tde_generate_internal_key(&key, TDE_KEY_TYPE_SMGR);
+	pg_tde_generate_internal_key(&key);
 
 	pg_tde_save_smgr_key(*rlocator, &key);
 }


### PR DESCRIPTION
Since we never read the two type and start_lsn fields for a SMGR key we might as well set them to zero and change to struct so that it is clear which fields are used and not.

We take care here to make sure the on disk format does not change and sizes of fields an alignment remain the same. The only minor difference is that the type field of the key is always zero but since it is never read that makes no difference.

These two unused fields can be removed in the next file version bump.