### PR TITLE
PG-1605 Fix encryption with old keys with disabled WAL encryption

### DIFF
--- a/contrib/pg_tde/t/2pc_replication.pl
+++ b/contrib/pg_tde/t/2pc_replication.pl
@@ -28,6 +28,9 @@ sub configure_and_reload
 	return;
 }
 
+unlink('/tmp/pg_global_keyring.file');
+unlink('/tmp/pg_local_keyring.file');
+
 # Set up two nodes, which will alternately be primary and replication standby.
 
 # Setup london node


### PR DESCRIPTION
To not break recovery when we replay encrypted WAL but WAL encryption is disabled the simplest way is to treat disabled WAL encryption just like enabled WAL encryption. The issue is not big in practice since it should only hit users who disable WAL encryption and then crash the database but treating both cases the same way makes the code simple to understand.
