### PR TITLE
Remove merge separator from documentation page

### DIFF
--- a/contrib/pg_tde/documentation/docs/functions.md
+++ b/contrib/pg_tde/documentation/docs/functions.md
@@ -285,7 +285,7 @@ SELECT pg_tde_set_server_key_using_global_key_provider(
 
 !!! warning
     The WAL encryption feature is currently in beta and is not effective unless explicitly enabled. It is not yet production ready. **Do not enable this feature in production environments**.
-=======
+
 The `ensure_new_key` parameter instructs the function how to handle a principal key during key rotation:
 
 * If set to `true`, a new key must be unique.


### PR DESCRIPTION
It was accidentally introduced in commit 8d88d3f28a060d060db0e1eedb5aa47ce3d1150f.