### PR TITLE
pg_tde: harden archive/restore helpers to clean up tmpfs on failure

### DIFF
--- a/contrib/pg_tde/src/bin/pg_tde_archive_decrypt.c
+++ b/contrib/pg_tde/src/bin/pg_tde_archive_decrypt.c
@@ -8,7 +8,50 @@
 #include "access/pg_tde_fe_init.h"
 #include "access/pg_tde_xlog_smgr.h"
 
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <signal.h>
+
 #define TMPFS_DIRECTORY "/dev/shm"
+
+static char g_tmpdir[MAXPGPATH] = "";
+static char g_tmppath[MAXPGPATH] = "";
+
+static void
+cleanup_tmp(void)
+{
+	if (g_tmppath[0] != '\0')
+	{
+		if (unlink(g_tmppath) < 0)
+			pg_log_warning("could not remove file \"%s\": %m", g_tmppath);
+		g_tmppath[0] = '\0';
+	}
+	if (g_tmpdir[0] != '\0')
+	{
+		if (rmdir(g_tmpdir) < 0)
+			pg_log_warning("could not remove directory \"%s\": %m", g_tmpdir);
+		g_tmpdir[0] = '\0';
+	}
+}
+
+static void
+signal_cleanup_and_exit(int sig)
+{
+	cleanup_tmp();
+	_exit(128 + sig);
+}
+
+static bool
+check_free_space_sufficient_bytes(const char *path, uint64 requiredBytes, uint64 *freeBytesOut)
+{
+	struct statvfs vfs;
+	if (statvfs(path, &vfs) != 0)
+		return false;
+	uint64 freeBytes = (uint64) vfs.f_bavail * (uint64) vfs.f_frsize;
+	if (freeBytesOut)
+		*freeBytesOut = freeBytes;
+	return freeBytes >= requiredBytes;
+}
 
 static bool
 is_segment(const char *filename)
