### PR TITLE
Use Perl constructs instead of env variables for `TDE_MODE`

### DIFF
--- a/contrib/amcheck/t/001_verify_heapam.pl
+++ b/contrib/amcheck/t/001_verify_heapam.pl
@@ -9,10 +9,8 @@ use PostgreSQL::Test::Utils;
 
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => "hacks relation files directly for scaffolding";
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'hacks relation files directly for scaffolding';
 
 my ($node, $result);
 

--- a/src/bin/pg_amcheck/t/003_check.pl
+++ b/src/bin/pg_amcheck/t/003_check.pl
@@ -9,10 +9,8 @@ use PostgreSQL::Test::Utils;
 
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => "hacks relation files directly for scaffolding";
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'hacks relation files directly for scaffolding';
 
 my ($node, $port, %corrupt_page, %remove_relation);
 

--- a/src/bin/pg_amcheck/t/005_opclass_damage.pl
+++ b/src/bin/pg_amcheck/t/005_opclass_damage.pl
@@ -10,10 +10,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => 'investigate why this fails';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'investigate why this fails';
 
 my $node = PostgreSQL::Test::Cluster->new('test');
 $node->init;

--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -10,17 +10,11 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_wal
+	'pg_basebackup without -E from server with encrypted WAL produces broken backups';
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  'uses corrupt_page_checksum to directly hack relation files';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'uses corrupt_page_checksum to directly hack relation files';
 
 program_help_ok('pg_basebackup');
 program_version_ok('pg_basebackup');

--- a/src/bin/pg_checksums/t/002_actions.pl
+++ b/src/bin/pg_checksums/t/002_actions.pl
@@ -12,11 +12,8 @@ use PostgreSQL::Test::Utils;
 
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  'uses corrupt_page_checksum to directly hack relation files';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'uses corrupt_page_checksum to directly hack relation files';
 
 # Utility routine to create and check a table with corrupted checksums
 # on a wanted tablespace.  Note that this stops and starts the node

--- a/src/bin/pg_combinebackup/t/003_timeline.pl
+++ b/src/bin/pg_combinebackup/t/003_timeline.pl
@@ -10,11 +10,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_wal
+	'pg_basebackup without -E from server with encrypted WAL produces broken backups';
 
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_COMBINEBACKUP_MODE} || '--copy';

--- a/src/bin/pg_combinebackup/t/006_db_file_copy.pl
+++ b/src/bin/pg_combinebackup/t/006_db_file_copy.pl
@@ -7,11 +7,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_wal
+	'pg_basebackup without -E from server with encrypted WAL produces broken backups';
 
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_COMBINEBACKUP_MODE} || '--copy';

--- a/src/bin/pg_combinebackup/t/008_promote.pl
+++ b/src/bin/pg_combinebackup/t/008_promote.pl
@@ -10,11 +10,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_wal
+	'pg_basebackup without -E from server with encrypted WAL produces broken backups';
 
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_COMBINEBACKUP_MODE} || '--copy';

--- a/src/bin/pg_dump/t/004_pg_dump_parallel.pl
+++ b/src/bin/pg_dump/t/004_pg_dump_parallel.pl
@@ -8,11 +8,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  'pg_restore fail to restore _pg_tde schema on cluster which already has it';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'pg_restore fail to restore _pg_tde schema on cluster which already has it';
 
 my $dbname1 = 'regression_src';
 my $dbname2 = 'regression_dest1';

--- a/src/bin/pg_dump/t/010_dump_connstr.pl
+++ b/src/bin/pg_dump/t/010_dump_connstr.pl
@@ -8,11 +8,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  'pg_restore fail to restore _pg_tde schema on cluster which already has it';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'pg_restore fail to restore _pg_tde schema on cluster which already has it';
 
 if ($PostgreSQL::Test::Utils::is_msys2)
 {

--- a/src/bin/pg_rewind/t/001_basic.pl
+++ b/src/bin/pg_rewind/t/001_basic.pl
@@ -11,11 +11,8 @@ use lib $FindBin::RealBin;
 
 use RewindTest;
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  "copies WAL directly to archive without using archive_command";
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_wal
+	'copies WAL directly to archive without using archive_command';
 
 sub run_test
 {

--- a/src/bin/pg_upgrade/t/002_pg_upgrade.pl
+++ b/src/bin/pg_upgrade/t/002_pg_upgrade.pl
@@ -15,11 +15,8 @@ use PostgreSQL::Test::Utils;
 use PostgreSQL::Test::AdjustUpgrade;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  'pg_restore fail to restore _pg_tde schema on cluster which already has it';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	 'pg_restore fail to restore _pg_tde schema on cluster which already has it';
 
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_UPGRADE_MODE} || '--copy';

--- a/src/bin/pg_upgrade/t/003_logical_slots.pl
+++ b/src/bin/pg_upgrade/t/003_logical_slots.pl
@@ -11,11 +11,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  'pg_restore fail to restore _pg_tde schema on cluster which already has it';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'pg_restore fail to restore _pg_tde schema on cluster which already has it';
 
 # Can be changed to test the other modes
 my $mode = $ENV{PG_TEST_PG_UPGRADE_MODE} || '--copy';

--- a/src/bin/pg_upgrade/t/004_subscription.pl
+++ b/src/bin/pg_upgrade/t/004_subscription.pl
@@ -12,11 +12,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  'pg_restore fail to restore _pg_tde schema on cluster which already has it';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'pg_restore fail to restore _pg_tde schema on cluster which already has it';
 
 # Can be changed to test the other modes.
 my $mode = $ENV{PG_TEST_PG_UPGRADE_MODE} || '--copy';

--- a/src/bin/pg_verifybackup/t/009_extract.pl
+++ b/src/bin/pg_verifybackup/t/009_extract.pl
@@ -11,11 +11,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  "pg_basebackup without -E from server with encrypted WAL produces broken backups";
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_wal
+	'pg_basebackup without -E from server with encrypted WAL produces broken backups';
 
 my $primary = PostgreSQL::Test::Cluster->new('primary');
 $primary->init(allows_streaming => 1);

--- a/src/bin/pg_waldump/t/001_basic.pl
+++ b/src/bin/pg_waldump/t/001_basic.pl
@@ -7,10 +7,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => "pg_waldump needs extra options for encrypted WAL";
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_wal
+	'pg_waldump needs extra options for encrypted WAL';
 
 program_help_ok('pg_waldump');
 program_version_ok('pg_waldump');

--- a/src/bin/pg_waldump/t/002_save_fullpage.pl
+++ b/src/bin/pg_waldump/t/002_save_fullpage.pl
@@ -9,10 +9,8 @@ use PostgreSQL::Test::RecursiveCopy;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => "pg_waldump needs extra options for encrypted WAL";
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_wal
+	'pg_waldump needs extra options for encrypted WAL';
 
 my ($blocksize, $walfile_name);
 

--- a/src/bin/scripts/t/020_createdb.pl
+++ b/src/bin/scripts/t/020_createdb.pl
@@ -8,11 +8,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  'tries to use FILE_COPY strategy for database creation with encrypted objects in the template';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'tries to use FILE_COPY strategy for database creation with encrypted objects in the template';
 
 program_help_ok('createdb');
 program_version_ok('createdb');

--- a/src/test/perl/PostgreSQL/Test/Cluster.pm
+++ b/src/test/perl/PostgreSQL/Test/Cluster.pm
@@ -1528,7 +1528,7 @@ sub new
 		}
 	}
 
