### PR TITLE
Update WAL backup topic  regarding TAR not supporting `-X stream` when WAL encryption is enabled

### DIFF
--- a/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-archive-decrypt.md
+++ b/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-archive-decrypt.md
@@ -52,3 +52,8 @@ archive_command='pg_tde_archive_decrypt %f %p "cp %%p /mnt/server/archivedir/%%f
 ```ini
 archive_command='pg_tde_archive_decrypt %f %p "pgbackrest --stanza=your_stanza archive-push %%p"'
 ```
+
+!!! warning
+    When using PgBackRest with WAL encryption, disable PostgreSQL data checksums. 
+    Otherwise, PgBackRest may spam error messages, and in some package builds the 
+    log statement can cause crashes.

--- a/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-archive-decrypt.md
+++ b/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-archive-decrypt.md
@@ -54,6 +54,4 @@ archive_command='pg_tde_archive_decrypt %f %p "pgbackrest --stanza=your_stanza a
 ```
 
 !!! warning
-    When using PgBackRest with WAL encryption, disable PostgreSQL data checksums. 
-    Otherwise, PgBackRest may spam error messages, and in some package builds the 
-    log statement can cause crashes.
+    When using PgBackRest with WAL encryption, disable PostgreSQL data checksums. Otherwise, PgBackRest may spam error messages, and in some package builds the log statement can cause crashes.

--- a/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-archive-decrypt.md
+++ b/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-archive-decrypt.md
@@ -3,8 +3,7 @@
 The `pg_tde_archive_decrypt` tool wraps an archive command and decrypts WAL files before archiving. It allows external tools to access unencrypted WAL data, which is required because WAL encryption keys in the two-key hierarchy are host-specific and may not be available on the replay host.
 
 !!! tip
-
-    For more information on the encryption architecture and key hierarchy, see [Architecture](../architecture/architcture.md).
+    For more information on the encryption architecture and key hierarchy, see [Architecture](../architecture/architecture.md).
 
 This tool is often used in conjunction with [pg_tde_restore_encrypt](./pg-tde-restore-encrypt.md) to support WAL archive.
 

--- a/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-restore-encrypt.md
+++ b/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-restore-encrypt.md
@@ -49,6 +49,4 @@ restore_command='pg_tde_restore_encrypt %f %p "pgbackrest --stanza=your_stanza a
 ```
 
 !!! warning
-    When using PgBackRest with WAL encryption, disable PostgreSQL data checksums. 
-    Otherwise, PgBackRest may spam error messages, and in some package builds the 
-    log statement can cause crashes.
+    When using PgBackRest with WAL encryption, disable PostgreSQL data checksums. Otherwise, PgBackRest may spam error messages, and in some package builds the log statement can cause crashes.

--- a/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-restore-encrypt.md
+++ b/contrib/pg_tde/documentation/docs/command-line-tools/pg-tde-restore-encrypt.md
@@ -47,3 +47,8 @@ restore_command='pg_tde_restore_encrypt %f %p "cp /mnt/server/archivedir/%%f %%p
 ```ini
 restore_command='pg_tde_restore_encrypt %f %p "pgbackrest --stanza=your_stanza archive-get %%f \"%%p\""'
 ```
+
+!!! warning
+    When using PgBackRest with WAL encryption, disable PostgreSQL data checksums. 
+    Otherwise, PgBackRest may spam error messages, and in some package builds the 
+    log statement can cause crashes.

--- a/contrib/pg_tde/documentation/docs/how-to/backup-wal-enabled.md
+++ b/contrib/pg_tde/documentation/docs/how-to/backup-wal-enabled.md
@@ -28,6 +28,9 @@ When you want to restore a backup created with `pg_basebackup -E`:
 1. Ensure all external files referenced by your providers configuration (such as certificates or key files) are also present and accessible at the same relative paths.
 2. Start PostgreSQL with the restored data directory.
 
+!!! warning
+    When using `pgBackRest` with WAL encryption, disable checksums. Otherwise, `pgBackRest` may spam error messages, and in some package builds the log statement can cause crashes.
+
 ## Backup method compatibility with WAL encryption
 
 Tar format (`-F t`):

--- a/contrib/pg_tde/documentation/docs/how-to/backup-wal-enabled.md
+++ b/contrib/pg_tde/documentation/docs/how-to/backup-wal-enabled.md
@@ -28,9 +28,6 @@ When you want to restore a backup created with `pg_basebackup -E`:
 1. Ensure all external files referenced by your providers configuration (such as certificates or key files) are also present and accessible at the same relative paths.
 2. Start PostgreSQL with the restored data directory.
 
-!!! warning
-    When using `pgBackRest` with WAL encryption, disable checksums. Otherwise, `pgBackRest` may spam error messages, and in some package builds the log statement can cause crashes.
-
 ## Backup method compatibility with WAL encryption
 
 Tar format (`-F t`):


### PR DESCRIPTION
- renamed title, reorg content for easier scanning
- turned into note the `pg_tde/wal_keys` at the end