@@ -191,6 +234,53 @@ main(int argc, char *argv[])
 	if (issegment)
 	{
 		char	   *s;
+		struct stat st;
+		uint64 requiredBytes = 0;
+		uint64 freeBytes = 0;
+
+		/*
+		 * Estimate how much tmpfs space we need to hold the decrypted WAL file.
+		 *
+		 * Preferred path: use the size of the encrypted source file. For full
+		 * segments this equals the WAL segment size (e.g., 16MB, 64MB). For
+		 * partial segments it will be smaller, which is fine because we only
+		 * decrypt and write as many bytes as exist in the source.
+		 */
+		if (stat(sourcepath, &st) == 0 && S_ISREG(st.st_mode))
+			requiredBytes = (uint64) st.st_size;
+		else
+		{
+			/*
+			 * Fallback when stat fails or source is not a regular file: assume at
+			 * least one WAL block (XLOG_BLCKSZ, typically 16KB). This case is not
+			 * expected in normal operation, but avoids a zero-size estimate.
+			 */
+			requiredBytes = (uint64) XLOG_BLCKSZ;
+		}
+
+		/*
+		 * Add a fixed safety margin (4MB).
+		 *
+		 * Rationale:
+		 * - Provides headroom for directory entries, filesystem metadata and
+		 *   small helper buffers so we don't hit ENOSPC mid-write.
+		 * - Covers minor discrepancies (e.g., trailing partial page, alignment).
+		 * - When the base is a full segment (commonly 16MB), 4MB is a small
+		 *   relative slack (25%). When the base comes from the minimal fallback
+		 *   (16KB), the large relative slack is intentional: the fallback is used
+		 *   only when we cannot size the source, and in practice WAL segments are
+		 *   much larger than 16KB. The extra headroom errs on the side of
+		 *   failing fast rather than starting a write that will soon exhaust
+		 *   tmpfs.
+		 */
+		requiredBytes += (uint64) (4 * 1024 * 1024);
+
+		if (!check_free_space_sufficient_bytes(TMPFS_DIRECTORY, requiredBytes, &freeBytes))
+		{
+			pg_log_error("insufficient temporary space in '%s' for decrypted WAL (required: %llu bytes, free: %llu bytes)",
+					 TMPFS_DIRECTORY, (unsigned long long) requiredBytes, (unsigned long long) freeBytes);
+			exit(1);
+		}
 
 		if (mkdtemp(tmpdir) == NULL)
 			pg_fatal("could not create temporary directory \"%s\": %m", tmpdir);
@@ -198,6 +288,13 @@ main(int argc, char *argv[])
 		s = stpcpy(tmppath, tmpdir);
 		s = stpcpy(s, "/");
 		stpcpy(s, sourcename);
+
+		/* register for cleanup on exit and on signals */
+		snprintf(g_tmpdir, sizeof(g_tmpdir), "%s", tmpdir);
+		snprintf(g_tmppath, sizeof(g_tmppath), "%s", tmppath);
+		atexit(cleanup_tmp);
+		signal(SIGINT, signal_cleanup_and_exit);
+		signal(SIGTERM, signal_cleanup_and_exit);
 
 		command = replace_percent_placeholders(command,
 											   "ARCHIVE-COMMAND", "fp",
@@ -228,13 +325,7 @@ main(int argc, char *argv[])
 
 	free(command);
 
-	if (issegment)
-	{
-		if (unlink(tmppath) < 0)
-			pg_log_warning("could not remove file \"%s\": %m", tmppath);
-		if (rmdir(tmpdir) < 0)
-			pg_log_warning("could not remove directory \"%s\": %m", tmpdir);
-	}
+	/* No explicit cleanup here; atexit(cleanup_tmp) handles normal process exit. */
 
 	return 0;
 }

--- a/contrib/pg_tde/src/bin/pg_tde_restore_encrypt.c
+++ b/contrib/pg_tde/src/bin/pg_tde_restore_encrypt.c
@@ -8,7 +8,95 @@
 #include "access/pg_tde_fe_init.h"
 #include "access/pg_tde_xlog_smgr.h"
 
+#include "catalog/pg_control.h"
+
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <signal.h>
+
 #define TMPFS_DIRECTORY "/dev/shm"
+
+static char g_tmpdir[MAXPGPATH] = "";
+static char g_tmppath[MAXPGPATH] = "";
+
+static void
+cleanup_tmp(void)
+{
+	if (g_tmppath[0] != '\0')
+	{
+		if (unlink(g_tmppath) < 0)
+			pg_log_warning("could not remove file \"%s\": %m", g_tmppath);
+		g_tmppath[0] = '\0';
+	}
+	if (g_tmpdir[0] != '\0')
+	{
+		if (rmdir(g_tmpdir) < 0)
+			pg_log_warning("could not remove directory \"%s\": %m", g_tmpdir);
+		g_tmpdir[0] = '\0';
+	}
+}
+
+static void
+signal_cleanup_and_exit(int sig)
+{
+	cleanup_tmp();
+	_exit(128 + sig);
+}
+
+static bool
+check_free_space_sufficient_bytes(const char *path, uint64 requiredBytes, uint64 *freeBytesOut)
+{
+	struct statvfs vfs;
+	if (statvfs(path, &vfs) != 0)
+		return false;
+	uint64 freeBytes = (uint64) vfs.f_bavail * (uint64) vfs.f_frsize;
+	if (freeBytesOut)
+		*freeBytesOut = freeBytes;
+	return freeBytes >= requiredBytes;
+}
+
+/* Try to derive data directory by stripping "/pg_wal/..." from the target path. */
+static bool
+get_data_dir_from_targetpath(const char *targetpath, char *dataDirOut, size_t outLen)
+{
+    const char *needle = "/" XLOGDIR "/"; /* "/pg_wal/" */
+    const char *pos = strstr(targetpath, needle);
+    if (pos == NULL)
+        return false;
+    size_t dirLen = (size_t) (pos - targetpath);
+    if (dirLen == 0 || dirLen >= outLen)
+        return false;
+    memcpy(dataDirOut, targetpath, dirLen);
+    dataDirOut[dirLen] = '\0';
+    return true;
+}
+
+/* Read xlog_seg_size from pg_control in the given data directory. */
+static bool
+read_wal_segment_size_from_control(const char *dataDir, uint32 *segSizeOut)
+{
+    char controlPath[MAXPGPATH];
+    int fd;
+    char buffer[PG_CONTROL_FILE_SIZE];
+    ControlFileData ControlFile;
+
+    snprintf(controlPath, sizeof(controlPath), "%s/%s", dataDir, XLOG_CONTROL_FILE);
+    fd = open(controlPath, O_RDONLY | PG_BINARY, 0);
+    if (fd < 0)
+        return false;
+    if (read(fd, buffer, PG_CONTROL_FILE_SIZE) != PG_CONTROL_FILE_SIZE)
+    {
+        close(fd);
+        return false;
+    }
+    close(fd);
+
+    memcpy(&ControlFile, buffer, sizeof(ControlFileData));
+    if (!IsValidWalSegSize(ControlFile.xlog_seg_size))
+        return false;
+    *segSizeOut = ControlFile.xlog_seg_size;
+    return true;
+}
 
 /*
  * Partial WAL segments are archived but never automatically fetched from the
@@ -186,6 +274,43 @@ main(int argc, char *argv[])
 	if (issegment)
 	{
 		char	   *s;
+		uint64 requiredBytes = 0;
+		uint64 freeBytes = 0;
+
+		/*
+		 * Estimate tmpfs space for the unencrypted file the restore command will
+		 * write. Prefer an accurate value from the cluster's control file
+		 * (xlog_seg_size). If we cannot determine it, fall back to 16MB.
+		 */
+		{
+			/*
+			 * Note: restore_command may be invoked repeatedly (one process per
+			 * segment, with retries on failure). Reading pg_control here is an
+			 * ~8KB I/O that will be page-cache hot after the first call and is
+			 * negligible compared to downloading the WAL from a remote repository
+			 * (e.g., S3 via pgBackRest) or reading it from a local archive, and the
+			 * subsequent encrypt/write. We read pg_control rather than a WAL header
+			 * because we must know the exact segment size before starting the wrapped
+			 * restore to preflight /dev/shm capacity and avoid mid-write ENOSPC.
+			 * Reading the WAL header would happen too late for that purpose.
+			 */
+			char dataDir[MAXPGPATH];
+			uint32 segsz = 0;
+			if (get_data_dir_from_targetpath(targetpath, dataDir, sizeof(dataDir)) &&
+				read_wal_segment_size_from_control(dataDir, &segsz))
+				requiredBytes = (uint64) segsz;
+			else
+				requiredBytes = (uint64) (16 * 1024 * 1024);
+		}
+		/* Fixed 4MB slack; see pg_tde_archive_decrypt.c for detailed rationale. */
+		requiredBytes += (uint64) (4 * 1024 * 1024);
+
+		if (!check_free_space_sufficient_bytes(TMPFS_DIRECTORY, requiredBytes, &freeBytes))
+		{
+			pg_log_error("insufficient temporary space in '%s' for restored WAL (required: %llu bytes, free: %llu bytes)",
+					 TMPFS_DIRECTORY, (unsigned long long) requiredBytes, (unsigned long long) freeBytes);
+			exit(1);
+		}
 
 		if (mkdtemp(tmpdir) == NULL)
 			pg_fatal("could not create temporary directory \"%s\": %m", tmpdir);
@@ -193,6 +318,13 @@ main(int argc, char *argv[])
 		s = stpcpy(tmppath, tmpdir);
 		s = stpcpy(s, "/");
 		stpcpy(s, targetname);
+
+		/* register for cleanup */
+		snprintf(g_tmpdir, sizeof(g_tmpdir), "%s", tmpdir);
+		snprintf(g_tmppath, sizeof(g_tmppath), "%s", tmppath);
+		atexit(cleanup_tmp);
+		signal(SIGINT, signal_cleanup_and_exit);
+		signal(SIGTERM, signal_cleanup_and_exit);
 
 		command = replace_percent_placeholders(command,
 											   "RESTORE-COMMAND", "fp",
@@ -224,11 +356,7 @@ main(int argc, char *argv[])
 	if (issegment)
 	{
 		write_encrypted_segment(targetpath, sourcename, tmppath);
-
-		if (unlink(tmppath) < 0)
-			pg_log_warning("could not remove file \"%s\": %m", tmppath);
-		if (rmdir(tmpdir) < 0)
-			pg_log_warning("could not remove directory \"%s\": %m", tmpdir);
+		/* No explicit cleanup here; atexit(cleanup_tmp) handles normal process exit. */
 	}
 
 	return 0;


### PR DESCRIPTION
The pg_tde helper binaries decrypt/reencrypt WAL via a temporary file under TMPFS_DIRECTORY (/dev/shm). On very low‑memory systems this tmpfs can fill, and previous behavior left temporary files/directories behind on failures or abrupt termination, compounding ENOSPC and retries.

Changes:
- Always remove the temporary file and directory on normal exit and on
  SIGINT/SIGTERM (atexit() + signal handlers).
- Check the tmpfs dir capacity before creating the temp file. The temp file size is taken to be:
  * In archive (`pg_tde_restore_encrypt.c`): size = encrypted source file size + 4MB slack.
  * In restore (`pg_tde_archive_decrypt.c`): read xlog_seg_size from pg_control (derived from DEST-PATH
    data dir); fallback to 16MB if unavailable + 4MB slack.
  * If the check fails due to insufficient remaining /dev/shm capacity, exit nonzero with a clear error so Postgres will retry later rather than failing mid‑write.

FWIW, the initial condition that has led this failures was a programming mistake on my part rather than pg_tde's defect, but even then, I think it's better to harden the achirve/restore binaries so that they don't exacerbate the problem by cluttering tmpfs.

I've not tested this patch in a realistic environment yet (I indent to do that, but maybe only the next week or so), yet I would like to publish the patch already for review and feedback.

I'm not an expert in C, Postgres, or pgBackRest; the patch is authored by AI coding agent; but I've reviewed it and it makes sense to me.