### PR TITLE
Add some simple tests for the archive and restore command

### DIFF
--- a/contrib/pg_tde/t/pg_tde_change_key_provider.pl
+++ b/contrib/pg_tde/t/pg_tde_change_key_provider.pl
@@ -6,6 +6,14 @@ use Test::More;
 
 use JSON;
 
+command_like([ 'pg_tde_change_key_provider', '--help' ],
+	qr/Usage:/, 'displays help');
+
+command_like(
+	[ 'pg_tde_change_key_provider', '--version' ],
+	qr/pg_tde_change_key_provider \(PostgreSQL\) /,
+	'displays version');
+
 my $node = PostgreSQL::Test::Cluster->new('main');
 $node->init;
 $node->append_conf('postgresql.conf', q{shared_preload_libraries = 'pg_tde'});


### PR DESCRIPTION
These error paths are annoying to test with the whole setup so we call the CLI tools directly. Plus add a couple of tests for the `--help` argument.