### PR TITLE
Don't use pointless AAD for WAL keys

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
@@ -581,7 +581,7 @@ pg_tde_decrypt_wal_key(TDEPrincipalKey *principal_key, WalKeyFileEntry *entry)
 
 	if (!AesGcmDecrypt(principal_key->keyData,
 					   entry->entry_iv, MAP_ENTRY_IV_SIZE,
-					   (unsigned char *) entry, offsetof(WalKeyFileEntry, enc_key),
+					   NULL, 0,
 					   entry->enc_key.key, INTERNAL_KEY_LEN,
 					   key->key,
 					   entry->aead_tag, MAP_ENTRY_AEAD_TAG_SIZE))
@@ -632,7 +632,7 @@ pg_tde_initialize_wal_key_file_entry(WalKeyFileEntry *entry,
 
 	AesGcmEncrypt(principal_key->keyData,
 				  entry->entry_iv, MAP_ENTRY_IV_SIZE,
-				  (unsigned char *) entry, offsetof(WalKeyFileEntry, enc_key),
+				  NULL, 0,
 				  rel_key_data->key, INTERNAL_KEY_LEN,
 				  entry->enc_key.key,
 				  entry->aead_tag, MAP_ENTRY_AEAD_TAG_SIZE);


### PR DESCRIPTION
Using the type field as additional authentication data when encrypting the WAL keys seems silly. It's better to be explicit about no AAD being used.

I did want to use the `wal_start` as AAD, but that would have needed some rework of the mechanism to write the lsn to the last key after a written wal segment. If there is time I might try to do it before release, but this will have to do for now.