### PR TITLE
Remove warning about the WAL format being unstable

### DIFF
--- a/contrib/pg_tde/expected/access_control.out
+++ b/contrib/pg_tde/expected/access_control.out
@@ -64,7 +64,6 @@ ERROR:  must be superuser to access global key providers
 SELECT pg_tde_set_default_key_using_global_key_provider('key1', 'global-file-provider');
 ERROR:  must be superuser to access global key providers
 SELECT pg_tde_set_server_key_using_global_key_provider('key1', 'global-file-provider');
-WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 ERROR:  must be superuser to access global key providers
 SELECT pg_tde_delete_default_key();
 ERROR:  must be superuser to access global key providers

--- a/contrib/pg_tde/expected/delete_principal_key.out
+++ b/contrib/pg_tde/expected/delete_principal_key.out
@@ -150,7 +150,6 @@ SELECT pg_tde_set_key_using_global_key_provider('test-db-key','file-provider');
 (1 row)
 
 SELECT pg_tde_set_server_key_using_global_key_provider('test-db-key','file-provider');
-WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
  pg_tde_set_server_key_using_global_key_provider 
 -------------------------------------------------
  

--- a/contrib/pg_tde/expected/key_provider.out
+++ b/contrib/pg_tde/expected/key_provider.out
@@ -245,7 +245,6 @@ SELECT pg_tde_create_key_using_global_key_provider('server-key', 'global-provide
 (1 row)
 
 SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'global-provider');
-WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
  pg_tde_set_server_key_using_global_key_provider 
 -------------------------------------------------
  
@@ -319,7 +318,6 @@ ERROR:  key provider name cannot be null
 SELECT pg_tde_set_key_using_global_key_provider('key', NULL);
 ERROR:  key provider name cannot be null
 SELECT pg_tde_set_server_key_using_global_key_provider('key', NULL);
-WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 ERROR:  key provider name cannot be null
 -- Setting principal key fails if key name is NULL
 SELECT pg_tde_set_default_key_using_global_key_provider(NULL, 'file-keyring');
@@ -329,7 +327,6 @@ ERROR:  key name cannot be null
 SELECT pg_tde_set_key_using_global_key_provider(NULL, 'file-keyring');
 ERROR:  key name cannot be null
 SELECT pg_tde_set_server_key_using_global_key_provider(NULL, 'file-keyring');
-WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 ERROR:  key name cannot be null
 -- Empty string is not allowed for a principal key name
 SELECT pg_tde_create_key_using_database_key_provider('', 'file-provider');
@@ -364,7 +361,6 @@ SELECT pg_tde_set_key_using_global_key_provider('not-existing', 'file-keyring');
 ERROR:  key "not-existing" does not exist
 HINT:  Use pg_tde_create_key_using_global_key_provider() to create it.
 SELECT pg_tde_set_server_key_using_global_key_provider('not-existing', 'file-keyring');
-WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 ERROR:  key "not-existing" does not exist
 HINT:  Use pg_tde_create_key_using_global_key_provider() to create it.
 DROP EXTENSION pg_tde;

--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -593,9 +593,6 @@ pg_tde_set_server_key_using_global_key_provider(PG_FUNCTION_ARGS)
 	char	   *principal_key_name = PG_ARGISNULL(0) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(0));
 	char	   *provider_name = PG_ARGISNULL(1) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(1));
 
-	ereport(WARNING,
-			errmsg("The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!"));
-
 	/* Using a global provider for the global (wal) database */
 	pg_tde_set_principal_key_internal(GLOBAL_DATA_TDE_OID,
 									  GLOBAL_DATA_TDE_OID,

--- a/contrib/pg_tde/t/expected/crash_recovery.out
+++ b/contrib/pg_tde/t/expected/crash_recovery.out
@@ -17,7 +17,6 @@ SELECT pg_tde_set_server_key_using_global_key_provider('wal_encryption_key', 'gl
  
 (1 row)
 
-psql:<stdin>:1: WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 SELECT pg_tde_add_database_key_provider_file('db_keyring', '/tmp/crash_recovery.per');
  pg_tde_add_database_key_provider_file 
 ---------------------------------------
@@ -56,7 +55,6 @@ SELECT pg_tde_set_server_key_using_global_key_provider('wal_encryption_key_1', '
  
 (1 row)
 
-psql:<stdin>:1: WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 SELECT pg_tde_create_key_using_database_key_provider('db_key_1', 'db_keyring');
  pg_tde_create_key_using_database_key_provider 
 -----------------------------------------------
@@ -86,7 +84,6 @@ SELECT pg_tde_set_server_key_using_global_key_provider('wal_encryption_key_2', '
  
 (1 row)
 
-psql:<stdin>:1: WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 SELECT pg_tde_create_key_using_database_key_provider('db_key_2', 'db_keyring');
  pg_tde_create_key_using_database_key_provider 
 -----------------------------------------------

--- a/contrib/pg_tde/t/expected/replication.out
+++ b/contrib/pg_tde/t/expected/replication.out
@@ -80,7 +80,6 @@ SELECT pg_tde_set_server_key_using_global_key_provider('test-global-key', 'file-
  
 (1 row)
 
-psql:<stdin>:1: WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 CREATE TABLE test_enc2 (x int PRIMARY KEY) USING tde_heap;
 INSERT INTO test_enc2 (x) VALUES (1), (2);
 ALTER SYSTEM SET pg_tde.wal_encrypt = 'on';

--- a/contrib/pg_tde/t/expected/wal_encrypt.out
+++ b/contrib/pg_tde/t/expected/wal_encrypt.out
@@ -25,7 +25,6 @@ SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'file-keyri
  
 (1 row)
 
-psql:<stdin>:1: WARNING:  The WAL encryption feature is currently in beta and may be unstable. Do not use it in production environments!
 SELECT pg_tde_verify_server_key();
  pg_tde_verify_server_key 
 --------------------------


### PR DESCRIPTION
In the next release the WAL will no longer be in beta testing.