### PR TITLE
Mark MdSMgrId PGDLLIMPORT (PSP17)

### DIFF
--- a/src/include/storage/md.h
+++ b/src/include/storage/md.h
@@ -21,7 +21,7 @@
 
 /* registration function for md storage manager */
 extern void mdsmgr_register(void);
-extern SMgrId MdSMgrId;
+extern PGDLLIMPORT SMgrId MdSMgrId;
 
 /* md storage manager functionality */
 extern void mdinit(void);


### PR DESCRIPTION
Needed so loadable modules can reference the builtin md smgr id across the DLL boundary on Windows; no-op elsewhere.