### PR TITLE
PG-1870 Run postgresql TAP suite with pg_tde enabled

### DIFF
--- a/ci_scripts/tde_setup.sql
+++ b/ci_scripts/tde_setup.sql
@@ -1,6 +1,6 @@
-CREATE SCHEMA IF NOT EXISTS tde;
-CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
+CREATE SCHEMA IF NOT EXISTS _pg_tde;
+CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA _pg_tde;
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-SELECT tde.pg_tde_add_database_key_provider_file('reg_file-vault', '/tmp/pg_tde_test_keyring.per');
-SELECT tde.pg_tde_create_key_using_database_key_provider('test-db-key', 'reg_file-vault');
-SELECT tde.pg_tde_set_key_using_database_key_provider('test-db-key', 'reg_file-vault');
+SELECT _pg_tde.pg_tde_add_database_key_provider_file('reg_file-vault', '/tmp/pg_tde_test_keyring.per');
+SELECT _pg_tde.pg_tde_create_key_using_database_key_provider('test-db-key', 'reg_file-vault');
+SELECT _pg_tde.pg_tde_set_key_using_database_key_provider('test-db-key', 'reg_file-vault');

--- a/ci_scripts/tde_setup_global.sql
+++ b/ci_scripts/tde_setup_global.sql
@@ -1,11 +1,10 @@
-CREATE SCHEMA tde;
-CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA tde;
+CREATE SCHEMA IF NOT EXISTS _pg_tde;
+CREATE EXTENSION IF NOT EXISTS pg_tde SCHEMA _pg_tde;
 
 \! rm -f '/tmp/pg_tde_test_keyring.per'
-SELECT tde.pg_tde_add_global_key_provider_file('reg_file-global', '/tmp/pg_tde_test_keyring.per');
-SELECT tde.pg_tde_create_key_using_global_key_provider('server-key', 'reg_file-global');
-SELECT tde.pg_tde_set_server_key_using_global_key_provider('server-key', 'reg_file-global');
+SELECT _pg_tde.pg_tde_add_global_key_provider_file('reg_file-global', '/tmp/pg_tde_test_keyring.per');
+SELECT _pg_tde.pg_tde_create_key_using_global_key_provider('server-key', 'reg_file-global');
+SELECT _pg_tde.pg_tde_set_server_key_using_global_key_provider('server-key', 'reg_file-global');
 ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 ALTER SYSTEM SET default_table_access_method = 'tde_heap';
-ALTER SYSTEM SET search_path = "$user",public,tde;
 -- restart required

--- a/contrib/amcheck/t/001_verify_heapam.pl
+++ b/contrib/amcheck/t/001_verify_heapam.pl
@@ -9,6 +9,11 @@ use PostgreSQL::Test::Utils;
 
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => "hacks relation files directly for scaffolding";
+}
+
 my ($node, $result);
 
 #

--- a/meson.build
+++ b/meson.build
@@ -3445,6 +3445,48 @@ sys.exit(sp.returncode)
      env: test_env,
      suite: ['setup'])
 
+test_tde_template_dir = test_install_destdir / 'pg_tde_template'
+test_env.set('TDE_TEMPLATE_DIR', test_tde_template_dir)
+
+test('init_tde_files',
+     find_program('sh', required: true, native: true),
+     args: [
+       '-c', '''
+set -e
+
+if [ -z "$TDE_MODE" ]; then
+	exit;
+fi
+
+set -e
+
+PATH="$1":$PATH
+TMP_DATA_DIR=$(mktemp -d)
+
+rm -rf "$2"
+mkdir "$2"
+
+pg_ctl -D "$TMP_DATA_DIR" init -o '--set shared_preload_libraries=pg_tde'
+
+postgres --single -F -j -D "$TMP_DATA_DIR" postgres << SQL
+	CREATE EXTENSION pg_tde;
+	SELECT pg_tde_add_global_key_provider_file('global_test_provider', '$2/pg_tde_test_keys');
+	SELECT pg_tde_create_key_using_global_key_provider('test_default_key', 'global_test_provider');
+	SELECT pg_tde_set_default_key_using_global_key_provider('test_default_key', 'global_test_provider');
+SQL
+
+cp -RPp "$TMP_DATA_DIR/pg_tde" "$2/pg_tde"
+rm -rf "$TMP_DATA_DIR"
+''',
+       'init_tde_files',
+       temp_install_bindir,
+       test_tde_template_dir
+     ],
+     priority: setup_tests_priority - 2,
+     timeout: 300,
+     is_parallel: false,
+     env: test_env,
+     suite: ['setup'])
 
 
 ###############################################################

