### PR TITLE
PG-1879 Clean up makefile before repo split

### DIFF
--- a/ci_scripts/make-build.sh
+++ b/ci_scripts/make-build.sh
@@ -44,4 +44,4 @@ case "$1" in
 esac
 
 ./configure --prefix="$INSTALL_DIR" --enable-debug --enable-tap-tests $ARGS 
-make install-world -j
+make install-world -j -s

--- a/contrib/pg_tde/Makefile
+++ b/contrib/pg_tde/Makefile
@@ -80,17 +80,19 @@ include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
 SHLIB_LINK = -lcurl -lcrypto -lssl
+LDFLAGS_EX = -L$(top_builddir)/src/fe_utils
+PG_LIBS = -lcurl -lcrypto -lssl -lpgfeutils
 
 $(KMIP_OBJS): CFLAGS += '-w' # This is a 3rd party, disable warnings completely
 
-src/bin/pg_tde_change_key_provider: src/bin/pg_tde_change_key_provider.o $(top_srcdir)/src/fe_utils/simple_list.o $(top_builddir)/src/libtde/libtde.a
-	$(CC) -DFRONTEND $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
+src/bin/pg_tde_change_key_provider: src/bin/pg_tde_change_key_provider.o $(top_builddir)/src/libtde/libtde.a | submake-libpgfeutils
+	$(CC) -DFRONTEND $(CFLAGS) $^ $(PG_LIBS_INTERNAL) $(LDFLAGS) $(LDFLAGS_EX) $(PG_LIBS) $(LIBS) -o $@$(X)
 
-src/bin/pg_tde_archive_decrypt: src/bin/pg_tde_archive_decrypt.o xlogreader.o $(top_srcdir)/src/fe_utils/simple_list.o $(top_builddir)/src/libtde/libtdexlog.a $(top_builddir)/src/libtde/libtde.a
-	$(CC) -DFRONTEND $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
+src/bin/pg_tde_archive_decrypt: src/bin/pg_tde_archive_decrypt.o xlogreader.o $(top_builddir)/src/libtde/libtdexlog.a $(top_builddir)/src/libtde/libtde.a | submake-libpgfeutils
+	$(CC) -DFRONTEND $(CFLAGS) $^ $(PG_LIBS_INTERNAL) $(LDFLAGS) $(LDFLAGS_EX) $(PG_LIBS) $(LIBS) -o $@$(X)
 
-src/bin/pg_tde_restore_encrypt: src/bin/pg_tde_restore_encrypt.o xlogreader.o $(top_srcdir)/src/fe_utils/simple_list.o $(top_builddir)/src/libtde/libtdexlog.a $(top_builddir)/src/libtde/libtde.a
-	$(CC) -DFRONTEND $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
+src/bin/pg_tde_restore_encrypt: src/bin/pg_tde_restore_encrypt.o xlogreader.o $(top_builddir)/src/libtde/libtdexlog.a $(top_builddir)/src/libtde/libtde.a | submake-libpgfeutils
+	$(CC) -DFRONTEND $(CFLAGS) $^ $(PG_LIBS_INTERNAL) $(LDFLAGS) $(LDFLAGS_EX) $(PG_LIBS) $(LIBS) -o $@$(X)
 
 xlogreader.c: % : $(top_srcdir)/src/backend/access/transam/%
 	rm -f $@ && $(LN_S) $< .

--- a/contrib/pg_tde/Makefile
+++ b/contrib/pg_tde/Makefile
@@ -86,13 +86,13 @@ PG_LIBS = -lcurl -lcrypto -lssl -lpgfeutils
 $(KMIP_OBJS): CFLAGS += '-w' # This is a 3rd party, disable warnings completely
 
 src/bin/pg_tde_change_key_provider: src/bin/pg_tde_change_key_provider.o $(top_builddir)/src/libtde/libtde.a | submake-libpgfeutils
-	$(CC) -DFRONTEND $(CFLAGS) $^ $(PG_LIBS_INTERNAL) $(LDFLAGS) $(LDFLAGS_EX) $(PG_LIBS) $(LIBS) -o $@$(X)
+	$(CC) $(CFLAGS) $^ $(PG_LIBS_INTERNAL) $(LDFLAGS) $(LDFLAGS_EX) $(PG_LIBS) $(LIBS) -o $@$(X)
 
 src/bin/pg_tde_archive_decrypt: src/bin/pg_tde_archive_decrypt.o xlogreader.o $(top_builddir)/src/libtde/libtdexlog.a $(top_builddir)/src/libtde/libtde.a | submake-libpgfeutils
