### PR TITLE
Remove two pointless debug log statemenets

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -187,8 +187,6 @@ pg_tde_save_principal_key(const TDEPrincipalKey *principal_key, bool write_xlog)
 
 	pg_tde_set_db_file_path(principal_key->keyInfo.databaseId, db_map_path);
 
-	ereport(DEBUG2, errmsg("pg_tde_save_principal_key"));
-
 	pg_tde_sign_principal_key_info(&signed_key_Info, principal_key);
 
 	if (write_xlog)

--- a/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
@@ -735,8 +735,6 @@ pg_tde_save_server_key(const TDEPrincipalKey *principal_key, bool write_xlog)
 	off_t		curr_pos = 0;
 	TDESignedPrincipalKeyInfo signed_key_Info;
 
-	ereport(DEBUG2, errmsg("pg_tde_save_server_key"));
-
 	pg_tde_sign_principal_key_info(&signed_key_Info, principal_key);
 
 	if (write_xlog)


### PR DESCRIPTION
Just logging that the function was called at DEBUG2 is not very helpful to anyone and is presumably jsut a leftover from someone's attempt at debugging a particular issue they had at some point.