--- a/src/bin/pg_amcheck/t/003_check.pl
+++ b/src/bin/pg_amcheck/t/003_check.pl
@@ -9,6 +9,11 @@ use PostgreSQL::Test::Utils;
 
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => "hacks relation files directly for scaffolding";
+}
+
 my ($node, $port, %corrupt_page, %remove_relation);
 
 # Returns the filesystem path for the named relation.

--- a/src/bin/pg_amcheck/t/005_opclass_damage.pl
+++ b/src/bin/pg_amcheck/t/005_opclass_damage.pl
@@ -10,6 +10,11 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => 'investigate why this fails';
+}
+
 my $node = PostgreSQL::Test::Cluster->new('test');
 $node->init;
 $node->start;

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -10,6 +10,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
+}
+
 program_help_ok('pg_basebackup');
 program_version_ok('pg_basebackup');
 program_options_handling_ok('pg_basebackup');

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -16,6 +16,12 @@ if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
 	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
 }
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  'uses corrupt_page_checksum to directly hack relation files';
+}
+
 program_help_ok('pg_basebackup');
 program_version_ok('pg_basebackup');
 program_options_handling_ok('pg_basebackup');

--- a/src/bin/pg_checksums/t/002_actions.pl
+++ b/src/bin/pg_checksums/t/002_actions.pl
@@ -12,6 +12,11 @@ use PostgreSQL::Test::Utils;
 
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  'uses corrupt_page_checksum to directly hack relation files';
+}
 
 # Utility routine to create and check a table with corrupted checksums
 # on a wanted tablespace.  Note that this stops and starts the node

--- a/src/bin/pg_combinebackup/t/003_timeline.pl
+++ b/src/bin/pg_combinebackup/t/003_timeline.pl
@@ -10,6 +10,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
+}
+
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_COMBINEBACKUP_MODE} || '--copy';
 

--- a/src/bin/pg_combinebackup/t/006_db_file_copy.pl
+++ b/src/bin/pg_combinebackup/t/006_db_file_copy.pl
@@ -7,6 +7,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
+}
+
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_COMBINEBACKUP_MODE} || '--copy';
 

--- a/src/bin/pg_combinebackup/t/008_promote.pl
+++ b/src/bin/pg_combinebackup/t/008_promote.pl
@@ -10,6 +10,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
+}
+
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_COMBINEBACKUP_MODE} || '--copy';
 

--- a/src/bin/pg_dump/t/004_pg_dump_parallel.pl
+++ b/src/bin/pg_dump/t/004_pg_dump_parallel.pl
@@ -8,6 +8,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  'pg_restore fail to restore _pg_tde schema on cluster which already has it';
+}
+
 my $dbname1 = 'regression_src';
 my $dbname2 = 'regression_dest1';
 my $dbname3 = 'regression_dest2';

--- a/src/bin/pg_dump/t/010_dump_connstr.pl
+++ b/src/bin/pg_dump/t/010_dump_connstr.pl
@@ -8,6 +8,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  'pg_restore fail to restore _pg_tde schema on cluster which already has it';
+}
+
 if ($PostgreSQL::Test::Utils::is_msys2)
 {
 	plan skip_all => 'High bit name tests fail on Msys2';

--- a/src/bin/pg_rewind/t/001_basic.pl
+++ b/src/bin/pg_rewind/t/001_basic.pl
@@ -11,6 +11,12 @@ use lib $FindBin::RealBin;
 
 use RewindTest;
 
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  "copies WAL directly to archive without using archive_command";
+}
+
 sub run_test
 {
 	my $test_mode = shift;

--- a/src/bin/pg_rewind/t/002_databases.pl
+++ b/src/bin/pg_rewind/t/002_databases.pl
@@ -11,6 +11,12 @@ use lib $FindBin::RealBin;
 
 use RewindTest;
 
+if ($ENV{TDE_MODE} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  "pg_combinebackup doesn't set filemodes of pg_tde/ correctly?";
+}
+
 sub run_test
 {
 	my $test_mode = shift;

--- a/src/bin/pg_upgrade/t/002_pg_upgrade.pl
+++ b/src/bin/pg_upgrade/t/002_pg_upgrade.pl
@@ -15,6 +15,12 @@ use PostgreSQL::Test::Utils;
 use PostgreSQL::Test::AdjustUpgrade;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  'pg_restore fail to restore _pg_tde schema on cluster which already has it';
+}
+
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_UPGRADE_MODE} || '--copy';
 