-	$(CC) -DFRONTEND $(CFLAGS) $^ $(PG_LIBS_INTERNAL) $(LDFLAGS) $(LDFLAGS_EX) $(PG_LIBS) $(LIBS) -o $@$(X)
+	$(CC) $(CFLAGS) $^ $(PG_LIBS_INTERNAL) $(LDFLAGS) $(LDFLAGS_EX) $(PG_LIBS) $(LIBS) -o $@$(X)
 
 src/bin/pg_tde_restore_encrypt: src/bin/pg_tde_restore_encrypt.o xlogreader.o $(top_builddir)/src/libtde/libtdexlog.a $(top_builddir)/src/libtde/libtde.a | submake-libpgfeutils
-	$(CC) -DFRONTEND $(CFLAGS) $^ $(PG_LIBS_INTERNAL) $(LDFLAGS) $(LDFLAGS_EX) $(PG_LIBS) $(LIBS) -o $@$(X)
+	$(CC) $(CFLAGS) $^ $(PG_LIBS_INTERNAL) $(LDFLAGS) $(LDFLAGS_EX) $(PG_LIBS) $(LIBS) -o $@$(X)
 
 xlogreader.c: % : $(top_srcdir)/src/backend/access/transam/%
 	rm -f $@ && $(LN_S) $< .

--- a/contrib/pg_tde/Makefile
+++ b/contrib/pg_tde/Makefile
@@ -27,6 +27,12 @@ version
 TAP_TESTS = 1
 endif
 
+KMIP_OBJS = \
+src/libkmip/libkmip/src/kmip.o \
+src/libkmip/libkmip/src/kmip_bio.o \
+src/libkmip/libkmip/src/kmip_locate.o \
+src/libkmip/libkmip/src/kmip_memset.o
+
 OBJS = src/encryption/enc_tde.o \
 src/encryption/enc_aes.o \
 src/access/pg_tde_tdemap.o \
@@ -47,10 +53,7 @@ src/smgr/pg_tde_smgr.o \
 src/pg_tde_event_capture.o \
 src/pg_tde_guc.o \
 src/pg_tde.o \
-src/libkmip/libkmip/src/kmip.o \
-src/libkmip/libkmip/src/kmip_bio.o \
-src/libkmip/libkmip/src/kmip_locate.o \
-src/libkmip/libkmip/src/kmip_memset.o
+$(KMIP_OBJS)
 
 SCRIPTS_built = src/bin/pg_tde_archive_decrypt \
 src/bin/pg_tde_change_key_provider \
@@ -77,6 +80,8 @@ include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
 override SHLIB_LINK += -lcurl -lcrypto -lssl
+
+$(KMIP_OBJS): CFLAGS += '-w' # This is a 3rd party, disable warnings completely
 
 src/bin/pg_tde_change_key_provider: src/bin/pg_tde_change_key_provider.o $(top_srcdir)/src/fe_utils/simple_list.o $(top_builddir)/src/libtde/libtde.a
 	$(CC) -DFRONTEND $(CFLAGS) $^ $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)

--- a/contrib/pg_tde/Makefile
+++ b/contrib/pg_tde/Makefile
@@ -59,8 +59,8 @@ SCRIPTS_built = src/bin/pg_tde_archive_decrypt \
 src/bin/pg_tde_change_key_provider \
 src/bin/pg_tde_restore_encrypt
 
-EXTRA_INSTALL += contrib/pg_buffercache contrib/test_decoding
-EXTRA_CLEAN += src/bin/pg_tde_archive_decrypt.o \
+EXTRA_INSTALL = contrib/pg_buffercache contrib/test_decoding
+EXTRA_CLEAN = src/bin/pg_tde_archive_decrypt.o \
 src/bin/pg_tde_change_key_provider.o \
 src/bin/pg_tde_restore_encrypt.o \
 xlogreader.c \
@@ -69,17 +69,17 @@ xlogreader.o
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
-override PG_CPPFLAGS += -I$(CURDIR)/src/include -I$(CURDIR)/src/libkmip/libkmip/include
+PG_CPPFLAGS = -I$(CURDIR)/src/include -I$(CURDIR)/src/libkmip/libkmip/include
 include $(PGXS)
 else
 subdir = contrib/pg_tde
 top_builddir = ../..
-override PG_CPPFLAGS += -I$(top_srcdir)/$(subdir)/src/include  -I$(top_srcdir)/$(subdir)/src/libkmip/libkmip/include
+PG_CPPFLAGS = -I$(top_srcdir)/$(subdir)/src/include -I$(top_srcdir)/$(subdir)/src/libkmip/libkmip/include
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-override SHLIB_LINK += -lcurl -lcrypto -lssl
+SHLIB_LINK = -lcurl -lcrypto -lssl
 
 $(KMIP_OBJS): CFLAGS += '-w' # This is a 3rd party, disable warnings completely
 


### PR DESCRIPTION
Various clean ups of the makefile to make it easier to turn `pg_tde` into an external extensions.

- Remove noise with `override` and `+=`
- Silence warnings when building `libkmip`
- Use `libpgfeutils.a` when building command line tools
- Silence building PostgreSQL in the CI