### PR TITLE
Add support for `--alow-group-access` in `TDE_MODE`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3475,7 +3475,7 @@ postgres --single -F -j -D "$TMP_DATA_DIR" postgres << SQL
 	SELECT pg_tde_set_default_key_using_global_key_provider('test_default_key', 'global_test_provider');
 SQL
 
-cp -RPp "$TMP_DATA_DIR/pg_tde" "$2/pg_tde"
+cp -RP "$TMP_DATA_DIR/pg_tde" "$2/pg_tde"
 rm -rf "$TMP_DATA_DIR"
 ''',
        'init_tde_files',

--- a/src/bin/pg_rewind/t/002_databases.pl
+++ b/src/bin/pg_rewind/t/002_databases.pl
@@ -11,12 +11,6 @@ use lib $FindBin::RealBin;
 
 use RewindTest;
 
-if ($ENV{TDE_MODE} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  "pg_combinebackup doesn't set filemodes of pg_tde/ correctly?";
-}
-
 sub run_test
 {
 	my $test_mode = shift;

--- a/src/test/perl/PostgreSQL/Test/TdeCluster.pm
+++ b/src/test/perl/PostgreSQL/Test/TdeCluster.pm
@@ -5,6 +5,7 @@ use parent 'PostgreSQL::Test::Cluster';
 use strict;
 use warnings FATAL => 'all';
 
+use File::stat;
 use List::Util                      ();
 use PostgreSQL::Test::RecursiveCopy ();
 use PostgreSQL::Test::Utils         ();
@@ -165,21 +166,26 @@ sub _tde_init_principal_key
 			SELECT pg_tde_set_default_key_using_global_key_provider('default_test_key', 'global_test_provider');
 		));
 
-		PostgreSQL::Test::Utils::system_log('cp', '-R', '-P', '-p',
+		PostgreSQL::Test::Utils::system_log('cp', '-R', '-P',
 			$temp_dir . '/pg_tde',
 			$tde_template_dir);
 	}
 
-	PostgreSQL::Test::Utils::system_log('cp', '-R', '-P', '-p',
+	my $stat = stat($self->data_dir);
+	my $oldmask = umask((~$stat->mode) & 0777);
+
+	PostgreSQL::Test::Utils::system_log('cp', '-R', '-P', '--no-preserve=mode',
 		$tde_template_dir . '/pg_tde',
 		$self->pg_tde_dir);
 
 	# We don't want clusters sharing the KMS file as any concurrent writes will
 	# mess it up.
 	PostgreSQL::Test::Utils::system_log(
-		'cp', '-R', '-P', '-p',
+		'cp', '-R', '-P', '--no-preserve=mode',
 		$tde_template_dir . '/pg_tde_test_keys',
 		$self->basedir . '/pg_tde_test_keys');
+
+	umask($oldmask);
 
 	PostgreSQL::Test::Utils::system_log(
 		'pg_tde_change_key_provider',


### PR DESCRIPTION
One of the pg_rewind tests were failing due to us not making sure to set the correct permissions when copying `pg_tde` into the data directory when setting to WAL encryption in `TDE_MODE`.

Also remove `-p` when copying the `pg_tde` directory since I do not see any point in preserving timestamps or owner and group.