--- a/src/bin/pg_upgrade/t/002_pg_upgrade.pl
+++ b/src/bin/pg_upgrade/t/002_pg_upgrade.pl
@@ -15,11 +15,6 @@ use PostgreSQL::Test::Utils;
 use PostgreSQL::Test::AdjustUpgrade;
 use Test::More;
 
-if (defined($ENV{TDE_MODE}))
-{
-    plan skip_all => "Running with TDE doesn't support special server starts yet";
-}
-
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_UPGRADE_MODE} || '--copy';
 

--- a/src/bin/pg_upgrade/t/003_logical_slots.pl
+++ b/src/bin/pg_upgrade/t/003_logical_slots.pl
@@ -11,6 +11,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  'pg_restore fail to restore _pg_tde schema on cluster which already has it';
+}
+
 # Can be changed to test the other modes
 my $mode = $ENV{PG_TEST_PG_UPGRADE_MODE} || '--copy';
 

--- a/src/bin/pg_upgrade/t/004_subscription.pl
+++ b/src/bin/pg_upgrade/t/004_subscription.pl
@@ -12,6 +12,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  'pg_restore fail to restore _pg_tde schema on cluster which already has it';
+}
+
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_UPGRADE_MODE} || '--copy';
 

--- a/src/bin/pg_verifybackup/t/009_extract.pl
+++ b/src/bin/pg_verifybackup/t/009_extract.pl
@@ -10,6 +10,13 @@ use File::Path qw(rmtree);
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
+
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
+}
+
 my $primary = PostgreSQL::Test::Cluster->new('primary');
 $primary->init(allows_streaming => 1);
 $primary->start;

--- a/src/bin/pg_waldump/t/001_basic.pl
+++ b/src/bin/pg_waldump/t/001_basic.pl
@@ -7,6 +7,11 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => "pg_waldump needs extra options for encrypted WAL";
+}
+
 program_help_ok('pg_waldump');
 program_version_ok('pg_waldump');
 program_options_handling_ok('pg_waldump');

--- a/src/bin/pg_waldump/t/002_save_fullpage.pl
+++ b/src/bin/pg_waldump/t/002_save_fullpage.pl
@@ -9,6 +9,11 @@ use PostgreSQL::Test::RecursiveCopy;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => "pg_waldump needs extra options for encrypted WAL";
+}
+
 my ($blocksize, $walfile_name);
 
 # Function to extract the LSN from the given block structure

--- a/src/bin/scripts/t/020_createdb.pl
+++ b/src/bin/scripts/t/020_createdb.pl
@@ -8,6 +8,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  'tries to use FILE_COPY strategy for database creation with encrypted objects in the template';
+}
+
 program_help_ok('createdb');
 program_version_ok('createdb');
 program_options_handling_ok('createdb');

--- a/src/test/perl/PostgreSQL/Test/Cluster.pm
+++ b/src/test/perl/PostgreSQL/Test/Cluster.pm
@@ -107,6 +107,7 @@ use File::Temp ();
 use IPC::Run;
 use PostgreSQL::Version;
 use PostgreSQL::Test::RecursiveCopy;
+use PostgreSQL::Test::TdeCluster;
 use Socket;
 use Test::More;
 use PostgreSQL::Test::Utils          ();
@@ -1525,6 +1526,11 @@ sub new
 			carp
 			  "PostgreSQL::Test::Cluster isn't fully compatible with version $ver";
 		}
+	}
+
+	if ($ENV{TDE_MODE})
+	{
+		bless $node, 'PostgreSQL::Test::TdeCluster';
 	}
 
 	# Add node to list of nodes