-	if ($ENV{TDE_MODE})
+	if ($PostgreSQL::Test::TdeCluster::tde_mode)
 	{
 		bless $node, 'PostgreSQL::Test::TdeCluster';
 	}

--- a/src/test/recovery/t/014_unlogged_reinit.pl
+++ b/src/test/recovery/t/014_unlogged_reinit.pl
@@ -12,10 +12,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => 'invalid page in block';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'invalid page in block';
 
 my $node = PostgreSQL::Test::Cluster->new('main');
 

--- a/src/test/recovery/t/016_min_consistency.pl
+++ b/src/test/recovery/t/016_min_consistency.pl
@@ -13,10 +13,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => 'reads LSN directly from relation files';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'reads LSN directly from relation files';
 
 # Find the largest LSN in the set of pages part of the given relation
 # file.  This is used for offline checks of page consistency.  The LSN

--- a/src/test/recovery/t/018_wal_optimize.pl
+++ b/src/test/recovery/t/018_wal_optimize.pl
@@ -16,10 +16,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => 'invalid page in block';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'invalid page in block';
 
 sub check_orphan_relfilenodes
 {

--- a/src/test/recovery/t/032_relfilenode_reuse.pl
+++ b/src/test/recovery/t/032_relfilenode_reuse.pl
@@ -8,10 +8,8 @@ use PostgreSQL::Test::Utils;
 use Test::More;
 use File::Basename;
 
-if ($ENV{TDE_MODE_SMGR} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => 'invalid page in block';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'invalid page in block';
 
 my $node_primary = PostgreSQL::Test::Cluster->new('primary');
 $node_primary->init(allows_streaming => 1);

--- a/src/test/recovery/t/039_end_of_wal.pl
+++ b/src/test/recovery/t/039_end_of_wal.pl
@@ -13,10 +13,8 @@ use Fcntl qw(SEEK_SET);
 
 use integer;    # causes / operator to use integer math
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => 'uses write_wal to hack wal directly';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_wal
+	'uses write_wal to hack wal directly';
 
 # Is this a big-endian system ("network" byte order)?  We can't use 'Q' in
 # pack() calls because it's not available in some perl builds, so we need to

--- a/src/test/recovery/t/042_low_level_backup.pl
+++ b/src/test/recovery/t/042_low_level_backup.pl
@@ -13,11 +13,8 @@ use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all =>
-	  'directly copies archived data without using restore_command';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_wal
+	'directly copies archived data without using restore_command';
 
 # Start primary node with archiving.
 my $node_primary = PostgreSQL::Test::Cluster->new('primary');

--- a/src/test/recovery/t/043_no_contrecord_switch.pl
+++ b/src/test/recovery/t/043_no_contrecord_switch.pl
@@ -12,10 +12,8 @@ use Fcntl qw(SEEK_SET);
 
 use integer;    # causes / operator to use integer math
 
-if ($ENV{TDE_MODE_WAL} and not $ENV{TDE_MODE_NOSKIP})
-{
-	plan skip_all => 'uses write_wal to hack wal directly';
-}
+PostgreSQL::Test::TdeCluster::skip_if_tde_mode_smgr
+	'uses write_wal to hack wal directly';
 
 # Values queried from the server
 my $WAL_SEGMENT_SIZE;


### PR DESCRIPTION
Exposing and setting the environment variables everywhere makes it harder to refactor and to understand what is going on. Instead we can just write a couple of helper functions and use Perl scalar variables.