### PR TITLE
Respect extra arguments to initdb in `TDE_MODE`

### DIFF
--- a/src/bin/pg_rewind/t/002_databases.pl
+++ b/src/bin/pg_rewind/t/002_databases.pl
@@ -11,12 +11,6 @@ use lib $FindBin::RealBin;
 
 use RewindTest;
 
-if ($ENV{TDE_MODE} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  "pg_combinebackup doesn't set filemodes of pg_tde/ correctly?";
-}
-
 sub run_test
 {
 	my $test_mode = shift;


### PR DESCRIPTION
Previously we ignored the extra arguments to `initdb` when initializing the `pg_tde` directory and just copied the `pg_tde` directory from a database initialized without the extra arguments, or if available from the cache.

Now make sure that when extra arguments are supplied that we do not use the cache and that we copy the `pg_tde` directory from database initialized with the extra arguments.

As far as I know this is only relevant to the `--allow-group-access` flag but we may as well make the solution generic.

Alternative to #562