--- a/src/test/perl/PostgreSQL/Test/TdeCluster.pm
+++ b/src/test/perl/PostgreSQL/Test/TdeCluster.pm
@@ -135,9 +135,17 @@ sub pg_tde_dir
 sub _tde_init_principal_key
 {
 	my ($self) = @_;
+	my $tde_template_dir;
 
-	my $tde_template_dir =
-	  $PostgreSQL::Test::Utils::tmp_check . '/pg_tde_template';
+	if (defined($ENV{TDE_TEMPLATE_DIR}))
+	{
+		$tde_template_dir = $ENV{TDE_TEMPLATE_DIR};
+	}
+	else
+	{
+		$tde_template_dir =
+		  $PostgreSQL::Test::Utils::tmp_check . '/pg_tde_template';
+	}
 
 	unless (-e $tde_template_dir)
 	{

--- a/src/test/perl/PostgreSQL/Test/TdeCluster.pm
+++ b/src/test/perl/PostgreSQL/Test/TdeCluster.pm
@@ -1,0 +1,120 @@
+package PostgreSQL::Test::TdeCluster;
+
+use parent 'PostgreSQL::Test::Cluster';
+
+use strict;
+use warnings FATAL => 'all';
+
+use List::Util                      ();
+use PostgreSQL::Test::RecursiveCopy ();
+use PostgreSQL::Test::Utils         ();
+
+our ($tde_template_dir);
+
+BEGIN
+{
+	$ENV{TDE_MODE_NOSKIP} = 0 unless defined($ENV{TDE_MODE_NOSKIP});
+}
+
+sub init
+{
+	my ($self, %params) = @_;
+
+	$self->SUPER::init(%params);
+
+	$self->SUPER::append_conf('postgresql.conf',
+		'shared_preload_libraries = pg_tde');
+
+	$self->_tde_init_principal_key;
+
+	return;
+}
+
+sub append_conf
+{
+	my ($self, $filename, $str) = @_;
+
+	if ($filename eq 'postgresql.conf' or $filename eq 'postgresql.auto.conf')
+	{
+		# TODO: Will not work with shared_preload_libraries= without any
+		#       libraries, but no TAP test currently do that.
+		$str =~
+		  s/shared_preload_libraries *= *'?([^'\n]+)'?/shared_preload_libraries = 'pg_tde,$1'/;
+	}
+
+	$self->SUPER::append_conf($filename, $str);
+}
+
+sub pg_tde_dir
+{
+	my ($self) = @_;
+	return $self->data_dir . '/pg_tde';
+}
+
+sub _tde_init_principal_key
+{
+	my ($self) = @_;
+
+	my $tde_template_dir =
+	  $PostgreSQL::Test::Utils::tmp_check . '/pg_tde_template';
+
+	unless (-e $tde_template_dir)
+	{
+		my $temp_dir = PostgreSQL::Test::Utils::tempdir();
+		mkdir $tde_template_dir;
+
+		PostgreSQL::Test::Utils::system_log(
+			'initdb',
+			'-D' => $temp_dir,
+			'--set' => 'shared_preload_libraries=pg_tde');
+
+		_tde_init_sql_command(
+			$temp_dir, 'postgres', qq(
+			CREATE EXTENSION pg_tde;
+			SELECT pg_tde_add_global_key_provider_file('global_test_provider', '$tde_template_dir/pg_tde_test_keys');
+			SELECT pg_tde_create_key_using_global_key_provider('default_test_key', 'global_test_provider');
+			SELECT pg_tde_set_default_key_using_global_key_provider('default_test_key', 'global_test_provider');
+		));
+
+		PostgreSQL::Test::Utils::system_log('cp', '-R', '-P', '-p',
+			$temp_dir . '/pg_tde',
+			$tde_template_dir);
+	}
+
+	PostgreSQL::Test::Utils::system_log('cp', '-R', '-P', '-p',
+		$tde_template_dir . '/pg_tde',
+		$self->pg_tde_dir);
+
+	# We don't want clusters sharing the KMS file as any concurrent writes will
+	# mess it up.
+	PostgreSQL::Test::Utils::system_log(
+		'cp', '-R', '-P', '-p',
+		$tde_template_dir . '/pg_tde_test_keys',
+		$self->basedir . '/pg_tde_test_keys');
+
+	PostgreSQL::Test::Utils::system_log(
+		'pg_tde_change_key_provider',
+		'-D' => $self->data_dir,
+		'1664',
+		'global_test_provider',
+		'file',
+		$self->basedir . '/pg_tde_test_keys');
+}
+
+sub _tde_init_sql_command
+{
+	my ($datadir, $database, $sql) = @_;
+	PostgreSQL::Test::Utils::run_log(
+		[
+			'postgres',
+			'--single', '-j', '-F',
+			'-D' => $datadir,
+			'-c' => 'exit_on_error=true',
+			'-c' => 'log_checkpoints=false',
+			$database,
+		],
+		'<',
+		\$sql);
+}
+
+1;

