### PR TITLE
Remove some unused fields from InternalKey

### DIFF
--- a/contrib/pg_tde/src/encryption/enc_tde.c
+++ b/contrib/pg_tde/src/encryption/enc_tde.c
@@ -27,11 +27,8 @@ iv_prefix_debug(const char *iv_prefix, char *out_hex)
 #endif
 
 void
-pg_tde_generate_internal_key(InternalKey *int_key, TDEMapEntryType entry_type)
+pg_tde_generate_internal_key(InternalKey *int_key)
 {
-	int_key->type = entry_type;
-	int_key->start_lsn = InvalidXLogRecPtr;
-
 	if (!RAND_bytes(int_key->key, INTERNAL_KEY_LEN))
 		ereport(ERROR,
 				errcode(ERRCODE_INTERNAL_ERROR),

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -22,9 +22,6 @@ typedef struct InternalKey
 {
 	uint8		key[INTERNAL_KEY_LEN];
 	uint8		base_iv[INTERNAL_KEY_IV_LEN];
-	uint32		type;
-
-	XLogRecPtr	start_lsn;
 } InternalKey;
 
 #define MAP_ENTRY_IV_SIZE 16

--- a/contrib/pg_tde/src/include/encryption/enc_tde.h
+++ b/contrib/pg_tde/src/include/encryption/enc_tde.h
@@ -7,7 +7,7 @@
 
 #include "access/pg_tde_tdemap.h"
 
-extern void pg_tde_generate_internal_key(InternalKey *int_key, TDEMapEntryType entry_type);
+extern void pg_tde_generate_internal_key(InternalKey *int_key);
 extern void pg_tde_stream_crypt(const char *iv_prefix,
 								uint32 start_offset,
 								const char *data,

--- a/contrib/pg_tde/src/smgr/pg_tde_smgr.c
+++ b/contrib/pg_tde/src/smgr/pg_tde_smgr.c
@@ -75,7 +75,7 @@ tde_smgr_create_key(const RelFileLocatorBackend *smgr_rlocator)
 {
 	InternalKey *key = palloc_object(InternalKey);
 
-	pg_tde_generate_internal_key(key, TDE_KEY_TYPE_SMGR);
+	pg_tde_generate_internal_key(key);
 
 	if (RelFileLocatorBackendIsTemp(*smgr_rlocator))
 		tde_smgr_save_temp_key(&smgr_rlocator->locator, key);
@@ -105,7 +105,7 @@ tde_smgr_create_key_redo(const RelFileLocator *rlocator)
 	if (pg_tde_has_smgr_key(*rlocator))
 		return;
 
-	pg_tde_generate_internal_key(&key, TDE_KEY_TYPE_SMGR);
+	pg_tde_generate_internal_key(&key);
 
 	pg_tde_save_smgr_key(*rlocator, &key);
 }


### PR DESCRIPTION
Add them as reserved fields in the TDEMapEntry structure however, so we do not affect existing key files.