### PR TITLE
Register built-in dynamic managers in EXEC_BACKEND child (PSP17)

### DIFF
--- a/src/backend/postmaster/launch_backend.c
+++ b/src/backend/postmaster/launch_backend.c
@@ -662,6 +662,15 @@ SubPostmasterMain(int argc, char *argv[])
 	LocalProcessControlFile(false);
 
 	/*
+	 * Re-register built-in dynamic managers (e.g. md smgr). On fork-based
+	 * platforms the child inherits the postmaster's already-populated smgr
+	 * table; under EXEC_BACKEND the child starts with an empty table, so we
+	 * must re-run registration. Must happen before shared_preload_libraries
+	 * so extensions can still register their own smgrs from _PG_init().
+	 */
+	register_builtin_dynamic_managers();
+
+	/*
 	 * Reload any libraries that were preloaded by the postmaster.  Since we
 	 * exec'd this process, those libraries didn't come along with us; but we
 	 * should load them into all child processes to be consistent with the


### PR DESCRIPTION
Under EXEC_BACKEND the exec'd child starts with an empty (palloc'd) smgr table; register_builtin_dynamic_managers() is only called from the postmaster (inherited via fork) and InitStandaloneProcess. Re-run it in SubPostmasterMain, before process_shared_preload_libraries(), mirroring the postmaster so extensions can still register their own smgrs.