--- a/src/test/recovery/t/014_unlogged_reinit.pl
+++ b/src/test/recovery/t/014_unlogged_reinit.pl
@@ -12,6 +12,11 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => 'invalid page in block';
+}
+
 my $node = PostgreSQL::Test::Cluster->new('main');
 
 $node->init;

--- a/src/test/recovery/t/016_min_consistency.pl
+++ b/src/test/recovery/t/016_min_consistency.pl
@@ -13,6 +13,11 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => 'reads LSN directly from relation files';
+}
+
 # Find the largest LSN in the set of pages part of the given relation
 # file.  This is used for offline checks of page consistency.  The LSN
 # is historically stored as a set of two numbers of 4 byte-length

--- a/src/test/recovery/t/018_wal_optimize.pl
+++ b/src/test/recovery/t/018_wal_optimize.pl
@@ -16,6 +16,11 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => 'invalid page in block';
+}
+
 sub check_orphan_relfilenodes
 {
 	local $Test::Builder::Level = $Test::Builder::Level + 1;

--- a/src/test/recovery/t/020_archive_status.pl
+++ b/src/test/recovery/t/020_archive_status.pl
@@ -10,6 +10,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  q(Failed test 'pg_stat_archiver failed to archive 000000010000000000000004');
+}
+
 my $primary = PostgreSQL::Test::Cluster->new('primary');
 $primary->init(
 	has_archiving => 1,

--- a/src/test/recovery/t/027_stream_regress.pl
+++ b/src/test/recovery/t/027_stream_regress.pl
@@ -9,11 +9,6 @@ use PostgreSQL::Test::Utils;
 use Test::More;
 use File::Basename;
 
-if (defined($ENV{TDE_MODE}))
-{
-    plan skip_all => "Running with TDE doesn't support special server starts yet";
-}
-
 # Initialize primary node
 my $node_primary = PostgreSQL::Test::Cluster->new('primary');
 $node_primary->init(allows_streaming => 1);

--- a/src/test/recovery/t/032_relfilenode_reuse.pl
+++ b/src/test/recovery/t/032_relfilenode_reuse.pl
@@ -8,6 +8,10 @@ use PostgreSQL::Test::Utils;
 use Test::More;
 use File::Basename;
 
+if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => 'invalid page in block';
+}
 
 my $node_primary = PostgreSQL::Test::Cluster->new('primary');
 $node_primary->init(allows_streaming => 1);

--- a/src/test/recovery/t/039_end_of_wal.pl
+++ b/src/test/recovery/t/039_end_of_wal.pl
@@ -13,6 +13,11 @@ use Fcntl qw(SEEK_SET);
 
 use integer;    # causes / operator to use integer math
 
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => 'uses write_wal to hack wal directly';
+}
+
 # Is this a big-endian system ("network" byte order)?  We can't use 'Q' in
 # pack() calls because it's not available in some perl builds, so we need to
 # break 64 bit LSN values into two 'I' values.  Fortunately we don't need to

--- a/src/test/recovery/t/042_low_level_backup.pl
+++ b/src/test/recovery/t/042_low_level_backup.pl
@@ -13,6 +13,12 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all =>
+	  'directly copies archived data without using restore_command';
+}
+
 # Start primary node with archiving.
 my $node_primary = PostgreSQL::Test::Cluster->new('primary');
 $node_primary->init(has_archiving => 1, allows_streaming => 1);

--- a/src/test/recovery/t/043_no_contrecord_switch.pl
+++ b/src/test/recovery/t/043_no_contrecord_switch.pl
@@ -12,6 +12,11 @@ use Fcntl qw(SEEK_SET);
 
 use integer;    # causes / operator to use integer math
 
+if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
+{
+	plan skip_all => 'uses write_wal to hack wal directly';
+}
+
 # Values queried from the server
 my $WAL_SEGMENT_SIZE;
 my $WAL_BLOCK_SIZE;

--- a/src/test/regress/expected/create_am_1.out
+++ b/src/test/regress/expected/create_am_1.out
@@ -129,11 +129,11 @@ ERROR:  function int4in(internal) does not exist
 CREATE ACCESS METHOD bogus TYPE TABLE HANDLER bthandler;
 ERROR:  function bthandler must return type table_am_handler
 SELECT amname, amhandler, amtype FROM pg_am where amtype = 't' ORDER BY 1, 2;
