### PR TITLE
Split the type enum for WAL key and SMGR key types

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
@@ -114,7 +114,7 @@ pg_tde_wal_last_key_set_location(WalLocation loc)
 
 		if (wal_location_cmp(prev_entry.enc_key.wal_start, loc) >= 0)
 		{
-			prev_entry.enc_key.type = TDE_KEY_TYPE_WAL_INVALID;
+			prev_entry.enc_key.type = WAL_KEY_TYPE_INVALID;
 
 			if (pg_pwrite(fd, &prev_entry, sizeof(WalKeyFileEntry), prev_key_pos) != sizeof(WalKeyFileEntry))
 			{
@@ -145,7 +145,7 @@ pg_tde_wal_last_key_set_location(WalLocation loc)
  * with the actual lsn by the first WAL write.
  */
 void
-pg_tde_create_wal_key(WalEncryptionKey *rel_key_data, TDEMapEntryType entry_type)
+pg_tde_create_wal_key(WalEncryptionKey *rel_key_data, WalEncryptionKeyType entry_type)
 {
 	TDEPrincipalKey *principal_key;
 
@@ -159,7 +159,7 @@ pg_tde_create_wal_key(WalEncryptionKey *rel_key_data, TDEMapEntryType entry_type
 				errhint("Use pg_tde_set_server_key_using_global_key_provider() to configure one."));
 	}
 
-	/* TODO: no need in generating key if TDE_KEY_TYPE_WAL_UNENCRYPTED */
+	/* TODO: no need in generating key if WAL_KEY_TYPE_UNENCRYPTED */
 	rel_key_data->type = entry_type;
 	rel_key_data->wal_start.lsn = InvalidXLogRecPtr;
 	rel_key_data->wal_start.tli = 0;
@@ -302,8 +302,8 @@ pg_tde_fetch_wal_keys(WalLocation start)
 		 * Skip new (just created but not updated by write) and invalid keys
 		 */
 		if (wal_location_valid(entry.enc_key.wal_start) &&
-			(entry.enc_key.type == TDE_KEY_TYPE_WAL_UNENCRYPTED ||
-			 entry.enc_key.type == TDE_KEY_TYPE_WAL_ENCRYPTED) &&
+			(entry.enc_key.type == WAL_KEY_TYPE_UNENCRYPTED ||
+			 entry.enc_key.type == WAL_KEY_TYPE_ENCRYPTED) &&
 			wal_location_cmp(entry.enc_key.wal_start, start) >= 0)
 		{
 			WalEncryptionKey *rel_key_data = pg_tde_decrypt_wal_key(principal_key, &entry);

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -6,15 +6,6 @@
 #include "catalog/tde_principal_key.h"
 #include "common/pg_tde_utils.h"
 
-typedef enum
-{
-	MAP_ENTRY_EMPTY = 0,
-	TDE_KEY_TYPE_SMGR = 1,
-	TDE_KEY_TYPE_WAL_UNENCRYPTED = 2,
-	TDE_KEY_TYPE_WAL_ENCRYPTED = 3,
-	TDE_KEY_TYPE_WAL_INVALID = 4,
-} TDEMapEntryType;
-
 #define INTERNAL_KEY_LEN 16
 #define INTERNAL_KEY_IV_LEN 16
 

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
@@ -6,6 +6,13 @@
 #include "access/pg_tde_tdemap.h"
 #include "catalog/tde_principal_key.h"
 
+typedef enum
+{
+	WAL_KEY_TYPE_INVALID = 0,
+	WAL_KEY_TYPE_UNENCRYPTED = 1,
+	WAL_KEY_TYPE_ENCRYPTED = 2,
+} WalEncryptionKeyType;
+
 typedef struct WalLocation
 {
 	XLogRecPtr	lsn;
@@ -65,7 +72,7 @@ typedef struct WALKeyCacheRec
 } WALKeyCacheRec;
 
 extern int	pg_tde_count_wal_keys_in_file(void);
-extern void pg_tde_create_wal_key(WalEncryptionKey *rel_key_data, TDEMapEntryType entry_type);
+extern void pg_tde_create_wal_key(WalEncryptionKey *rel_key_data, WalEncryptionKeyType entry_type);
 extern void pg_tde_delete_server_key(void);
 extern WALKeyCacheRec *pg_tde_fetch_wal_keys(WalLocation start);
 extern WALKeyCacheRec *pg_tde_get_last_wal_key(void);


### PR DESCRIPTION
Since they used no common types at all (with a small exception of empty being used in the WAL code but not WAL file) it makes a lot of sense to split the two enums. Additionally we clean up the code a bit and introduce a minor performance improvement when generating a new WAL key.