### PR TITLE
PG-1857 Do not start basebackup w/o WAL keys

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8967,6 +8967,12 @@ do_pg_backup_start(const char *backupidstr, bool fast, List **tablespaces,
 			WALInsertLockRelease();
 		} while (!gotUniqueStartpoint);
 
+		/* TODO: we should rather check if the last WAL key is encrypted */
+		if (access("pg_tde/wal_keys", F_OK) == 0)
+		{
+			state->tde_have_wal_keys = true;
+		}
+
 		/*
 		 * Construct tablespace_map file.
 		 */

--- a/src/backend/backup/basebackup.c
+++ b/src/backend/backup/basebackup.c
@@ -269,6 +269,7 @@ perform_base_backup(basebackup_options *opt, bbsink *sink,
 
 	state.startptr = backup_state->startpoint;
 	state.starttli = backup_state->starttli;
+	state.tde_have_wal_keys = backup_state->tde_have_wal_keys;
 
 	/*
 	 * Once do_pg_backup_start has been called, ensure that any failure causes

--- a/src/backend/backup/basebackup_copy.c
+++ b/src/backend/backup/basebackup_copy.c
@@ -86,7 +86,7 @@ static void bbsink_copystream_cleanup(bbsink *sink);
 
 static void SendCopyOutResponse(void);
 static void SendCopyDone(void);
-static void SendXlogRecPtrResult(XLogRecPtr ptr, TimeLineID tli);
+static void SendXlogRecPtrResult(XLogRecPtr ptr, TimeLineID tli, bool wal_keys);
 static void SendTablespaceList(List *tablespaces);
 
 static const bbsink_ops bbsink_copystream_ops = {
@@ -146,7 +146,7 @@ bbsink_copystream_begin_backup(bbsink *sink)
 	mysink->msgbuffer[0] = 'd'; /* archive or manifest data */
 
 	/* Tell client the backup start location. */
-	SendXlogRecPtrResult(state->startptr, state->starttli);
+	SendXlogRecPtrResult(state->startptr, state->starttli, state->tde_have_wal_keys);
 
 	/* Send client a list of tablespaces. */
 	SendTablespaceList(state->tablespaces);
@@ -298,7 +298,7 @@ bbsink_copystream_end_backup(bbsink *sink, XLogRecPtr endptr,
 							 TimeLineID endtli)
 {
 	SendCopyDone();
-	SendXlogRecPtrResult(endptr, endtli);
+	SendXlogRecPtrResult(endptr, endtli, false);
 }
 
 /*
@@ -338,17 +338,17 @@ SendCopyDone(void)
  * XLogRecPtr record (in text format)
  */
 static void
-SendXlogRecPtrResult(XLogRecPtr ptr, TimeLineID tli)
+SendXlogRecPtrResult(XLogRecPtr ptr, TimeLineID tli, bool wal_keys)
 {
 	DestReceiver *dest;
 	TupOutputState *tstate;
 	TupleDesc	tupdesc;
-	Datum		values[2];
-	bool		nulls[2] = {0};
+	Datum		values[3];
+	bool		nulls[3] = {0};
 
 	dest = CreateDestReceiver(DestRemoteSimple);
 
-	tupdesc = CreateTemplateTupleDesc(2);
+	tupdesc = CreateTemplateTupleDesc(3);
 	TupleDescInitBuiltinEntry(tupdesc, (AttrNumber) 1, "recptr", TEXTOID, -1, 0);
 
 	/*
@@ -357,12 +357,16 @@ SendXlogRecPtrResult(XLogRecPtr ptr, TimeLineID tli)
 	 */
 	TupleDescInitBuiltinEntry(tupdesc, (AttrNumber) 2, "tli", INT8OID, -1, 0);
 
+
+	TupleDescInitBuiltinEntry(tupdesc, (AttrNumber) 3, "walkeys", INT4OID, -1, 0);
+
 	/* send RowDescription */
 	tstate = begin_tup_output_tupdesc(dest, tupdesc, &TTSOpsVirtual);
 
 	/* Data row */
 	values[0] = CStringGetTextDatum(psprintf("%X/%X", LSN_FORMAT_ARGS(ptr)));
 	values[1] = Int64GetDatum(tli);
+	values[2] = BoolGetDatum(wal_keys);
 	do_tup_output(tstate, values, nulls);
 
 	end_tup_output(tstate);

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1794,6 +1794,7 @@ BaseBackup(char *compression_algorithm, char *compression_detail,
 				serverMajor;
 	int			writing_to_stdout;
 	bool		use_new_option_syntax = false;
+	bool		tde_src_wal_keys = false;
 	PQExpBufferData buf;
 
 	Assert(conn != NULL);
@@ -2058,6 +2059,10 @@ BaseBackup(char *compression_algorithm, char *compression_detail,
 		starttli = atoi(PQgetvalue(res, 0, 1));
 	else
 		starttli = latesttli;
+
+	if (PQnfields(res) >= 3)
+		tde_src_wal_keys = atoi(PQgetvalue(res, 0, 2));
+		
 	PQclear(res);
 
 	if (verbose && includewal != NO_WAL)
@@ -2130,6 +2135,16 @@ BaseBackup(char *compression_algorithm, char *compression_detail,
 		if (verbose)
 			pg_log_info("starting background WAL receiver");
 
+#ifdef PERCONA_EXT
+		{
+			char tde_wal_keys_file[MAXPGPATH];
+
+			snprintf(tde_wal_keys_file, sizeof(tde_wal_keys_file), "%s/%s/%s", basedir, PG_TDE_DATA_DIR, "wal_keys");
+
+			if (tde_src_wal_keys && access(tde_wal_keys_file, F_OK) != 0)
+				pg_fatal("could not start WAL receiver, copy pg_tde from the source to the destination dir");
+		}
+#endif
 		if (client_compress->algorithm == PG_COMPRESSION_GZIP)
 		{
 			wal_compress_algorithm = PG_COMPRESSION_GZIP;

--- a/src/include/access/xlogbackup.h
+++ b/src/include/access/xlogbackup.h
@@ -30,6 +30,7 @@ typedef struct BackupState
 	bool		started_in_recovery;	/* backup started in recovery? */
 	XLogRecPtr	istartpoint;	/* incremental based on backup at this LSN */
 	TimeLineID	istarttli;		/* incremental based on backup on this TLI */
+	bool		tde_have_wal_keys;
 
 	/* Fields saved at the end of backup */
 	XLogRecPtr	stoppoint;		/* backup stop WAL location */

--- a/src/include/backup/basebackup_sink.h
+++ b/src/include/backup/basebackup_sink.h
@@ -72,6 +72,7 @@ typedef struct bbsink_state
 	bool		bytes_total_is_valid;
 	XLogRecPtr	startptr;
 	TimeLineID	starttli;
+	bool		tde_have_wal_keys;
 } bbsink_state;
 
 /*


### PR DESCRIPTION
To check if everyone's on board with the idea. 
This requires small changes in the backend and basebackup protocol. But it is more reliable - the backup won't start at all if the source server has wal_keys but the destination doesn't. 
Another, simpler approach would be to check during the file copy if we stumble upon pg_tde/wal_keys and, if there is no such file in the destination, then we abort the backup. It would require changes only in bin/pg_basebackup. But it can expose unencrypted WAL files in the backup directory (the backup might take who knows how long until we encounter pg_tde/wal_keys).

The code needs improvements - get rid off hardcoded strings etc. Plus we might want to check on the server side if the last WAL key is encrypted instead of just existence of the file. 

Also needs tests