### PR TITLE
PG-1895 Rewrite global providers during basebackup

### DIFF
--- a/src/bin/pg_basebackup/bbstreamer_file.c
+++ b/src/bin/pg_basebackup/bbstreamer_file.c
@@ -247,19 +247,18 @@ bbstreamer_extractor_content(bbstreamer *streamer, bbstreamer_member *member,
 #ifdef PERCONA_EXT
 				/* 
 				 * A streamed WAL is encrypted with the newly generated WAL key,
-				 * hence we have to prevent these files from rewriting.
+				 * hence we have to prevent wal_keys from rewriting.
 				 */
-				if (mystreamer->encryped_wal)
+				if (strcmp(member->pathname, "pg_tde/wal_keys") == 0)
 				{
-					if (strcmp(member->pathname, "pg_tde/wal_keys") == 0 ||
-						strcmp(member->pathname, "pg_tde/1664_providers") == 0)
+					if (mystreamer->encryped_wal)
 							break;
-				}
-				else if (strcmp(member->pathname, "pg_tde/wal_keys") == 0)
-				{
-					pg_log_warning("the source has WAL keys, but no WAL encryption configured for the target backups");
-					pg_log_warning_detail("This may lead to exposed data and broken backup.");
-					pg_log_warning_hint("Run pg_basebackup with -E to encrypt streamed WAL.");
+					else
+					{
+						pg_log_warning("the source has WAL keys, but no WAL encryption configured for the target backups");
+						pg_log_warning_detail("This may lead to exposed data and broken backup.");
+						pg_log_warning_hint("Run pg_basebackup with -E to encrypt streamed WAL.");
+					} 
 				}
 #endif
 				mystreamer->file =


### PR DESCRIPTION
Before this commit, we excluded 1664_providers from being rewritten during a backup, since this is one of the files that the user has to copy to the destination before the backup starts. It was done so the user can have different global providers and keys to encrypt backup's WAL than the source server. However, this raised several issues in case the server creates new providers or modifies existing ones during the backup. Then, those changes will be lost in the backup and data related to such providers might become unreadable, or redo might struggle to perform a rotation.

This commit treats 1664_providers as the rest of the files and makes provider changes safe during the backup.

We still don't rewrite wal_keys, as we generate a unique WAL key for the backup, and the server can't generate new WAL keys can't during the backup.

Fixes PG-1895