### PR TITLE
Fix possible _keys file loss during key rotation

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -297,10 +297,9 @@ pg_tde_perform_rotate_key(const TDEPrincipalKey *principal_key, const TDEPrincip
 	CloseTransientFile(new_fd);
 
 	/*
-	 * Do the final steps - replace the current _map with the file with new
+	 * Do the final step - replace the current _keys with the file with new
 	 * data
 	 */
-	durable_unlink(old_path, ERROR);
 	durable_rename(new_path, old_path, ERROR);
 
 	/*

--- a/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
@@ -718,10 +718,9 @@ pg_tde_perform_rotate_server_key(const TDEPrincipalKey *principal_key,
 	CloseTransientFile(new_fd);
 
 	/*
-	 * Do the final steps - replace the current WAL key file with the file
-	 * with new data.
+	 * Do the final step - replace the current WAL key file with the file with
+	 * new data.
 	 */
-	durable_unlink(get_wal_key_file_path(), ERROR);
 	durable_rename(tmp_path, get_wal_key_file_path(), ERROR);
 
 	/*


### PR DESCRIPTION
There is no reason to do durable_unlink before durable_rename. Rename can handle existing file. But with this sequence, the cluster may endup in unrecoverable state should server crash in-between this two ops, as there is going to be no "_keys" at all.
The current sequence may also cause an issue with backups: <durable_unlink>, <pg_basebackup gets a file list>, <durable_rename>. And no "_keys" file in the backup as the result.

Fixes: [PG-1896](https://perconadev.atlassian.net/browse/PG-1896)

[PG-1896]: https://perconadev.atlassian.net/browse/PG-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