### PR TITLE
Disable archiving during `TDE_MODE_SMGR` setup

### DIFF
--- a/src/test/perl/PostgreSQL/Test/TdeCluster.pm
+++ b/src/test/perl/PostgreSQL/Test/TdeCluster.pm
@@ -200,6 +200,7 @@ sub _tde_init_sql_command
 			'-D' => $datadir,
 			'-c' => 'exit_on_error=true',
 			'-c' => 'log_checkpoints=false',
+			'-c' => 'archive_mode=off',
 			$database,
 		],
 		'<',

--- a/src/test/recovery/t/020_archive_status.pl
+++ b/src/test/recovery/t/020_archive_status.pl
@@ -10,12 +10,6 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  q(Failed test 'pg_stat_archiver failed to archive 000000010000000000000004');
-}
-
 my $primary = PostgreSQL::Test::Cluster->new('primary');
 $primary->init(
 	has_archiving => 1,


### PR DESCRIPTION
Archiving being enabled during the setup of the SMGR environment caused one of the test suites for WAL archiving to fail so we disable it while running queries in single-user mode.