### PR TITLE
PG-1892 Use InternalKey for all decrypted keys, and only for decrypted keys

### DIFF
--- a/contrib/pg_tde/src/catalog/tde_principal_key.c
+++ b/contrib/pg_tde/src/catalog/tde_principal_key.c
@@ -812,7 +812,7 @@ pg_tde_delete_default_key(PG_FUNCTION_ARGS)
 	principal_key = GetPrincipalKeyNoDefault(GLOBAL_DATA_TDE_OID, LW_EXCLUSIVE);
 	if (pg_tde_is_same_principal_key(default_principal_key, principal_key))
 	{
-		if (pg_tde_count_wal_keys_in_file() != 0)
+		if (pg_tde_count_wal_ranges_in_file() != 0)
 			ereport(ERROR,
 					errcode(ERRCODE_OBJECT_IN_USE),
 					errmsg("cannot delete default principal key"),

--- a/contrib/pg_tde/src/include/access/pg_tde_keys_common.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_keys_common.h
@@ -3,9 +3,6 @@
 
 #include "catalog/tde_principal_key.h"
 
-#define INTERNAL_KEY_LEN 16
-#define INTERNAL_KEY_IV_LEN 16
-
 #define MAP_ENTRY_IV_SIZE 16
 #define MAP_ENTRY_AEAD_TAG_SIZE 16
 

--- a/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_tdemap.h
@@ -4,12 +4,7 @@
 #include "storage/relfilelocator.h"
 
 #include "access/pg_tde_keys_common.h"
-
-typedef struct InternalKey
-{
-	uint8		key[INTERNAL_KEY_LEN];
-	uint8		base_iv[INTERNAL_KEY_IV_LEN];
-} InternalKey;
+#include "encryption/enc_tde.h"
 
 extern void pg_tde_save_smgr_key(RelFileLocator rel, const InternalKey *key);
 extern bool pg_tde_has_smgr_key(RelFileLocator rel);

--- a/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
+++ b/contrib/pg_tde/src/include/access/pg_tde_xlog_keys.h
@@ -4,6 +4,7 @@
 #include "access/xlog_internal.h"
 
 #include "access/pg_tde_keys_common.h"
+#include "access/pg_tde_tdemap.h"
 
 typedef enum
 {

--- a/contrib/pg_tde/src/include/encryption/enc_tde.h
+++ b/contrib/pg_tde/src/include/encryption/enc_tde.h
@@ -5,7 +5,14 @@
 #ifndef ENC_TDE_H
 #define ENC_TDE_H
 
-#include "access/pg_tde_tdemap.h"
+#define INTERNAL_KEY_LEN 16
+#define INTERNAL_KEY_IV_LEN 16
+
+typedef struct InternalKey
+{
+	uint8		key[INTERNAL_KEY_LEN];
+	uint8		base_iv[INTERNAL_KEY_IV_LEN];
+} InternalKey;
 
 extern void pg_tde_generate_internal_key(InternalKey *int_key);
 extern void pg_tde_stream_crypt(const char *iv_prefix,


### PR DESCRIPTION
This PR does a few different things with the goal of using `InternalKey` for all decrypted keys (and only for decrypted keys) so that we can easily in the future switch them over to a secure allocator.

It reworks `WalEncryptionKey` to something that seems more appropriate for what it actually is and decouples both `InternalKey` and `WalEncryptionKey` from the file formats where the encrypted versions of them are saved as we now, with the GA, need to be much more conscious about any changes to the file formats.
