### PR TITLE
Only initialize WAL shmem structures once in `EXEC_BACKEND` builds

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_smgr.c
@@ -156,22 +156,25 @@ TDEXLogEncryptStateSize(void)
 void
 TDEXLogShmemInit(void)
 {
-	bool		foundBuf;
+	bool		found;
 
 	EncryptionState = (EncryptionStateData *)
 		ShmemInitStruct("TDE XLog Encryption State",
 						TDEXLogEncryptStateSize(),
-						&foundBuf);
+						&found);
 
-	memset(EncryptionState, 0, sizeof(EncryptionStateData));
+	if (!found)
+	{
+		memset(EncryptionState, 0, sizeof(EncryptionStateData));
+
+		pg_atomic_init_u64(&EncryptionState->enc_key_lsn, 0);
+
+		elog(DEBUG1, "pg_tde: initialized encryption buffer %lu bytes", TDEXLogEncryptStateSize());
+	}
 
 	EncryptionBuf = (char *) TYPEALIGN(PG_IO_ALIGN_SIZE, ((char *) EncryptionState) + sizeof(EncryptionStateData));
 
 	Assert((char *) EncryptionState + TDEXLogEncryptStateSize() >= (char *) EncryptionBuf + TDEXLogEncryptBuffSize());
-
-	pg_atomic_init_u64(&EncryptionState->enc_key_lsn, 0);
-
-	elog(DEBUG1, "pg_tde: initialized encryption buffer %lu bytes", TDEXLogEncryptStateSize());
 }
 
 #else							/* !FRONTEND */


### PR DESCRIPTION
This only affects `EXEC_BACKEND`/Windows builds which we currently do not support, but we fix this anyway to make the code more consistent and easier to understand since we try to care about this in other places.

In the future we may want to add CI and proper support for `EXEC_BACKEND` builds.

The issue was originally found by Zsolt Parragi.