### PR TITLE
Fix XLogging of rotated key

### DIFF
--- a/contrib/pg_tde/src/access/pg_tde_tdemap.c
+++ b/contrib/pg_tde/src/access/pg_tde_tdemap.c
@@ -318,8 +318,8 @@ pg_tde_perform_rotate_key(const TDEPrincipalKey *principal_key, const TDEPrincip
 	{
 		XLogPrincipalKeyRotate xlrec;
 
-		xlrec.databaseId = principal_key->keyInfo.databaseId;
-		xlrec.keyringId = principal_key->keyInfo.keyringId;
+		xlrec.databaseId = new_principal_key->keyInfo.databaseId;
+		xlrec.keyringId = new_principal_key->keyInfo.keyringId;
 		memcpy(xlrec.keyName, new_principal_key->keyInfo.name, sizeof(new_principal_key->keyInfo.name));
 
 		XLogBeginInsert();

--- a/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
+++ b/contrib/pg_tde/src/access/pg_tde_xlog_keys.c
@@ -739,8 +739,8 @@ pg_tde_perform_rotate_server_key(const TDEPrincipalKey *principal_key,
 	{
 		XLogPrincipalKeyRotate xlrec;
 
-		xlrec.databaseId = principal_key->keyInfo.databaseId;
-		xlrec.keyringId = principal_key->keyInfo.keyringId;
+		xlrec.databaseId = new_principal_key->keyInfo.databaseId;
+		xlrec.keyringId = new_principal_key->keyInfo.keyringId;
 		memcpy(xlrec.keyName, new_principal_key->keyInfo.name, sizeof(new_principal_key->keyInfo.name));
 
 		XLogBeginInsert();


### PR DESCRIPTION
Before this commit, we XLogged the provider ID (keyringId) of the old key. Yet, we then attempt to fetch the new key from the old provider during the Redo, which obviously fails and crashes the recovery. So the next steps lead to the recovery stalemate:
- Create new provider (with new destination - mount_path, url etc).
- Create new server/global key.
- Rotate key.
- <Crash!>

This commit fixes it by Xlogging the new key's provider ID.

For: PG-1895