### PR TITLE
Update codechecker to 6.26.1

### DIFF
--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -20,19 +20,13 @@ jobs:
         with:
           submodules: recursive
 
-      # CodeChecker doesn't support python 3.12 for now: https://github.com/Ericsson/codechecker/issues/4350
-      - name: Downgrade python to 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11
-
       - name: Install dependencies
         run: ci_scripts/ubuntu-deps.sh
 
       - name: Install CodeChecker
         run: |
           ## CodeChecker version should match version installed on server side.
-          pip3 install codechecker==6.21
+          pip3 install codechecker==6.26.1
 
       - name: Configure CodeChecker
         run: |


### PR DESCRIPTION
Codechecker was updated on server side, so we have to update it in CI as well.

Test workflow run: https://github.com/percona/postgres/actions/runs/17446631286/job/49632658600
Test report: https://codechecker.percona.com/pg_tde/reports?review-status=Unreviewed&review-status=Confirmed%20bug&detection-status=New&detection-status=Reopened&detection-status=Unresolved&run=575%2Fmerge