-  amname  |      amhandler       | amtype 
-----------+----------------------+--------
- heap     | heap_tableam_handler | t
- heap2    | heap_tableam_handler | t
- tde_heap | pg_tdeam_handler     | t
+  amname  |        amhandler         | amtype 
+----------+--------------------------+--------
+ heap     | heap_tableam_handler     | t
+ heap2    | heap_tableam_handler     | t
+ tde_heap | _pg_tde.pg_tdeam_handler | t
 (3 rows)
 
 -- First create tables employing the new AM using USING

--- a/src/test/regress/expected/psql_1.out
+++ b/src/test/regress/expected/psql_1.out
@@ -5013,33 +5013,33 @@ List of access methods
 
 \dA: extra argument "bar" ignored
 \dA+
-                              List of access methods
-   Name   | Type  |       Handler        |              Description               
-----------+-------+----------------------+----------------------------------------
- brin     | Index | brinhandler          | block range index (BRIN) access method
- btree    | Index | bthandler            | b-tree index access method
- gin      | Index | ginhandler           | GIN index access method
- gist     | Index | gisthandler          | GiST index access method
- hash     | Index | hashhandler          | hash index access method
- heap     | Table | heap_tableam_handler | heap table access method
- heap2    | Table | heap_tableam_handler | 
- spgist   | Index | spghandler           | SP-GiST index access method
- tde_heap | Table | pg_tdeam_handler     | tde_heap table access method
+                                List of access methods
+   Name   | Type  |         Handler          |              Description               
+----------+-------+--------------------------+----------------------------------------
+ brin     | Index | brinhandler              | block range index (BRIN) access method
+ btree    | Index | bthandler                | b-tree index access method
+ gin      | Index | ginhandler               | GIN index access method
+ gist     | Index | gisthandler              | GiST index access method
+ hash     | Index | hashhandler              | hash index access method
+ heap     | Table | heap_tableam_handler     | heap table access method
+ heap2    | Table | heap_tableam_handler     | 
+ spgist   | Index | spghandler               | SP-GiST index access method
+ tde_heap | Table | _pg_tde.pg_tdeam_handler | tde_heap table access method
 (9 rows)
 
 \dA+ *
-                              List of access methods
-   Name   | Type  |       Handler        |              Description               
-----------+-------+----------------------+----------------------------------------
- brin     | Index | brinhandler          | block range index (BRIN) access method
- btree    | Index | bthandler            | b-tree index access method
- gin      | Index | ginhandler           | GIN index access method
- gist     | Index | gisthandler          | GiST index access method
- hash     | Index | hashhandler          | hash index access method
- heap     | Table | heap_tableam_handler | heap table access method
- heap2    | Table | heap_tableam_handler | 
- spgist   | Index | spghandler           | SP-GiST index access method
- tde_heap | Table | pg_tdeam_handler     | tde_heap table access method
+                                List of access methods
+   Name   | Type  |         Handler          |              Description               
+----------+-------+--------------------------+----------------------------------------
+ brin     | Index | brinhandler              | block range index (BRIN) access method
+ btree    | Index | bthandler                | b-tree index access method
+ gin      | Index | ginhandler               | GIN index access method
+ gist     | Index | gisthandler              | GiST index access method
+ hash     | Index | hashhandler              | hash index access method
+ heap     | Table | heap_tableam_handler     | heap table access method
+ heap2    | Table | heap_tableam_handler     | 
+ spgist   | Index | spghandler               | SP-GiST index access method
+ tde_heap | Table | _pg_tde.pg_tdeam_handler | tde_heap table access method
 (9 rows)
 
 \dA+ h*


### PR DESCRIPTION
This enables wal encryption and table encryption by default when running postgres TAP suite with `TDE_MODE=1`.

A few tests had to be skipped for various reasons, and some of these should most likely be looked into as they might be actual bugs or test setup issues we can fix.

Use `TDE_MODE=1` to enable pg_tde with both wal and relation encryption. Use `TDE_MODE_WAL=0` to disable wal encryption and `TDE_MODE_SMGR=0` to disable relation encryption.

For example to run the postgres suite with WAL encryption turned on, but not SMGR:
`TDE_MODE=1 TDE_MODE_SMGR=0 meson test --no-suite pg_tde` 

There is also `TDE_MODE_NOSKIP=1` which will force all tests to run. This is useful when investigating the test failures that made it necessary to skip some tests.