### PR TITLE
Move common things for key files into a separate header file

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -17,6 +17,7 @@
 #include "access/pg_tde_xlog.h"
 #include "catalog/tde_global_space.h"
 #include "catalog/tde_principal_key.h"
+#include "common/pg_tde_utils.h"
 #include "encryption/enc_aes.h"
 #include "encryption/enc_tde.h"
 #include "keyring/keyring_api.h"

--- a/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
@@ -9,11 +9,11 @@
 #include "storage/fd.h"
 #include "utils/memutils.h"
 
-#include "access/pg_tde_tdemap.h"
 #include "access/pg_tde_xlog_keys.h"
 #include "access/pg_tde_xlog.h"
 #include "catalog/tde_global_space.h"
 #include "catalog/tde_principal_key.h"
+#include "common/pg_tde_utils.h"
 #include "encryption/enc_aes.h"
 #include "encryption/enc_tde.h"
 

--- a/contrib/pg_tde/src/include/access/pg_tde_keys_common.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_keys_common.h
@@ -1,0 +1,19 @@
+#ifndef PG_TDE_KEYS_COMMON_H
+#define PG_TDE_KEYS_COMMON_H
+
+#include "catalog/tde_principal_key.h"
+
+#define INTERNAL_KEY_LEN 16
+#define INTERNAL_KEY_IV_LEN 16
+
+#define MAP_ENTRY_IV_SIZE 16
+#define MAP_ENTRY_AEAD_TAG_SIZE 16
+
+typedef struct
+{
+	TDEPrincipalKeyInfo data;
+	unsigned char sign_iv[MAP_ENTRY_IV_SIZE];
+	unsigned char aead_tag[MAP_ENTRY_AEAD_TAG_SIZE];
+} TDESignedPrincipalKeyInfo;
+
+#endif							/* PG_TDE_KEYS_COMMON_H */

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -1,29 +1,15 @@
 #ifndef PG_TDE_MAP_H
 #define PG_TDE_MAP_H
 
-#include "access/xlog_internal.h"
 #include "storage/relfilelocator.h"
-#include "catalog/tde_principal_key.h"
-#include "common/pg_tde_utils.h"
 
-#define INTERNAL_KEY_LEN 16
-#define INTERNAL_KEY_IV_LEN 16
+#include "access/pg_tde_keys_common.h"
 
 typedef struct InternalKey
 {
 	uint8		key[INTERNAL_KEY_LEN];
 	uint8		base_iv[INTERNAL_KEY_IV_LEN];
 } InternalKey;
-
-#define MAP_ENTRY_IV_SIZE 16
-#define MAP_ENTRY_AEAD_TAG_SIZE 16
-
-typedef struct
-{
-	TDEPrincipalKeyInfo data;
-	unsigned char sign_iv[MAP_ENTRY_IV_SIZE];
-	unsigned char aead_tag[MAP_ENTRY_AEAD_TAG_SIZE];
-} TDESignedPrincipalKeyInfo;
 
 extern void pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *key);
 extern bool pg_tde_has_smgr_key(RelFileLocator rel);

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
@@ -3,8 +3,7 @@
 
 #include "access/xlog_internal.h"
 
-#include "access/pg_tde_tdemap.h"
-#include "catalog/tde_principal_key.h"
+#include "access/pg_tde_keys_common.h"
 
 typedef enum
 {


### PR DESCRIPTION
Instead of having the WAL key code include the headers for the SMGR keys we move the shared code into a separate header file. Additionally we clean up some minor header issues.