### PR TITLE
Clean up `.gitignore` for pg_tde

### DIFF
--- a/contrib/pg_tde/.gitignore
+++ b/contrib/pg_tde/.gitignore
@@ -1,21 +1,16 @@
-*.so
-*.o
 *.frontend
 __pycache__
-.vscode
 
-/autom4te.cache
-/config.cache
-/config.log
-/config.status
-/configure~
-/log
-/results
+# Generated subdirectories
+/log/
+/results/
+/t/results/
+/tmp_check/
+
+# Binaries
 /src/bin/pg_tde_archive_decrypt
 /src/bin/pg_tde_change_key_provider
 /src/bin/pg_tde_restore_encrypt
-/t/results
-/tmp_check
 
 # Tool files
 /typedefs-full.list


### PR DESCRIPTION
This is an attempt at making the file more similar to the other contrib extensions' `.gitignore` files.

- Remove ignore of editor specific files
- Sort ignores into groups
- Remove things already ignore by the root `.gitignore`
- Remove legacy autoconf ignores