### PR TITLE
PG-1813 Make WAL keys TLI aware

### DIFF
--- a/contrib/pg_tde/meson.build
+++ b/contrib/pg_tde/meson.build
@@ -126,6 +126,7 @@ tap_tests = [
   't/unlogged_tables.pl',
   't/wal_archiving.pl',
   't/wal_encrypt.pl',
+  't/wal_key_tli.pl',
 ]
 
 tests += {

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
@@ -6,13 +6,47 @@
 #include "access/pg_tde_tdemap.h"
 #include "catalog/tde_principal_key.h"
 
+typedef struct WalLocation
+{
+	XLogRecPtr	lsn;
+	TimeLineID	tli;
+} WalLocation;
+
+/*
+ * Compares given WAL locations and returns -1 if l1 < l2, 0 if l1 == l2,
+ * and 1 if l1 > l2
+ */
+static inline int
+wal_location_cmp(WalLocation l1, WalLocation l2)
+{
+	if (unlikely(l1.tli < l2.tli))
+		return -1;
+
+	if (unlikely(l1.tli > l2.tli))
+		return 1;
+
+	if (l1.lsn < l2.lsn)
+		return -1;
+
+	if (l1.lsn > l2.lsn)
+		return 1;
+
+	return 0;
+}
+
+static inline bool
+wal_location_valid(WalLocation loc)
+{
+	return loc.tli != 0 && loc.lsn != InvalidXLogRecPtr;
+}
+
 typedef struct WalEncryptionKey
 {
 	uint8		key[INTERNAL_KEY_LEN];
 	uint8		base_iv[INTERNAL_KEY_IV_LEN];
 	uint32		type;
 
-	XLogRecPtr	start_lsn;
+	WalLocation wal_start;
 } WalEncryptionKey;
 
 /*
@@ -21,8 +55,8 @@ typedef struct WalEncryptionKey
  */
 typedef struct WALKeyCacheRec
 {
-	XLogRecPtr	start_lsn;
-	XLogRecPtr	end_lsn;
+	WalLocation start;
+	WalLocation end;
 
 	WalEncryptionKey key;
 	void	   *crypt_ctx;
@@ -33,7 +67,7 @@ typedef struct WALKeyCacheRec
 extern int	pg_tde_count_wal_keys_in_file(void);
 extern void pg_tde_create_wal_key(WalEncryptionKey *rel_key_data, TDEMapEntryType entry_type);
 extern void pg_tde_delete_server_key(void);
-extern WALKeyCacheRec *pg_tde_fetch_wal_keys(XLogRecPtr start_lsn);
+extern WALKeyCacheRec *pg_tde_fetch_wal_keys(WalLocation start);
 extern WALKeyCacheRec *pg_tde_get_last_wal_key(void);
 extern TDESignedPrincipalKeyInfo *pg_tde_get_server_key_info(void);
 extern WALKeyCacheRec *pg_tde_get_wal_cache_keys(void);
@@ -41,6 +75,6 @@ extern void pg_tde_perform_rotate_server_key(TDEPrincipalKey *principal_key, TDE
 extern WalEncryptionKey *pg_tde_read_last_wal_key(void);
 extern void pg_tde_save_server_key(const TDEPrincipalKey *principal_key, bool write_xlog);
 extern void pg_tde_save_server_key_redo(const TDESignedPrincipalKeyInfo *signed_key_info);
-extern void pg_tde_wal_last_key_set_lsn(XLogRecPtr lsn);
+extern void pg_tde_wal_last_key_set_location(WalLocation loc);
 
 #endif							/* PG_TDE_XLOG_KEYS_H */

--- a/contrib/pg_tde/src/include/pg_tde_fe.h
+++ b/contrib/pg_tde/src/include/pg_tde_fe.h
@@ -88,6 +88,8 @@ static int	tde_fe_error_level = 0;
 #define FreeFile(file) fclose(file)
 
 #define pg_fsync(fd) fsync(fd)
+
+#define pg_read_barrier() NULL
 #endif							/* FRONTEND */
 
 #endif							/* PG_TDE_EREPORT_H */

--- a/contrib/pg_tde/t/wal_key_tli.pl
+++ b/contrib/pg_tde/t/wal_key_tli.pl
@@ -1,0 +1,83 @@
+
+# Copyright (c) 2021-2024, PostgreSQL Global Development Group
+
+# A copy pg_rewind_databases with added restart of the standby, which forces two
+# WAL keys with the same LSN but different TLI on the primary after pg_rewind.
+
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+use FindBin;
+use lib $FindBin::RealBin;
+
+use RewindTest;
+
+sub run_test
+{
+	my $test_mode = shift;
+
+	RewindTest::setup_cluster($test_mode, ['-g']);
+	RewindTest::start_primary();
+
+	# Create a database in primary with a table.
+	primary_psql('CREATE DATABASE inprimary');
+	primary_psql('CREATE TABLE inprimary_tab (a int)', 'inprimary');
+
+	RewindTest::create_standby($test_mode);
+
+	# Generates a new WAL key with the start LSN 0/300000. After running
+	# pg_rewind, the primary will end up with that key and another one with the
+	# same LSN 0/300000, but different TLI.
+	$node_standby->restart;
+
+	# Create another database with another table, the creation is
+	# replicated to the standby.
+	primary_psql('CREATE DATABASE beforepromotion');
+	primary_psql('CREATE TABLE beforepromotion_tab (a int)',
+		'beforepromotion');
+
+	RewindTest::promote_standby();
+
+	# Create databases in the old primary and the new promoted standby.
+	primary_psql('CREATE DATABASE primary_afterpromotion');
+	primary_psql('CREATE TABLE primary_promotion_tab (a int)',
+		'primary_afterpromotion');
+	standby_psql('CREATE DATABASE standby_afterpromotion');
+	standby_psql('CREATE TABLE standby_promotion_tab (a int)',
+		'standby_afterpromotion');
+
+	# The clusters are now diverged.
+
+	RewindTest::run_pg_rewind($test_mode);
+
+	# Check that the correct databases are present after pg_rewind.
+	check_query(
+		'SELECT datname FROM pg_database ORDER BY 1',
+		qq(beforepromotion
+inprimary
+postgres
+standby_afterpromotion
+template0
+template1
+),
+		'database names');
+
+	# Permissions on PGDATA should have group permissions
+  SKIP:
+	{
+		skip "unix-style permissions not supported on Windows", 1
+		  if ($windows_os || $Config::Config{osname} eq 'cygwin');
+
+		ok(check_mode_recursive($node_primary->data_dir(), 0750, 0640),
+			'check PGDATA permissions');
+	}
+
+	RewindTest::clean_rewind_test();
+	return;
+}
+
+run_test('remote');
+
+done_testing();


### PR DESCRIPTION
Before this commit, WAL keys didn't mind TLI at all. But after pg_rewind, for example, pg_wal/ may contain segments from two timelines. And the wal reader choosing the key may pick the wrong one because LSNs of different TLIs may overlap. There was also another bug: There is a key with the start LSN 0/30000 in TLI 1. And after the start in TLI 2, the wal writer creates a new key with the SN 0/30000, but in TLI 2. But the reader wouldn't fetch the latest key because w/o TLI, these are the same.

This PR adds TLI to the Internal keys and makes use of it along with LSN for key compares.

It replaces [#491](https://github.com/percona/postgres/pull/491). The code is identical + addressed the [comment](https://github.com/percona/postgres/pull/491#discussion_r2251008224). It was just easier to create a new commit than bother with the rebase of latest changes.  

Fixes: https://perconadev.atlassian.net/browse/PG-1813