### PR TITLE
Clean up code examples in our documentation

### DIFF
--- a/contrib/pg_tde/documentation/CONTRIBUTING.md
+++ b/contrib/pg_tde/documentation/CONTRIBUTING.md
@@ -54,7 +54,7 @@ When you work, you should periodically run tests to check that your changes donâ
 
 To run the tests, use the following command:
 
-```
+```sh
 source ci_scripts/setup-keyring-servers.sh
 ci_scripts/make-test.sh all
 ```
@@ -148,6 +148,7 @@ To verify how your changes look, generate the static site with the documentation
 cd contrib/pg_tde/documentation
 docker run --rm -v $(pwd):/docs perconalab/pmm-doc-md mkdocs build
 ```
+
    If Docker can't find the image locally, it first downloads the image, and then runs it to build the documentation.
 
 3. Go to the ``site`` directory and open the ``index.html`` file to see the documentation.

--- a/contrib/pg_tde/documentation/docs/apt.md
+++ b/contrib/pg_tde/documentation/docs/apt.md
@@ -21,31 +21,31 @@ Check the [list of supported platforms](install.md#__tabbed_1_1) before continui
     Install them with the following command:
 
     ```{.bash data-prompt="$"}
-        sudo apt-get install -y wget gnupg2 curl lsb-release
+    sudo apt-get install -y wget gnupg2 curl lsb-release
     ```
 
 2. Fetch the `percona-release` package
 
     ```{.bash data-prompt="$"}
-        sudo wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
+    sudo wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
     ```
 
 3. Install `percona-release`
 
     ```{.bash data-prompt="$"}
-        sudo dpkg -i percona-release_latest.generic_all.deb
+    sudo dpkg -i percona-release_latest.generic_all.deb
     ```
 
 4. Enable the Percona Distribution for PostgreSQL repository
 
     ```{.bash data-prompt="$"}
-        sudo percona-release enable-only ppg-{{pgversion17}} 
+    sudo percona-release enable-only ppg-{{pgversion17}}
     ```
 
 6. Update the local cache
 
     ```{.bash data-prompt="$"}
-       sudo apt-get update
+    sudo apt-get update
     ```
 
 ## Install pg_tde {.power-number}
@@ -59,7 +59,7 @@ Check the [list of supported platforms](install.md#__tabbed_1_1) before continui
         The use of the `CASCADE` parameter deletes all tables that were created in the database with `pg_tde` enabled and also all dependencies upon the encrypted table (e.g. foreign keys in a non-encrypted table used in the encrypted one).     
 
         ```sql
-            DROP EXTENSION pg_tde CASCADE;
+        DROP EXTENSION pg_tde CASCADE;
         ```
 
     2. Uninstall the `percona-postgresql-17-pg-tde` package.  
@@ -67,7 +67,7 @@ Check the [list of supported platforms](install.md#__tabbed_1_1) before continui
 After all [preconditions](#preconditions) are met, run the following command to install `pg_tde`:
 
 ```{.bash data-prompt="$"}
-    sudo apt-get install -y percona-postgresql-17 
+sudo apt-get install -y percona-postgresql-17
 ```
 
 ## Next steps

--- a/contrib/pg_tde/documentation/docs/architecture/architecture.md
+++ b/contrib/pg_tde/documentation/docs/architecture/architecture.md
@@ -227,7 +227,7 @@ To change a provider from a command line, `pg_tde` provides the `pg_tde_change_k
 
 This tool work similarly to the above functions, with the following syntax:
 
-```bash
+```sh
 pg_tde_change_key_provider <dbOid> <providerType> ... details ...
 ```
 

--- a/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-change-key-provider.md
+++ b/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-change-key-provider.md
@@ -16,7 +16,7 @@ To modify the key provider configuration, specify all parameters depending on th
 
 The general syntax is as follows:
 
-```bash
+```sh
 pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> <new_provider_type> <provider_parameters...>
 ```
 
@@ -29,7 +29,7 @@ pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> <new_provider_
 
 Depending on the provider type, the additional parameters are:
 
-```bash
+```sh
 pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> file <filename>
 pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> vault-v2 <url> <mount_path> <token_path> [<ca_path>]
 pg_tde_change_key_provider [-D <datadir>] <dbOid> <provider_name> kmip <host> <port> <cert_path> <key_path> [<ca_path>] 

--- a/contrib/pg_tde/documentation/docs/contribute.md
+++ b/contrib/pg_tde/documentation/docs/contribute.md
@@ -54,7 +54,7 @@ When you work, you should periodically run tests to check that your changes donâ
 
 To run the tests, use the following command:
 
-```
+```sh
 source ci_scripts/setup-keyring-servers.sh
 ci_scripts/make-test.sh all
 ```
@@ -108,6 +108,7 @@ The steps are the following:
 
 ```sh
 git clone --recursive git@github.com:<your-name>/postgres.git
+```
 
 3. Change the directory to `contrib/pg_tde` and add the remote upstream repository:
 

--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -117,6 +117,7 @@ SELECT pg_tde_add_database_key_provider_kmip(
   '/path_to/client_key.pem',
   '/path_to/server_certificate.pem'
 );
+
 SELECT pg_tde_add_global_key_provider_kmip(
   'provider-name',
   'kmip-addr',
@@ -138,6 +139,7 @@ SELECT pg_tde_change_database_key_provider_kmip(
   '/path_to/client_key.pem',
   '/path_to/server_certificate.pem'
 );
+
 SELECT pg_tde_change_global_key_provider_kmip(
   'provider-name',
   'kmip-addr',
@@ -261,6 +263,7 @@ SELECT pg_tde_set_key_using_database_key_provider(
   'provider-name'
 );
 ```
+
 ### pg_tde_set_key_using_global_key_provider
 
 Sets or rotates the global principal key using the specified global key provider and the key name. This key is used for global settings like WAL encryption.

--- a/contrib/pg_tde/documentation/docs/how-to/decrypt.md
+++ b/contrib/pg_tde/documentation/docs/how-to/decrypt.md
@@ -27,8 +27,7 @@ The output returns `f` meaning that the table is no longer encrypted.
 Alternatively, you can create a new not encrypted table with the same structure and data as the initial table. For example, the original encrypted table is `EncryptedCustomers`. Use the following command to create a new table `Customers`:
 
 ```sql
-CREATE TABLE Customers AS
-SELECT * FROM EncryptedCustomers;
+CREATE TABLE Customers AS SELECT * FROM EncryptedCustomers;
 ```
 
 The new table `Customers` inherits the structure and the data from `EncryptedCustomers`.

--- a/contrib/pg_tde/documentation/docs/how-to/multi-tenant-setup.md
+++ b/contrib/pg_tde/documentation/docs/how-to/multi-tenant-setup.md
@@ -17,7 +17,7 @@ Load the `pg_tde` at startup time. The extension requires additional shared memo
 
 1. Use the [ALTER SYSTEM :octicons-link-external-16:](https://www.postgresql.org/docs/current/sql-altersystem.html) command from `psql` terminal to modify the `shared_preload_libraries` parameter. This requires superuser privileges.
 
-    ```
+    ```sql
     ALTER SYSTEM SET shared_preload_libraries = 'pg_tde';
     ```
 
@@ -37,7 +37,7 @@ Load the `pg_tde` at startup time. The extension requires additional shared memo
 
 3. Create the extension using the [CREATE EXTENSION :octicons-link-external-16:](https://www.postgresql.org/docs/current/sql-createextension.html) command. You must have the privileges of a superuser or a database owner to use this command. Connect to `psql` as a superuser for a database and run the following command:
 
-    ```
+    ```sql
     CREATE EXTENSION pg_tde;
     ```
 
@@ -73,7 +73,7 @@ You must do these steps for every database where you have created the extension.
           '/path_to/client_cert.pem', 
           '/path_to/client_key.pem', 
           '/path_to/server_certificate.pem'
-          );
+        );
         ```
 
         where:
@@ -95,7 +95,7 @@ You must do these steps for every database where you have created the extension.
             '/tmp/client_cert_jane_doe.pem', 
             '/tmp/client_key_jane_doe.pem', 
             '/tmp/server_certificate.pem'
-            );
+        );
         ```
 
     === "With HashiCorp Vault"
@@ -109,7 +109,7 @@ You must do these steps for every database where you have created the extension.
             'mount', 
             'secret_token_path', 
             'ca_path'
-            );
+        );
         ```
 
         where:
@@ -121,15 +121,15 @@ You must do these steps for every database where you have created the extension.
 
         <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
-	    ```sql
-	    SELECT pg_tde_add_database_key_provider_file_vault_v2(
+        ```sql
+        SELECT pg_tde_add_database_key_provider_file_vault_v2(
             'my-vault',
             'http://vault.vault.svc.cluster.local:8200',
             'secret/data',
             'hvs.zPuyktykA...example...ewUEnIRVaKoBzs2', 
             NULL
-            );
-	    ```
+        );
+        ```
 
     === "With a keyring file (not recommended)"
 
@@ -139,25 +139,25 @@ You must do these steps for every database where you have created the extension.
         SELECT pg_tde_add_database_key_provider_file(
             'provider-name', 
             '/path/to/the/keyring/data.file'
-            );
+        );
         ```
 
 	    <i warning>:material-information: Warning:</i> This example is for testing purposes only:
 
-	    ```sql
-	    SELECT pg_tde_add_database_key_provider_file(
+        ```sql
+        SELECT pg_tde_add_database_key_provider_file(
             'file-keyring', 
             '/tmp/pg_tde_test_local_keyring.per'
-            );
-	    ```
+        );
+        ```
 
 2. Create a key
-    ```sql
 
+    ```sql
     SELECT pg_tde_create_key_using_database_key_provider(
         'name-of-the-key', 
         'provider-name'
-        );
+    );
     ```
 
     where:
@@ -171,19 +171,19 @@ You must do these steps for every database where you have created the extension.
     SELECT pg_tde_create_key_using_database_key_provider(
         'test-db-master-key', 
         'file-vault'
-        );
+    );
     ```
 
     !!! note
         The key is auto-generated.
 
 3. Use the key as principal key
-    ```sql
 
+    ```sql
     SELECT pg_tde_set_key_using_database_key_provider(
         'name-of-the-key', 
         'provider-name'
-        );
+    );
     ```
 
     where:
@@ -197,5 +197,5 @@ You must do these steps for every database where you have created the extension.
     SELECT pg_tde_set_key_using_database_key_provider(
         'test-db-master-key',
         'file-vault'
-        );
+    );
     ```

--- a/contrib/pg_tde/documentation/docs/how-to/uninstall.md
+++ b/contrib/pg_tde/documentation/docs/how-to/uninstall.md
@@ -124,7 +124,7 @@ This can happen if WAL encryption was not properly disabled before removing `pg_
 
 You might see this when restarting the PostgreSQL cluster:
 
-```sh
+```
 2025-04-01 17:12:50.607 CEST [496385] PANIC:  could not locate a valid checkpoint record at 0/17B2580
 ```
 

--- a/contrib/pg_tde/documentation/docs/replication.md
+++ b/contrib/pg_tde/documentation/docs/replication.md
@@ -82,8 +82,7 @@ sudo systemctl start postgresql
 * On primary:
 
 ```sql
-SELECT client_addr, state 
-FROM pg_stat_replication;
+SELECT client_addr, state FROM pg_stat_replication;
 ```
 
 * On standby:

--- a/contrib/pg_tde/documentation/docs/yum.md
+++ b/contrib/pg_tde/documentation/docs/yum.md
@@ -11,13 +11,13 @@ You need the `percona-release` repository management tool that enables the desir
 1. Install `percona-release`:
 
     ```{.bash data-prompt="$"}
-        sudo yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm 
+    sudo yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
     ```
 
 2. Enable the repository.
 
     ```{.bash data-prompt="$"}
-        sudo percona-release enable-only ppg-17.5
+    sudo percona-release enable-only ppg-17.5
     ```
 
 ## Install pg_tde {.power-number}
@@ -31,7 +31,7 @@ You need the `percona-release` repository management tool that enables the desir
        The use of the `CASCADE` parameter deletes all tables that were created in the database with `pg_tde` enabled and also all dependencies upon the encrypted table (e.g. foreign keys in a non-encrypted table used in the encrypted one).    
 
     ```sql
-       DROP EXTENSION pg_tde CASCADE
+    DROP EXTENSION pg_tde CASCADE;
     ```
 
     2. Uninstall the `percona-pg_tde_17` package.  
@@ -39,7 +39,7 @@ You need the `percona-release` repository management tool that enables the desir
 Run the following command to install `pg_tde`:
 
 ```{.bash data-prompt="$"}
-    sudo yum -y install percona-postgresql17-server percona-postgresql17-contrib 
+sudo yum -y install percona-postgresql17-server percona-postgresql17-contrib
 ```
 
 ## Next steps


### PR DESCRIPTION
- Fix whitespace
- Make sure to use the right languages
- Do not wrap short SQL queries unnecessarily
- Add missing end of code block
- Add missing semicolon to SQL query
