### PR TITLE
PG-1862 Use system() over exec() for archive/restore commands

### DIFF
--- a/contrib/pg_tde/src/bin/pg_tde_archive_decrypt.c
+++ b/contrib/pg_tde/src/bin/pg_tde_archive_decrypt.c
@@ -149,7 +149,7 @@ main(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_tde_archive_deceypt (PostgreSQL) " PG_VERSION);
+			puts("pg_tde_archive_decrypt (PostgreSQL) " PG_VERSION);
 			exit(0);
 		}
 	}

--- a/contrib/pg_tde/t/wal_archiving.pl
+++ b/contrib/pg_tde/t/wal_archiving.pl
@@ -21,7 +21,8 @@ $primary->append_conf('postgresql.conf', "autovacuum = off");
 $primary->append_conf('postgresql.conf', "checkpoint_timeout = 1h");
 $primary->append_conf('postgresql.conf', "archive_mode = on");
 $primary->append_conf('postgresql.conf',
-	"archive_command = 'pg_tde_archive_decrypt %p cp %p $archive_dir/%f'");
+	"archive_command = 'pg_tde_archive_decrypt %f %p \"cp %%p $archive_dir/%%f\"'"
+);
 $primary->start;
 
 $primary->safe_psql('postgres', "CREATE EXTENSION pg_tde;");
@@ -75,7 +76,8 @@ like(
 my $replica = PostgreSQL::Test::Cluster->new('replica');
 $replica->init_from_backup($primary, 'backup');
 $replica->append_conf('postgresql.conf',
-	"restore_command = 'pg_tde_restore_encrypt %f %p cp $archive_dir/%f %p'");
+	"restore_command = 'pg_tde_restore_encrypt %f %p \"cp $archive_dir/%%f %%p\"'"
+);
 $replica->append_conf('postgresql.conf', "recovery_target_action = promote");
 $replica->set_recovery_mode;
 $replica->start;


### PR DESCRIPTION
Use a single argument for the wrapped command in the archivation wrappers.

Instead of giving all of the arguments of the command separately and trying to figure out which one should be replaced by the path to the unencrypted WAL segment, we take a single argument and do % parameter replacement similar to what postgres does with archive_command and restore_command.

This also mean that we can simplify by using system() instead of exec().

Replaces: #522 

https://perconadev.atlassian.net/browse/PG-1862